### PR TITLE
add the codec to the plotter

### DIFF
--- a/bench/plot-speeds.py
+++ b/bench/plot-speeds.py
@@ -26,10 +26,12 @@ def get_values(filename):
     for line in f:
         if line.startswith('-->'):
             tmp = line.split('-->')[1]
-            nthreads, size, elsize, sbits = [int(i) for i in tmp.split(', ')]
+            nthreads, size, elsize, sbits, codec = [i for i in tmp.split(', ')]
+            nthreads, size, elsize, sbits = map(int, (nthreads, size, elsize, sbits))
             values["size"] = size * NCHUNKS / MB_;
             values["elsize"] = elsize;
             values["sbits"] = sbits;
+            values["codec"] = codec
             # New run for nthreads
             (ratios, speedsw, speedsr) = ([], [], [])
             # Add a new entry for (ratios, speedw, speedr)
@@ -160,7 +162,7 @@ if __name__ == '__main__':
     if options.title:
         plot_title = options.title
     else:
-        plot_title += " (%(size).1f MB, %(elsize)d bytes, %(sbits)d bits)" % values
+        plot_title += " (%(size).1f MB, %(elsize)d bytes, %(sbits)d bits), %(codec)s" % values
 
     gtitle = plot_title
 


### PR DESCRIPTION
The plotting tool wasn't adapted to handle benchmark output that includes codec
information. This commit fixes that. Also, the codec is displayed by default in
the plot title.
