### PR TITLE
Building shared libraries

### DIFF
--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(SOURCES blosc.c blosclz.c shuffle.c)
 # library install directory
 set(lib_dir lib${LIB_SUFFIX})
+set(version_string ${BLOSC_VERSION_MAJOR}.${BLOSC_VERSION_MINOR}.${BLOSC_VERSION_PATCH})
 
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 if(WIN32)
@@ -22,6 +23,10 @@ endif(WIN32)
 # targets
 add_library(blosc_shared SHARED ${SOURCES})
 set_target_properties(blosc_shared PROPERTIES OUTPUT_NAME blosc)
+set_target_properties(blosc_shared PROPERTIES 
+        VERSION ${version_string}
+        SOVERSION ${version_string}
+    )
 target_link_libraries(blosc_shared ${LIBS})
 
 if(BUILD_STATIC)


### PR DESCRIPTION
This commit adds a Makefile to build blosc as shared library. It should allow blosc to be reused by other programs such as python-blosc or pytables, and be easier to package for Linux distributions.
(Perhaps the shared libs are useless here ?)

After linking, the shared library can be tested with:

``` bash
cd tests/
# Test shared library
sed -i "s|#include \"../blosc/blosc.h\"|#include <blosc.h>|" test_common.h
export LD_LIBRARY_PATH=../
for i in *.c; do 
    gcc "$i" -lpthread -L../ -I../blosc/ -lblosc
    ./a.out
done
```
