### PR TITLE
library names end with _debug in debug build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,8 @@ option(PREFER_EXTERNAL_COMPLIBS
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
+# differentiate debug library names
+set(CMAKE_DEBUG_POSTFIX _debug)
 
 if(NOT PREFER_EXTERNAL_COMPLIBS)
     message(STATUS "Finding external libraries disabled.  Using internal sources.")


### PR DESCRIPTION
- Adds a cmake configuration option to CMakeLists.txt telling cmake to append
  a postfix to library names generated as part of a debug build. To generate a
  debug build one can run cmake with -DCMAKE_BUILD_TYPE=DEBUG. Release builds
  (the default) are unaffected.
