### PR TITLE
add documentation for the blosc header

### DIFF
--- a/README_HEADER.rst
+++ b/README_HEADER.rst
@@ -1,7 +1,7 @@
 Blosc Header Format
 ===================
 
-Blosc (as of Version 1.1.3) has the following 16 byte header that stores
+Blosc (as of Version 1.0.0) has the following 16 byte header that stores
 information about the compressed buffer::
 
     |-0-|-1-|-2-|-3-|-4-|-5-|-6-|-7-|-8-|-9-|-A-|-B-|-C-|-D-|-E-|-F-|


### PR DESCRIPTION
A nice ascii-art representation of the blosc header.
