### PR TITLE
Use llabs function instead of abs to avoid truncating the result

### DIFF
--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -112,7 +112,7 @@
 }
 
 #define SAFE_COPY(op, ref, len, op_limit)     \
-if (abs(op-ref) < CPYSIZE) {                  \
+if (llabs(op-ref) < CPYSIZE) {                \
   for(; len; --len)                           \
     *op++ = *ref++;                           \
 }                                             \
@@ -120,7 +120,7 @@ else BLOCK_COPY(op, ref, len, op_limit);
 
 /* Copy optimized for GCC 4.8.  Seems like long copy loops are optimal. */
 #define GCC_SAFE_COPY(op, ref, len, op_limit) \
-if ((len > 32) || (abs(op-ref) < CPYSIZE)) {  \
+if ((len > 32) || (llabs(op-ref) < CPYSIZE)) { \
   for(; len; --len)                           \
     *op++ = *ref++;                           \
 }                                             \


### PR DESCRIPTION
When compiling blosc with MSVC 18.0 (VS2013), I saw some compiler warnings about ``long long int`` values being possibly truncated by ``abs`` (because that function takes an ``int``). I've modified the code to use the ``llabs`` function instead to avoid this issue.