### PR TITLE
Use the built-in stdint.h with MSVC when available

### DIFF
--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -32,7 +32,14 @@
 
 #if defined(_WIN32) && !defined(__MINGW32__)
   #include <windows.h>
-  #include "win32/stdint-windows.h"
+
+  /* stdint.h only available in VS2010 (VC++ 16.0) and newer */
+  #if defined(_MSC_VER) && _MSC_VER < 1600
+    #include "win32/stdint-windows.h"
+  #else
+    #include <stdint.h>
+  #endif
+
   #include <process.h>
   #define getpid _getpid
 #else

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -20,7 +20,13 @@
 
 #if defined(_WIN32) && !defined(__MINGW32__)
   #include <windows.h>
-  #include "win32/stdint-windows.h"
+
+  /* stdint.h only available in VS2010 (VC++ 16.0) and newer */
+  #if defined(_MSC_VER) && _MSC_VER < 1600
+    #include "win32/stdint-windows.h"
+  #else
+    #include <stdint.h>
+  #endif
 #else
   #include <stdint.h>
 #endif  /* _WIN32 */

--- a/blosc/shuffle.c
+++ b/blosc/shuffle.c
@@ -13,7 +13,14 @@
 
 #if defined(_WIN32) && !defined(__MINGW32__)
   #include <windows.h>
-  #include "win32/stdint-windows.h"
+
+  /* stdint.h only available in VS2010 (VC++ 16.0) and newer */
+  #if defined(_MSC_VER) && _MSC_VER < 1600
+    #include "win32/stdint-windows.h"
+  #else
+    #include <stdint.h>
+  #endif
+
   #define __SSE2__          /* Windows does not define this by default */
 #else
   #include <stdint.h>


### PR DESCRIPTION
``stdint.h`` is available in MSVC 16.0 / VS2010 and newer. I've added preprocessor checks so the compatibility header is only imported when compiling with an earlier version of MSVC; otherwise, the built-in ``stdint.h`` is used.