### PR TITLE
Fixed URLs in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,8 +40,8 @@ Blosc is distributed using the MIT license, see LICENSES/BLOSC.txt for
 details.
 
 .. [1] http://www.blosc.org
-.. [2] http://blosc.org/docs/StarvingCPUs-CISE-2010.pdf
-.. [3] http://blosc.org/trac/wiki/SyntheticBenchmarks
+.. [2] http://www.blosc.org/docs/StarvingCPUs-CISE-2010.pdf
+.. [3] http://www.blosc.org/trac/wiki/SyntheticBenchmarks
 
 Meta-compression and other advantages over existing compressors
 ===============================================================

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -26,7 +26,7 @@ Create a new build/ directory, change into it and issue::
 
 To actually test Blosc the hard way, look at the end of:
 
-http://blosc.org/trac/wiki/SyntheticBenchmarks
+http://www.blosc.org/trac/wiki/SyntheticBenchmarks
 
 where instructions on how to intensively test (and benchmark) Blosc
 are given.


### PR DESCRIPTION
http://blosc.org doesn't redirect to http://www.blosc.org any longer. Fixing broken links.
