### PR TITLE
fix codec enumeration (in README)

### DIFF
--- a/README_HEADER.rst
+++ b/README_HEADER.rst
@@ -20,7 +20,7 @@ All entries are little endian.
 :version:
     (``uint8``) Blosc format version.
 :versionlz:
-    (``uint8``) Blosclz format  version (internal Lempel-Ziv algorithm).
+    (``uint8``) Version of the internal compressor used.
 :flags and compressor enumeration:
     (``bitfield``) The flags of the buffer 
 
@@ -47,12 +47,10 @@ All entries are little endian.
     :``0``:
         ``blosclz``
     :``1``:
-        ``lz4``
+        ``lz4`` or ``lz4hc``
     :``2``:
-        ``lz4hc``
-    :``3``:
         ``snappy``
-    :``4``:
+    :``3``:
         ``zlib``
 
 :typesize:


### PR DESCRIPTION
Upon further inspection of the Blosc source code the changes made to the header
README in 8707b4c15b9ee2d553937c17a3c4e78c7fd87738 must be reverted, my bad. As
it turns out, there is now one set of integers used internally by blosc as
arguments to compress and another that is actually used to identify the codec
in the header. I presume that since LZ4 and LZ4HC have the same decompressor,
the same integer (namely `1`) is used for both. Updated the docs to account
for that.

Also, it turns out that the field that was previously used for the version of
the blosclz is now more general and stores the version of the codec used.
Updated the README to reflect that change.
