### PR TITLE
Cmake Debug Postfix Issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,9 +85,6 @@ option(PREFER_EXTERNAL_COMPLIBS
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
-# differentiate debug library names
-set(CMAKE_DEBUG_POSTFIX _debug)
-
 if(NOT PREFER_EXTERNAL_COMPLIBS)
     message(STATUS "Finding external libraries disabled.  Using internal sources.")
 endif(NOT PREFER_EXTERNAL_COMPLIBS)


### PR DESCRIPTION
This should not be hard coded into a CMakeLists.txt file. Different users may

want to specify different debug prefixes. 

The proper way to set this is to pass -DCMAKE_DEBUG_POSTFIX:string=_debug
to cmake when generating.
