### PR TITLE
Dynamically loadable HDF5 filter plugin

### DIFF
--- a/hdf5/README.rst
+++ b/hdf5/README.rst
@@ -17,9 +17,15 @@ value is returned.
 An example C program ("example.c") is included which demonstrates the
 proper use of the filter.
 
+Alternatively, instead of registering the Blosc filter,  you can use the
+automatically detectable `HDF5 filter plugin`_ which is supported in HDF5
+1.8.11 and later.
+
 This filter has been tested against HDF5 versions 1.6.5 through
 1.8.10.  It is released under the MIT license (see LICENSE.txt for
 details).
+
+.. _`HDF5 filter plugin`: http://www.hdfgroup.org/HDF5/doc/Advanced/DynamicallyLoadedFilters/HDF5DynamicallyLoadedFilters.pdf
 
 
 Compiling
@@ -56,6 +62,23 @@ to your filter's directory if you do not have HDF5 installed in your PATH.
 For activating the support for other compressors than the integrated
 BloscLZ (like LZ4, LZ4HC, Snappy or Zlib) see the README file in the
 main Blosc directory.
+
+
+Compiling dynamically loadable filter plugin
+============================================
+
+Compile blosc_plugin.c and blosc_filter.c to a shared library and then
+let HDF5 know where to find it.
+
+To complie using GCC on UNIX:
+
+    gcc -O3 -msse2 -lhdf5 -lpthread ../blosc/*.c \
+        blosc_filter.c blosc_plugin.c -fPIC -shared \
+        -o libblosch5plugin.so
+
+Then ether move the shared library to HDF5's default search location for
+plugins (on UNIX ``/usr/local/hdf5/lib/plugin``) or to a directory pointed to
+by the ``HDF5_PLUGIN_PATH`` environment variable.
 
 
 IMPORTANT WINDOWS NOTE

--- a/hdf5/blosc_plugin.c
+++ b/hdf5/blosc_plugin.c
@@ -1,0 +1,42 @@
+/*
+ * Dynamically loaded filter plugin for HDF5 blosc filter.
+ *
+ * Author: Kiyoshi Masui <kiyo@physics.ubc.ca>
+ * Created: 2014
+ *
+ */
+
+
+#include <stdint.h>
+
+
+#define H5Z_class_t_vers 2
+
+#include "blosc_plugin.h"
+#include "blosc_filter.h"
+
+
+// Prototypes for filter function in blosc_filter.c.
+size_t blosc_filter(unsigned flags, size_t cd_nelmts,
+                    const unsigned cd_values[], size_t nbytes,
+                    size_t *buf_size, void **buf);
+
+herr_t blosc_set_local(hid_t dcpl, hid_t type, hid_t space);
+
+
+H5Z_class_t blosc_H5Filter[1] = {{
+    H5Z_CLASS_T_VERS,
+    (H5Z_filter_t)(FILTER_BLOSC),
+    1, 1,
+    "blosc",
+    NULL,
+    (H5Z_set_local_func_t)(blosc_set_local),
+    (H5Z_func_t)(blosc_filter)
+}};
+
+
+H5PL_type_t H5PLget_plugin_type(void) {return H5PL_TYPE_FILTER;}
+
+
+const void* H5PLget_plugin_info(void) {return blosc_H5Filter;}
+

--- a/hdf5/blosc_plugin.h
+++ b/hdf5/blosc_plugin.h
@@ -1,0 +1,36 @@
+/*
+ * Dynamically loaded filter plugin for HDF5 blosc filter.
+ *
+ * Author: Kiyoshi Masui <kiyo@physics.ubc.ca>
+ * Created: 2014
+ *
+ *
+ * Header file
+ * -----------
+ *
+ * This provides dynamically loaded HDF5 filter functionality (introduced
+ * in HDF5-1.8.11, May 2013) to the blosc HDF5 filter.
+ *
+ * Usage: compile as a shared library and install either to the default
+ * search location for HDF5 filter plugins (on Linux 
+ * /usr/local/hdf5/lib/plugin) or to a location pointed to by the
+ * HDF5_PLUGIN_PATH environment variable.
+ *
+ */
+
+
+#ifndef PLUGIN_BLOSC_H
+#define PLUGIN_BLOSC_H
+
+#include "H5PLextern.h"
+
+
+H5PL_type_t H5PLget_plugin_type(void);
+
+
+const void* H5PLget_plugin_info(void);
+
+
+#endif    // PLUGIN_BLOSC_H
+
+


### PR DESCRIPTION
HDF5 1.8.11+ supports "dynamically loadable filter plugins" (http://www.hdfgroup.org/HDF5/doc/Advanced/DynamicallyLoadedFilters/HDF5DynamicallyLoadedFilters.pdf). Following that recipe, I've made a plugin for the blosc filter.

I needed to do this anyway for my own work and thought I would put in a pull request upstream to see if there is interest in having this in blosc.  I'm sure this isn't up to standard for merging yet: you will probably want to change the format and content of the headers and I put in the bare minimum for the README.