### PR TITLE
Modified examples to use the new context-based API

### DIFF
--- a/examples/many_compressors.c
+++ b/examples/many_compressors.c
@@ -53,10 +53,14 @@ int main(){
   static float data[SIZE];
   static float data_out[SIZE];
   static float data_dest[SIZE];
-  int isize = SIZE*sizeof(float), osize = SIZE*sizeof(float);
-  int dsize = SIZE*sizeof(float), csize;
-  int nthreads, pnthreads, i;
-  char* compressors[] = {"blosclz", "lz4", "lz4hc", "snappy", "zlib"};
+  const size_t isize = SIZE*sizeof(float), osize = SIZE*sizeof(float);
+  const size_t dsize = SIZE*sizeof(float), csize;
+  static const int nthreads = 4;    /* Number of threads to use */
+  static const int complevel = 5;   /* Compression level */
+  int i;
+  const char* const compressors[] = {"blosclz", "lz4", "lz4hc", "snappy", "zlib"};
+  const int ncompressors = sizeof(compressors) / sizeof(char*);
+  
   int ccode, rcode;
 
   for(i=0; i<SIZE; i++){
@@ -67,17 +71,12 @@ int main(){
   printf("Blosc version info: %s (%s)\n",
 	 BLOSC_VERSION_STRING, BLOSC_VERSION_DATE);
 
-  /* Initialize the Blosc compressor */
-  blosc_init();
-
-  nthreads = 4;
-  pnthreads = blosc_set_nthreads(nthreads);
-  printf("Using %d threads (previously using %d)\n", nthreads, pnthreads);
+  printf("Using %d threads\n", nthreads);
 
   /* Tell Blosc to use some number of threads */
-  for (ccode=0; ccode <= 4; ccode++) {
+  for (ccode=0; ccode < ncompressors; ccode++) {
 
-    rcode = blosc_set_compressor(compressors[ccode]);
+    rcode = blosc_compname_to_compcode(compressors[ccode]);
     if (rcode < 0) {
       printf("Error setting %s compressor.  It really exists?",
 	     compressors[ccode]);
@@ -86,7 +85,8 @@ int main(){
     printf("Using %s compressor\n", compressors[ccode]);
 
     /* Compress with clevel=5 and shuffle active  */
-    csize = blosc_compress(5, 1, sizeof(float), isize, data, data_out, osize);
+    csize = blosc_compress_ctx(5, 1, sizeof(float), isize, data, data_out, osize,
+      compressors[ccode], 0, nthreads);
     if (csize < 0) {
       printf("Compression error.  Error code: %d\n", csize);
       return csize;
@@ -95,19 +95,16 @@ int main(){
     printf("Compression: %d -> %d (%.1fx)\n", isize, csize, (1.*isize) / csize);
 
     /* Decompress  */
-    dsize = blosc_decompress(data_out, data_dest, dsize);
+    dsize = blosc_decompress_ctx(data_out, data_dest, dsize, nthreads);
     if (dsize < 0) {
         printf("Decompression error.  Error code: %d\n", dsize);
         return dsize;
     }
 
-    /* After using it, destroy the Blosc environment */
-    blosc_destroy();
-
     for(i=0;i<SIZE;i++){
       if(data[i] != data_dest[i]) {
-	printf("Decompressed data differs from original!\n");
-	return -1;
+	      printf("Decompressed data differs from original!\n");
+	      return -1;
       }
     }
 


### PR DESCRIPTION
I've modified the blosc examples so they use the new context-based API functions instead of the older functions which entail use of the global context.