### PR TITLE
Align small blocks to the vectorization size (typesize * 16)

### DIFF
--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -591,6 +591,21 @@ static int32_t compute_blocksize(int32_t clevel, int32_t typesize,
       blocksize *= 2;
     }
   }
+  else if (nbytes > (16 * 16))  {
+      /* align to typesize to make use of vectorized shuffles */
+      if (typesize == 2) {
+          blocksize -= blocksize & (16 * 2);
+      }
+      else if (typesize == 4) {
+          blocksize -= blocksize & (16 * 4);
+      }
+      else if (typesize == 8) {
+          blocksize -= blocksize & (16 * 8);
+      }
+      else if (typesize == 16) {
+          blocksize -= blocksize & (16 * 16);
+      }
+  }
 
   /* Check that blocksize is not too large */
   if (blocksize > (int32_t)nbytes) {

--- a/blosc/shuffle.c
+++ b/blosc/shuffle.c
@@ -242,12 +242,12 @@ shuffle16(uint8_t* dest, uint8_t* src, size_t size)
 void shuffle(size_t bytesoftype, size_t blocksize,
              uint8_t* _src, uint8_t* _dest) {
   int unaligned_dest = (int)((uintptr_t)_dest % 16);
-  int power_of_two = (blocksize & (blocksize - 1)) == 0;
+  int multiple_of_block = (blocksize % (16 * bytesoftype)) == 0;
   int too_small = (blocksize < 256);
 
-  if (unaligned_dest || !power_of_two || too_small) {
-    /* _dest buffer is not aligned, not a power of two or is too
-       small.  Call the non-sse2 version. */
+  if (unaligned_dest || !multiple_of_block || too_small) {
+    /* _dest buffer is not aligned, not multiple of the vectorization size
+     * or is too small.  Call the non-sse2 version. */
     _shuffle(bytesoftype, blocksize, _src, _dest);
     return;
   }
@@ -456,12 +456,12 @@ void unshuffle(size_t bytesoftype, size_t blocksize,
                uint8_t* _src, uint8_t* _dest) {
   int unaligned_src = (int)((uintptr_t)_src % 16);
   int unaligned_dest = (int)((uintptr_t)_dest % 16);
-  int power_of_two = (blocksize & (blocksize - 1)) == 0;
+  int multiple_of_block = (blocksize % (16 * bytesoftype)) == 0;
   int too_small = (blocksize < 256);
 
-  if (unaligned_src || unaligned_dest || !power_of_two || too_small) {
-    /* _src or _dest buffer is not aligned, not a power of two or is
-       too small.  Call the non-sse2 version. */
+  if (unaligned_src || unaligned_dest || !multiple_of_block || too_small) {
+    /* _src or _dest buffer is not aligned, not multiple of the vectorization
+     * size or is not too small.  Call the non-sse2 version. */
     _unshuffle(bytesoftype, blocksize, _src, _dest);
     return;
   }

--- a/tests/test_basics.c
+++ b/tests/test_basics.c
@@ -63,11 +63,42 @@ static char *test_maxout_great() {
   return 0;
 }
 
+static char * test_shuffle()
+{
+  int sizes[] = {7, 64 * 3, 7*256, 500, 8000, 100000, 702713};
+  int types[] = {1, 2, 3, 4, 5, 6, 7, 8, 16};
+  int i, j, k;
+  for (i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++) {
+    for (j = 0; j < sizeof(types) / sizeof(types[0]); j++) {
+      int n = sizes[i];
+      int t = types[j];
+      char * d = malloc(t * n);
+      char * d2 = malloc(t * n);
+      char * o = malloc(t * n + BLOSC_MAX_OVERHEAD);
+      for (k = 0; k < n; k++) {
+        d[k] = rand();
+      }
+      blosc_compress(5, 1, t, t * n, d, o, t * n + BLOSC_MAX_OVERHEAD);
+      blosc_decompress(o, d2, t * n);
+      int ok = 1;
+      for (k = 0; ok&& k < n; k++) {
+        ok = (d[k] == d2[k]);
+      }
+      free(d);
+      free(d2);
+      free(o);
+      mu_assert("ERROR: multi size test failed", ok);
+    }
+  }
+
+  return 0;
+}
 
 static char *all_tests() {
   mu_run_test(test_maxout_less);
   mu_run_test(test_maxout_equal);
   mu_run_test(test_maxout_great);
+  mu_run_test(test_shuffle);
   return 0;
 }
 


### PR DESCRIPTION
Allows usage of vectorized shuffles for small compressions which are not
aligned to a power of two without losing to much of the blocksize.
Also improve tests a bit.
