### PR TITLE
Fixes a corruption error when using LZ4.

### DIFF
--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -559,7 +559,7 @@ static int blosc_c(int32_t blocksize, int32_t leftoverblock,
       /* cbytes should never be negative */
       return -2;
     }
-    else if (cbytes == 0) {
+    else if (cbytes == 0 || cbytes == neblock) {
       /* The compressor has been unable to compress data at all. */
       /* Before doing the copy, check that we are not running into a
          buffer overflow. */


### PR DESCRIPTION
LZ4 is capable of returning a value that gets assigned to cbytes that is equal
to neblock. In this case, uppon decompression the data that LZ4 poorly
compressed would simply be memcpyed instead of being run though LZ4.
(see blosc.c:600)

Adding this check and simply memcpying the data if this is the case fixes the issue.
