### PR TITLE
Fix an unused variable warning for {snappy,lz4}-free compilation

### DIFF
--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -1693,7 +1693,10 @@ int blosc_get_complib_info(char *compname, char **complib, char **version)
   int clibcode;
   char *clibname;
   char *clibversion = "unknown";
+
+  #if (defined(HAVE_LZ4) && defined(LZ4_VERSION_MAJOR)) || (defined(HAVE_SNAPPY) && defined(SNAPPY_VERSION))
   char sbuffer[256];
+  #endif
 
   clibcode = compname_to_clibcode(compname);
   clibname = clibcode_to_clibname(clibcode);


### PR DESCRIPTION
```
upstream/c-blosc/blosc/blosc.c:1698:8: warning: unused variable 'sbuffer'
      [-Wunused-variable]
  char sbuffer[256];
       ^
```

Fixed with:

``` c
#if (defined(HAVE_LZ4) && defined(LZ4_VERSION_MAJOR)) || (defined(HAVE_SNAPPY) && defined(SNAPPY_VERSION))
```

Other possible approaches include:
- `char sbuffer[256] __attribute__ ((unused));` (works with GCC and clang)
- `sbuffer[0] = 0; // to avoid an unused variable warning`
- refactoring to have `*version = strdup(...)` inside each case's block
