### PR TITLE
SSE2 acceleration for shuffling larger types

### DIFF
--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -871,19 +871,10 @@ static int32_t compute_blocksize(struct blosc_context* context, int32_t clevel, 
     }
   }
   else if (nbytes > (16 * 16))  {
-      /* align to typesize to make use of vectorized shuffles */
-      if (typesize == 2) {
-          blocksize -= blocksize % (16 * 2);
-      }
-      else if (typesize == 4) {
-          blocksize -= blocksize % (16 * 4);
-      }
-      else if (typesize == 8) {
-          blocksize -= blocksize % (16 * 8);
-      }
-      else if (typesize == 16) {
-          blocksize -= blocksize % (16 * 16);
-      }
+    /* align to typesize to make use of vectorized shuffles */
+		if (typesize == 2 || typesize == 4 || typesize == 8 || typesize == 16 || typesize > 16) {
+			blocksize -= blocksize % (16 * typesize);
+    }
   }
 
   /* Check that blocksize is not too large */
@@ -891,9 +882,9 @@ static int32_t compute_blocksize(struct blosc_context* context, int32_t clevel, 
     blocksize = nbytes;
   }
 
-  /* blocksize must be a multiple of the typesize */
+  /* blocksize must be a multiple of the typesize and a multiple of the vector size */
   if (blocksize > typesize) {
-    blocksize = blocksize / typesize * typesize;
+		blocksize -= blocksize % (16 * typesize);
   }
 
   /* blocksize must not exceed (64 KB * typesize) in order to allow

--- a/blosc/shuffle.c
+++ b/blosc/shuffle.c
@@ -1,5 +1,5 @@
 /*********************************************************************
-Blosc - Blocked Suffling and Compression Library
+Blosc - Blocked Shuffling and Compression Library
 
 Author: Francesc Alted <francesc@blosc.org>
 Creation date: 2009-05-20
@@ -25,36 +25,36 @@ See LICENSES/BLOSC.txt for details about copyright and rights to use.
 
 /* Shuffle a block.  This can never fail. */
 static void _shuffle(size_t bytesoftype, size_t blocksize,
-	const uint8_t* _src, uint8_t* _dest)
+  const uint8_t* _src, uint8_t* _dest)
 {
-	size_t i, j, neblock, leftover;
+  size_t i, j, neblock, leftover;
 
-	/* Non-optimized shuffle */
-	neblock = blocksize / bytesoftype;  /* Number of elements in a block */
-	for (j = 0; j < bytesoftype; j++) {
-		for (i = 0; i < neblock; i++) {
-			_dest[j*neblock + i] = _src[i*bytesoftype + j];
-		}
-	}
-	leftover = blocksize % bytesoftype;
-	memcpy(_dest + neblock*bytesoftype, _src + neblock*bytesoftype, leftover);
+  /* Non-optimized shuffle */
+  neblock = blocksize / bytesoftype;  /* Number of elements in a block */
+  for (j = 0; j < bytesoftype; j++) {
+    for (i = 0; i < neblock; i++) {
+      _dest[j*neblock + i] = _src[i*bytesoftype + j];
+    }
+  }
+  leftover = blocksize % bytesoftype;
+  memcpy(_dest + neblock*bytesoftype, _src + neblock*bytesoftype, leftover);
 }
 
 /* Unshuffle a block.  This can never fail. */
 static void _unshuffle(size_t bytesoftype, size_t blocksize,
-	const uint8_t* _src, uint8_t* _dest)
+  const uint8_t* _src, uint8_t* _dest)
 {
-	size_t i, j, neblock, leftover;
+  size_t i, j, neblock, leftover;
 
-	/* Non-optimized unshuffle */
-	neblock = blocksize / bytesoftype;  /* Number of elements in a block */
-	for (i = 0; i < neblock; i++) {
-		for (j = 0; j < bytesoftype; j++) {
-			_dest[i*bytesoftype + j] = _src[j*neblock + i];
-		}
-	}
-	leftover = blocksize % bytesoftype;
-	memcpy(_dest + neblock*bytesoftype, _src + neblock*bytesoftype, leftover);
+  /* Non-optimized unshuffle */
+  neblock = blocksize / bytesoftype;  /* Number of elements in a block */
+  for (i = 0; i < neblock; i++) {
+    for (j = 0; j < bytesoftype; j++) {
+      _dest[i*bytesoftype + j] = _src[j*neblock + i];
+    }
+  }
+  leftover = blocksize % bytesoftype;
+  memcpy(_dest + neblock*bytesoftype, _src + neblock*bytesoftype, leftover);
 }
 
 
@@ -68,14 +68,14 @@ static void _unshuffle(size_t bytesoftype, size_t blocksize,
 #if 0
 static void printxmm(__m128i xmm0)
 {
-	uint8_t buf[16];
+  uint8_t buf[16];
 
-	((__m128i *)buf)[0] = xmm0;
-	printf("%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x\n",
-		buf[0], buf[1], buf[2], buf[3],
-		buf[4], buf[5], buf[6], buf[7],
-		buf[8], buf[9], buf[10], buf[11],
-		buf[12], buf[13], buf[14], buf[15]);
+  ((__m128i *)buf)[0] = xmm0;
+  printf("%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x\n",
+    buf[0], buf[1], buf[2], buf[3],
+    buf[4], buf[5], buf[6], buf[7],
+    buf[8], buf[9], buf[10], buf[11],
+    buf[12], buf[13], buf[14], buf[15]);
 }
 #endif
 
@@ -84,45 +84,45 @@ static void printxmm(__m128i xmm0)
 static void
 shuffle2(uint8_t* dest, const uint8_t* src, size_t size)
 {
-	size_t i, j;
-	const size_t numof16belem = size / (2 * sizeof(__m128i));
+  size_t i, j;
+  const size_t numof16belem = size / (2 * sizeof(__m128i));
 
 
-	for (i = 0, j = 0; i < numof16belem; i++, j += 2) {
-		__m128i xmm0[2], xmm1[2];
+  for (i = 0, j = 0; i < numof16belem; i++, j += 2) {
+    __m128i xmm0[2], xmm1[2];
 
-		/* Fetch and transpose bytes, words and double words in groups of
-		32 bytes */
-		xmm0[0] = _mm_loadu_si128((__m128i*)(src + (j + 0) * sizeof(__m128i)));
-		xmm0[0] = _mm_shufflelo_epi16(xmm0[0], 0xd8);
-		xmm0[0] = _mm_shufflehi_epi16(xmm0[0], 0xd8);
-		xmm0[0] = _mm_shuffle_epi32(xmm0[0], 0xd8);
-		xmm1[0] = _mm_shuffle_epi32(xmm0[0], 0x4e);
-		xmm0[0] = _mm_unpacklo_epi8(xmm0[0], xmm1[0]);
-		xmm0[0] = _mm_shuffle_epi32(xmm0[0], 0xd8);
-		xmm1[0] = _mm_shuffle_epi32(xmm0[0], 0x4e);
-		xmm0[0] = _mm_unpacklo_epi16(xmm0[0], xmm1[0]);
-		xmm0[0] = _mm_shuffle_epi32(xmm0[0], 0xd8);
+    /* Fetch and transpose bytes, words and double words in groups of
+    32 bytes */
+    xmm0[0] = _mm_loadu_si128((__m128i*)(src + (j + 0) * sizeof(__m128i)));
+    xmm0[0] = _mm_shufflelo_epi16(xmm0[0], 0xd8);
+    xmm0[0] = _mm_shufflehi_epi16(xmm0[0], 0xd8);
+    xmm0[0] = _mm_shuffle_epi32(xmm0[0], 0xd8);
+    xmm1[0] = _mm_shuffle_epi32(xmm0[0], 0x4e);
+    xmm0[0] = _mm_unpacklo_epi8(xmm0[0], xmm1[0]);
+    xmm0[0] = _mm_shuffle_epi32(xmm0[0], 0xd8);
+    xmm1[0] = _mm_shuffle_epi32(xmm0[0], 0x4e);
+    xmm0[0] = _mm_unpacklo_epi16(xmm0[0], xmm1[0]);
+    xmm0[0] = _mm_shuffle_epi32(xmm0[0], 0xd8);
 
-		xmm0[1] = _mm_loadu_si128((__m128i*)(src + (j + 1) * sizeof(__m128i)));
-		xmm0[1] = _mm_shufflelo_epi16(xmm0[1], 0xd8);
-		xmm0[1] = _mm_shufflehi_epi16(xmm0[1], 0xd8);
-		xmm0[1] = _mm_shuffle_epi32(xmm0[1], 0xd8);
-		xmm1[1] = _mm_shuffle_epi32(xmm0[1], 0x4e);
-		xmm0[1] = _mm_unpacklo_epi8(xmm0[1], xmm1[1]);
-		xmm0[1] = _mm_shuffle_epi32(xmm0[1], 0xd8);
-		xmm1[1] = _mm_shuffle_epi32(xmm0[1], 0x4e);
-		xmm0[1] = _mm_unpacklo_epi16(xmm0[1], xmm1[1]);
-		xmm0[1] = _mm_shuffle_epi32(xmm0[1], 0xd8);
+    xmm0[1] = _mm_loadu_si128((__m128i*)(src + (j + 1) * sizeof(__m128i)));
+    xmm0[1] = _mm_shufflelo_epi16(xmm0[1], 0xd8);
+    xmm0[1] = _mm_shufflehi_epi16(xmm0[1], 0xd8);
+    xmm0[1] = _mm_shuffle_epi32(xmm0[1], 0xd8);
+    xmm1[1] = _mm_shuffle_epi32(xmm0[1], 0x4e);
+    xmm0[1] = _mm_unpacklo_epi8(xmm0[1], xmm1[1]);
+    xmm0[1] = _mm_shuffle_epi32(xmm0[1], 0xd8);
+    xmm1[1] = _mm_shuffle_epi32(xmm0[1], 0x4e);
+    xmm0[1] = _mm_unpacklo_epi16(xmm0[1], xmm1[1]);
+    xmm0[1] = _mm_shuffle_epi32(xmm0[1], 0xd8);
 
-		/* Transpose quad words */
-		xmm1[0] = _mm_unpacklo_epi64(xmm0[0], xmm0[1]);
-		xmm1[1] = _mm_unpackhi_epi64(xmm0[0], xmm0[1]);
+    /* Transpose quad words */
+    xmm1[0] = _mm_unpacklo_epi64(xmm0[0], xmm0[1]);
+    xmm1[1] = _mm_unpackhi_epi64(xmm0[0], xmm0[1]);
 
-		/* Store the result vectors */
-		((__m128i *)dest)[0 * numof16belem + i] = xmm1[0];
-		((__m128i *)dest)[1 * numof16belem + i] = xmm1[1];
-	}
+    /* Store the result vectors */
+    ((__m128i *)dest)[0 * numof16belem + i] = xmm1[0];
+    ((__m128i *)dest)[1 * numof16belem + i] = xmm1[1];
+  }
 }
 
 
@@ -130,61 +130,61 @@ shuffle2(uint8_t* dest, const uint8_t* src, size_t size)
 static void
 shuffle4(uint8_t* dest, const uint8_t* src, size_t size)
 {
-	size_t i, j;
-	const size_t numof16belem = size / (4 * sizeof(__m128i));
+  size_t i, j;
+  const size_t numof16belem = size / (4 * sizeof(__m128i));
 
-	for (i = 0, j = 0; i < numof16belem; i++, j += 4) {
-		__m128i xmm0[4], xmm1[4];
+  for (i = 0, j = 0; i < numof16belem; i++, j += 4) {
+    __m128i xmm0[4], xmm1[4];
 
-		/* Fetch and transpose bytes and words in groups of 64 bytes */
-		xmm0[0] = _mm_loadu_si128((__m128i*)(src + (j + 0) * sizeof(__m128i)));
-		xmm1[0] = _mm_shuffle_epi32(xmm0[0], 0xd8);
-		xmm0[0] = _mm_shuffle_epi32(xmm0[0], 0x8d);
-		xmm0[0] = _mm_unpacklo_epi8(xmm1[0], xmm0[0]);
-		xmm1[0] = _mm_shuffle_epi32(xmm0[0], 0x04e);
-		xmm0[0] = _mm_unpacklo_epi16(xmm0[0], xmm1[0]);
+    /* Fetch and transpose bytes and words in groups of 64 bytes */
+    xmm0[0] = _mm_loadu_si128((__m128i*)(src + (j + 0) * sizeof(__m128i)));
+    xmm1[0] = _mm_shuffle_epi32(xmm0[0], 0xd8);
+    xmm0[0] = _mm_shuffle_epi32(xmm0[0], 0x8d);
+    xmm0[0] = _mm_unpacklo_epi8(xmm1[0], xmm0[0]);
+    xmm1[0] = _mm_shuffle_epi32(xmm0[0], 0x04e);
+    xmm0[0] = _mm_unpacklo_epi16(xmm0[0], xmm1[0]);
 
-		xmm0[1] = _mm_loadu_si128((__m128i*)(src + (j + 1) * sizeof(__m128i)));
-		xmm1[1] = _mm_shuffle_epi32(xmm0[1], 0xd8);
-		xmm0[1] = _mm_shuffle_epi32(xmm0[1], 0x8d);
-		xmm0[1] = _mm_unpacklo_epi8(xmm1[1], xmm0[1]);
-		xmm1[1] = _mm_shuffle_epi32(xmm0[1], 0x04e);
-		xmm0[1] = _mm_unpacklo_epi16(xmm0[1], xmm1[1]);
+    xmm0[1] = _mm_loadu_si128((__m128i*)(src + (j + 1) * sizeof(__m128i)));
+    xmm1[1] = _mm_shuffle_epi32(xmm0[1], 0xd8);
+    xmm0[1] = _mm_shuffle_epi32(xmm0[1], 0x8d);
+    xmm0[1] = _mm_unpacklo_epi8(xmm1[1], xmm0[1]);
+    xmm1[1] = _mm_shuffle_epi32(xmm0[1], 0x04e);
+    xmm0[1] = _mm_unpacklo_epi16(xmm0[1], xmm1[1]);
 
-		xmm0[2] = _mm_loadu_si128((__m128i*)(src + (j + 2) * sizeof(__m128i)));
-		xmm1[2] = _mm_shuffle_epi32(xmm0[2], 0xd8);
-		xmm0[2] = _mm_shuffle_epi32(xmm0[2], 0x8d);
-		xmm0[2] = _mm_unpacklo_epi8(xmm1[2], xmm0[2]);
-		xmm1[2] = _mm_shuffle_epi32(xmm0[2], 0x04e);
-		xmm0[2] = _mm_unpacklo_epi16(xmm0[2], xmm1[2]);
+    xmm0[2] = _mm_loadu_si128((__m128i*)(src + (j + 2) * sizeof(__m128i)));
+    xmm1[2] = _mm_shuffle_epi32(xmm0[2], 0xd8);
+    xmm0[2] = _mm_shuffle_epi32(xmm0[2], 0x8d);
+    xmm0[2] = _mm_unpacklo_epi8(xmm1[2], xmm0[2]);
+    xmm1[2] = _mm_shuffle_epi32(xmm0[2], 0x04e);
+    xmm0[2] = _mm_unpacklo_epi16(xmm0[2], xmm1[2]);
 
-		xmm0[3] = _mm_loadu_si128((__m128i*)(src + (j + 3) * sizeof(__m128i)));
-		xmm1[3] = _mm_shuffle_epi32(xmm0[3], 0xd8);
-		xmm0[3] = _mm_shuffle_epi32(xmm0[3], 0x8d);
-		xmm0[3] = _mm_unpacklo_epi8(xmm1[3], xmm0[3]);
-		xmm1[3] = _mm_shuffle_epi32(xmm0[3], 0x04e);
-		xmm0[3] = _mm_unpacklo_epi16(xmm0[3], xmm1[3]);
+    xmm0[3] = _mm_loadu_si128((__m128i*)(src + (j + 3) * sizeof(__m128i)));
+    xmm1[3] = _mm_shuffle_epi32(xmm0[3], 0xd8);
+    xmm0[3] = _mm_shuffle_epi32(xmm0[3], 0x8d);
+    xmm0[3] = _mm_unpacklo_epi8(xmm1[3], xmm0[3]);
+    xmm1[3] = _mm_shuffle_epi32(xmm0[3], 0x04e);
+    xmm0[3] = _mm_unpacklo_epi16(xmm0[3], xmm1[3]);
 
-		/* Transpose double words */
-		xmm1[0] = _mm_unpacklo_epi32(xmm0[0], xmm0[1]);
-		xmm1[1] = _mm_unpackhi_epi32(xmm0[0], xmm0[1]);
+    /* Transpose double words */
+    xmm1[0] = _mm_unpacklo_epi32(xmm0[0], xmm0[1]);
+    xmm1[1] = _mm_unpackhi_epi32(xmm0[0], xmm0[1]);
 
-		xmm1[2] = _mm_unpacklo_epi32(xmm0[2], xmm0[3]);
-		xmm1[3] = _mm_unpackhi_epi32(xmm0[2], xmm0[3]);
+    xmm1[2] = _mm_unpacklo_epi32(xmm0[2], xmm0[3]);
+    xmm1[3] = _mm_unpackhi_epi32(xmm0[2], xmm0[3]);
 
-		/* Transpose quad words */
-		xmm0[0] = _mm_unpacklo_epi64(xmm1[0], xmm1[2]);
-		xmm0[1] = _mm_unpackhi_epi64(xmm1[0], xmm1[2]);
+    /* Transpose quad words */
+    xmm0[0] = _mm_unpacklo_epi64(xmm1[0], xmm1[2]);
+    xmm0[1] = _mm_unpackhi_epi64(xmm1[0], xmm1[2]);
 
-		xmm0[2] = _mm_unpacklo_epi64(xmm1[1], xmm1[3]);
-		xmm0[3] = _mm_unpackhi_epi64(xmm1[1], xmm1[3]);
+    xmm0[2] = _mm_unpacklo_epi64(xmm1[1], xmm1[3]);
+    xmm0[3] = _mm_unpackhi_epi64(xmm1[1], xmm1[3]);
 
-		/* Store the result vectors */
-		((__m128i *)dest)[0 * numof16belem + i] = xmm0[0];
-		((__m128i *)dest)[1 * numof16belem + i] = xmm0[1];
-		((__m128i *)dest)[2 * numof16belem + i] = xmm0[2];
-		((__m128i *)dest)[3 * numof16belem + i] = xmm0[3];
-	}
+    /* Store the result vectors */
+    ((__m128i *)dest)[0 * numof16belem + i] = xmm0[0];
+    ((__m128i *)dest)[1 * numof16belem + i] = xmm0[1];
+    ((__m128i *)dest)[2 * numof16belem + i] = xmm0[2];
+    ((__m128i *)dest)[3 * numof16belem + i] = xmm0[3];
+  }
 }
 
 
@@ -192,94 +192,94 @@ shuffle4(uint8_t* dest, const uint8_t* src, size_t size)
 static void
 shuffle8(uint8_t* dest, const uint8_t* src, size_t size)
 {
-	size_t i, j;
-	const size_t numof16belem = size / (8 * sizeof(__m128i));
+  size_t i, j;
+  const size_t numof16belem = size / (8 * sizeof(__m128i));
 
-	for (i = 0, j = 0; i < numof16belem; i++, j += 8) {
-		__m128i xmm0[8], xmm1[8];
+  for (i = 0, j = 0; i < numof16belem; i++, j += 8) {
+    __m128i xmm0[8], xmm1[8];
 
-		/* Fetch and transpose bytes in groups of 128 bytes */
-		xmm0[0] = _mm_loadu_si128((__m128i*)(src + (j + 0) * sizeof(__m128i)));
-		xmm1[0] = _mm_shuffle_epi32(xmm0[0], 0x4e);
-		xmm1[0] = _mm_unpacklo_epi8(xmm0[0], xmm1[0]);
+    /* Fetch and transpose bytes in groups of 128 bytes */
+    xmm0[0] = _mm_loadu_si128((__m128i*)(src + (j + 0) * sizeof(__m128i)));
+    xmm1[0] = _mm_shuffle_epi32(xmm0[0], 0x4e);
+    xmm1[0] = _mm_unpacklo_epi8(xmm0[0], xmm1[0]);
 
-		xmm0[1] = _mm_loadu_si128((__m128i*)(src + (j + 1) * sizeof(__m128i)));
-		xmm1[1] = _mm_shuffle_epi32(xmm0[1], 0x4e);
-		xmm1[1] = _mm_unpacklo_epi8(xmm0[1], xmm1[1]);
+    xmm0[1] = _mm_loadu_si128((__m128i*)(src + (j + 1) * sizeof(__m128i)));
+    xmm1[1] = _mm_shuffle_epi32(xmm0[1], 0x4e);
+    xmm1[1] = _mm_unpacklo_epi8(xmm0[1], xmm1[1]);
 
-		xmm0[2] = _mm_loadu_si128((__m128i*)(src + (j + 2) * sizeof(__m128i)));
-		xmm1[2] = _mm_shuffle_epi32(xmm0[2], 0x4e);
-		xmm1[2] = _mm_unpacklo_epi8(xmm0[2], xmm1[2]);
+    xmm0[2] = _mm_loadu_si128((__m128i*)(src + (j + 2) * sizeof(__m128i)));
+    xmm1[2] = _mm_shuffle_epi32(xmm0[2], 0x4e);
+    xmm1[2] = _mm_unpacklo_epi8(xmm0[2], xmm1[2]);
 
-		xmm0[3] = _mm_loadu_si128((__m128i*)(src + (j + 3) * sizeof(__m128i)));
-		xmm1[3] = _mm_shuffle_epi32(xmm0[3], 0x4e);
-		xmm1[3] = _mm_unpacklo_epi8(xmm0[3], xmm1[3]);
+    xmm0[3] = _mm_loadu_si128((__m128i*)(src + (j + 3) * sizeof(__m128i)));
+    xmm1[3] = _mm_shuffle_epi32(xmm0[3], 0x4e);
+    xmm1[3] = _mm_unpacklo_epi8(xmm0[3], xmm1[3]);
 
-		xmm0[4] = _mm_loadu_si128((__m128i*)(src + (j + 4) * sizeof(__m128i)));
-		xmm1[4] = _mm_shuffle_epi32(xmm0[4], 0x4e);
-		xmm1[4] = _mm_unpacklo_epi8(xmm0[4], xmm1[4]);
+    xmm0[4] = _mm_loadu_si128((__m128i*)(src + (j + 4) * sizeof(__m128i)));
+    xmm1[4] = _mm_shuffle_epi32(xmm0[4], 0x4e);
+    xmm1[4] = _mm_unpacklo_epi8(xmm0[4], xmm1[4]);
 
-		xmm0[5] = _mm_loadu_si128((__m128i*)(src + (j + 5) * sizeof(__m128i)));
-		xmm1[5] = _mm_shuffle_epi32(xmm0[5], 0x4e);
-		xmm1[5] = _mm_unpacklo_epi8(xmm0[5], xmm1[5]);
+    xmm0[5] = _mm_loadu_si128((__m128i*)(src + (j + 5) * sizeof(__m128i)));
+    xmm1[5] = _mm_shuffle_epi32(xmm0[5], 0x4e);
+    xmm1[5] = _mm_unpacklo_epi8(xmm0[5], xmm1[5]);
 
-		xmm0[6] = _mm_loadu_si128((__m128i*)(src + (j + 6) * sizeof(__m128i)));
-		xmm1[6] = _mm_shuffle_epi32(xmm0[6], 0x4e);
-		xmm1[6] = _mm_unpacklo_epi8(xmm0[6], xmm1[6]);
+    xmm0[6] = _mm_loadu_si128((__m128i*)(src + (j + 6) * sizeof(__m128i)));
+    xmm1[6] = _mm_shuffle_epi32(xmm0[6], 0x4e);
+    xmm1[6] = _mm_unpacklo_epi8(xmm0[6], xmm1[6]);
 
-		xmm0[7] = _mm_loadu_si128((__m128i*)(src + (j + 7) * sizeof(__m128i)));
-		xmm1[7] = _mm_shuffle_epi32(xmm0[7], 0x4e);
-		xmm1[7] = _mm_unpacklo_epi8(xmm0[7], xmm1[7]);
+    xmm0[7] = _mm_loadu_si128((__m128i*)(src + (j + 7) * sizeof(__m128i)));
+    xmm1[7] = _mm_shuffle_epi32(xmm0[7], 0x4e);
+    xmm1[7] = _mm_unpacklo_epi8(xmm0[7], xmm1[7]);
 
-		/* Transpose words */
-		xmm0[0] = _mm_unpacklo_epi16(xmm1[0], xmm1[1]);
-		xmm0[1] = _mm_unpackhi_epi16(xmm1[0], xmm1[1]);
+    /* Transpose words */
+    xmm0[0] = _mm_unpacklo_epi16(xmm1[0], xmm1[1]);
+    xmm0[1] = _mm_unpackhi_epi16(xmm1[0], xmm1[1]);
 
-		xmm0[2] = _mm_unpacklo_epi16(xmm1[2], xmm1[3]);
-		xmm0[3] = _mm_unpackhi_epi16(xmm1[2], xmm1[3]);
+    xmm0[2] = _mm_unpacklo_epi16(xmm1[2], xmm1[3]);
+    xmm0[3] = _mm_unpackhi_epi16(xmm1[2], xmm1[3]);
 
-		xmm0[4] = _mm_unpacklo_epi16(xmm1[4], xmm1[5]);
-		xmm0[5] = _mm_unpackhi_epi16(xmm1[4], xmm1[5]);
+    xmm0[4] = _mm_unpacklo_epi16(xmm1[4], xmm1[5]);
+    xmm0[5] = _mm_unpackhi_epi16(xmm1[4], xmm1[5]);
 
-		xmm0[6] = _mm_unpacklo_epi16(xmm1[6], xmm1[7]);
-		xmm0[7] = _mm_unpackhi_epi16(xmm1[6], xmm1[7]);
+    xmm0[6] = _mm_unpacklo_epi16(xmm1[6], xmm1[7]);
+    xmm0[7] = _mm_unpackhi_epi16(xmm1[6], xmm1[7]);
 
-		/* Transpose double words */
-		xmm1[0] = _mm_unpacklo_epi32(xmm0[0], xmm0[2]);
-		xmm1[1] = _mm_unpackhi_epi32(xmm0[0], xmm0[2]);
+    /* Transpose double words */
+    xmm1[0] = _mm_unpacklo_epi32(xmm0[0], xmm0[2]);
+    xmm1[1] = _mm_unpackhi_epi32(xmm0[0], xmm0[2]);
 
-		xmm1[2] = _mm_unpacklo_epi32(xmm0[1], xmm0[3]);
-		xmm1[3] = _mm_unpackhi_epi32(xmm0[1], xmm0[3]);
+    xmm1[2] = _mm_unpacklo_epi32(xmm0[1], xmm0[3]);
+    xmm1[3] = _mm_unpackhi_epi32(xmm0[1], xmm0[3]);
 
-		xmm1[4] = _mm_unpacklo_epi32(xmm0[4], xmm0[6]);
-		xmm1[5] = _mm_unpackhi_epi32(xmm0[4], xmm0[6]);
+    xmm1[4] = _mm_unpacklo_epi32(xmm0[4], xmm0[6]);
+    xmm1[5] = _mm_unpackhi_epi32(xmm0[4], xmm0[6]);
 
-		xmm1[6] = _mm_unpacklo_epi32(xmm0[5], xmm0[7]);
-		xmm1[7] = _mm_unpackhi_epi32(xmm0[5], xmm0[7]);
+    xmm1[6] = _mm_unpacklo_epi32(xmm0[5], xmm0[7]);
+    xmm1[7] = _mm_unpackhi_epi32(xmm0[5], xmm0[7]);
 
-		/* Transpose quad words */
-		xmm0[0] = _mm_unpacklo_epi64(xmm1[0], xmm1[4]);
-		xmm0[1] = _mm_unpackhi_epi64(xmm1[0], xmm1[4]);
+    /* Transpose quad words */
+    xmm0[0] = _mm_unpacklo_epi64(xmm1[0], xmm1[4]);
+    xmm0[1] = _mm_unpackhi_epi64(xmm1[0], xmm1[4]);
 
-		xmm0[2] = _mm_unpacklo_epi64(xmm1[1], xmm1[5]);
-		xmm0[3] = _mm_unpackhi_epi64(xmm1[1], xmm1[5]);
+    xmm0[2] = _mm_unpacklo_epi64(xmm1[1], xmm1[5]);
+    xmm0[3] = _mm_unpackhi_epi64(xmm1[1], xmm1[5]);
 
-		xmm0[4] = _mm_unpacklo_epi64(xmm1[2], xmm1[6]);
-		xmm0[5] = _mm_unpackhi_epi64(xmm1[2], xmm1[6]);
+    xmm0[4] = _mm_unpacklo_epi64(xmm1[2], xmm1[6]);
+    xmm0[5] = _mm_unpackhi_epi64(xmm1[2], xmm1[6]);
 
-		xmm0[6] = _mm_unpacklo_epi64(xmm1[3], xmm1[7]);
-		xmm0[7] = _mm_unpackhi_epi64(xmm1[3], xmm1[7]);
+    xmm0[6] = _mm_unpacklo_epi64(xmm1[3], xmm1[7]);
+    xmm0[7] = _mm_unpackhi_epi64(xmm1[3], xmm1[7]);
 
-		/* Store the result vectors */
-		((__m128i *)dest)[0 * numof16belem + i] = xmm0[0];
-		((__m128i *)dest)[1 * numof16belem + i] = xmm0[1];
-		((__m128i *)dest)[2 * numof16belem + i] = xmm0[2];
-		((__m128i *)dest)[3 * numof16belem + i] = xmm0[3];
-		((__m128i *)dest)[4 * numof16belem + i] = xmm0[4];
-		((__m128i *)dest)[5 * numof16belem + i] = xmm0[5];
-		((__m128i *)dest)[6 * numof16belem + i] = xmm0[6];
-		((__m128i *)dest)[7 * numof16belem + i] = xmm0[7];
-	}
+    /* Store the result vectors */
+    ((__m128i *)dest)[0 * numof16belem + i] = xmm0[0];
+    ((__m128i *)dest)[1 * numof16belem + i] = xmm0[1];
+    ((__m128i *)dest)[2 * numof16belem + i] = xmm0[2];
+    ((__m128i *)dest)[3 * numof16belem + i] = xmm0[3];
+    ((__m128i *)dest)[4 * numof16belem + i] = xmm0[4];
+    ((__m128i *)dest)[5 * numof16belem + i] = xmm0[5];
+    ((__m128i *)dest)[6 * numof16belem + i] = xmm0[6];
+    ((__m128i *)dest)[7 * numof16belem + i] = xmm0[7];
+  }
 }
 
 
@@ -287,148 +287,148 @@ shuffle8(uint8_t* dest, const uint8_t* src, size_t size)
 static void
 shuffle16(uint8_t* dest, const uint8_t* src, size_t size)
 {
-	size_t i, j;
-	const size_t numof16belem = size / (16 * sizeof(__m128i));
+  size_t i, j;
+  const size_t numof16belem = size / (16 * sizeof(__m128i));
 
-	for (i = 0, j = 0; i < numof16belem; i++, j += 16) {
-		__m128i xmm0[16], xmm1[16];
+  for (i = 0, j = 0; i < numof16belem; i++, j += 16) {
+    __m128i xmm0[16], xmm1[16];
 
-		/* Fetch elements in groups of 256 bytes */
-		xmm0[0] = _mm_loadu_si128(((__m128i*)src) + (j + 0));
-		xmm0[1] = _mm_loadu_si128(((__m128i*)src) + (j + 1));
-		xmm0[2] = _mm_loadu_si128(((__m128i*)src) + (j + 2));
-		xmm0[3] = _mm_loadu_si128(((__m128i*)src) + (j + 3));
-		xmm0[4] = _mm_loadu_si128(((__m128i*)src) + (j + 4));
-		xmm0[5] = _mm_loadu_si128(((__m128i*)src) + (j + 5));
-		xmm0[6] = _mm_loadu_si128(((__m128i*)src) + (j + 6));
-		xmm0[7] = _mm_loadu_si128(((__m128i*)src) + (j + 7));
-		xmm0[8] = _mm_loadu_si128(((__m128i*)src) + (j + 8));
-		xmm0[9] = _mm_loadu_si128(((__m128i*)src) + (j + 9));
-		xmm0[10] = _mm_loadu_si128(((__m128i*)src) + (j + 10));
-		xmm0[11] = _mm_loadu_si128(((__m128i*)src) + (j + 11));
-		xmm0[12] = _mm_loadu_si128(((__m128i*)src) + (j + 12));
-		xmm0[13] = _mm_loadu_si128(((__m128i*)src) + (j + 13));
-		xmm0[14] = _mm_loadu_si128(((__m128i*)src) + (j + 14));
-		xmm0[15] = _mm_loadu_si128(((__m128i*)src) + (j + 15));
+    /* Fetch elements in groups of 256 bytes */
+    xmm0[0] = _mm_loadu_si128(((__m128i*)src) + (j + 0));
+    xmm0[1] = _mm_loadu_si128(((__m128i*)src) + (j + 1));
+    xmm0[2] = _mm_loadu_si128(((__m128i*)src) + (j + 2));
+    xmm0[3] = _mm_loadu_si128(((__m128i*)src) + (j + 3));
+    xmm0[4] = _mm_loadu_si128(((__m128i*)src) + (j + 4));
+    xmm0[5] = _mm_loadu_si128(((__m128i*)src) + (j + 5));
+    xmm0[6] = _mm_loadu_si128(((__m128i*)src) + (j + 6));
+    xmm0[7] = _mm_loadu_si128(((__m128i*)src) + (j + 7));
+    xmm0[8] = _mm_loadu_si128(((__m128i*)src) + (j + 8));
+    xmm0[9] = _mm_loadu_si128(((__m128i*)src) + (j + 9));
+    xmm0[10] = _mm_loadu_si128(((__m128i*)src) + (j + 10));
+    xmm0[11] = _mm_loadu_si128(((__m128i*)src) + (j + 11));
+    xmm0[12] = _mm_loadu_si128(((__m128i*)src) + (j + 12));
+    xmm0[13] = _mm_loadu_si128(((__m128i*)src) + (j + 13));
+    xmm0[14] = _mm_loadu_si128(((__m128i*)src) + (j + 14));
+    xmm0[15] = _mm_loadu_si128(((__m128i*)src) + (j + 15));
 
-		/* Transpose bytes */
-		xmm1[0] = _mm_unpacklo_epi8(xmm0[0], xmm0[1]);
-		xmm1[1] = _mm_unpackhi_epi8(xmm0[0], xmm0[1]);
+    /* Transpose bytes */
+    xmm1[0] = _mm_unpacklo_epi8(xmm0[0], xmm0[1]);
+    xmm1[1] = _mm_unpackhi_epi8(xmm0[0], xmm0[1]);
 
-		xmm1[2] = _mm_unpacklo_epi8(xmm0[2], xmm0[3]);
-		xmm1[3] = _mm_unpackhi_epi8(xmm0[2], xmm0[3]);
+    xmm1[2] = _mm_unpacklo_epi8(xmm0[2], xmm0[3]);
+    xmm1[3] = _mm_unpackhi_epi8(xmm0[2], xmm0[3]);
 
-		xmm1[4] = _mm_unpacklo_epi8(xmm0[4], xmm0[5]);
-		xmm1[5] = _mm_unpackhi_epi8(xmm0[4], xmm0[5]);
+    xmm1[4] = _mm_unpacklo_epi8(xmm0[4], xmm0[5]);
+    xmm1[5] = _mm_unpackhi_epi8(xmm0[4], xmm0[5]);
 
-		xmm1[6] = _mm_unpacklo_epi8(xmm0[6], xmm0[7]);
-		xmm1[7] = _mm_unpackhi_epi8(xmm0[6], xmm0[7]);
+    xmm1[6] = _mm_unpacklo_epi8(xmm0[6], xmm0[7]);
+    xmm1[7] = _mm_unpackhi_epi8(xmm0[6], xmm0[7]);
 
-		xmm1[8] = _mm_unpacklo_epi8(xmm0[8], xmm0[9]);
-		xmm1[9] = _mm_unpackhi_epi8(xmm0[8], xmm0[9]);
+    xmm1[8] = _mm_unpacklo_epi8(xmm0[8], xmm0[9]);
+    xmm1[9] = _mm_unpackhi_epi8(xmm0[8], xmm0[9]);
 
-		xmm1[10] = _mm_unpacklo_epi8(xmm0[10], xmm0[11]);
-		xmm1[11] = _mm_unpackhi_epi8(xmm0[10], xmm0[11]);
+    xmm1[10] = _mm_unpacklo_epi8(xmm0[10], xmm0[11]);
+    xmm1[11] = _mm_unpackhi_epi8(xmm0[10], xmm0[11]);
 
-		xmm1[12] = _mm_unpacklo_epi8(xmm0[12], xmm0[13]);
-		xmm1[13] = _mm_unpackhi_epi8(xmm0[12], xmm0[13]);
+    xmm1[12] = _mm_unpacklo_epi8(xmm0[12], xmm0[13]);
+    xmm1[13] = _mm_unpackhi_epi8(xmm0[12], xmm0[13]);
 
-		xmm1[14] = _mm_unpacklo_epi8(xmm0[14], xmm0[15]);
-		xmm1[15] = _mm_unpackhi_epi8(xmm0[14], xmm0[15]);
+    xmm1[14] = _mm_unpacklo_epi8(xmm0[14], xmm0[15]);
+    xmm1[15] = _mm_unpackhi_epi8(xmm0[14], xmm0[15]);
 
-		/* Transpose words */
-		xmm0[0] = _mm_unpacklo_epi16(xmm1[0], xmm1[2]);
-		xmm0[1] = _mm_unpackhi_epi16(xmm1[0], xmm1[2]);
+    /* Transpose words */
+    xmm0[0] = _mm_unpacklo_epi16(xmm1[0], xmm1[2]);
+    xmm0[1] = _mm_unpackhi_epi16(xmm1[0], xmm1[2]);
 
-		xmm0[2] = _mm_unpacklo_epi16(xmm1[1], xmm1[3]);
-		xmm0[3] = _mm_unpackhi_epi16(xmm1[1], xmm1[3]);
+    xmm0[2] = _mm_unpacklo_epi16(xmm1[1], xmm1[3]);
+    xmm0[3] = _mm_unpackhi_epi16(xmm1[1], xmm1[3]);
 
-		xmm0[4] = _mm_unpacklo_epi16(xmm1[4], xmm1[6]);
-		xmm0[5] = _mm_unpackhi_epi16(xmm1[4], xmm1[6]);
+    xmm0[4] = _mm_unpacklo_epi16(xmm1[4], xmm1[6]);
+    xmm0[5] = _mm_unpackhi_epi16(xmm1[4], xmm1[6]);
 
-		xmm0[6] = _mm_unpacklo_epi16(xmm1[5], xmm1[7]);
-		xmm0[7] = _mm_unpackhi_epi16(xmm1[5], xmm1[7]);
+    xmm0[6] = _mm_unpacklo_epi16(xmm1[5], xmm1[7]);
+    xmm0[7] = _mm_unpackhi_epi16(xmm1[5], xmm1[7]);
 
-		xmm0[8] = _mm_unpacklo_epi16(xmm1[8], xmm1[10]);
-		xmm0[9] = _mm_unpackhi_epi16(xmm1[8], xmm1[10]);
+    xmm0[8] = _mm_unpacklo_epi16(xmm1[8], xmm1[10]);
+    xmm0[9] = _mm_unpackhi_epi16(xmm1[8], xmm1[10]);
 
-		xmm0[10] = _mm_unpacklo_epi16(xmm1[9], xmm1[11]);
-		xmm0[11] = _mm_unpackhi_epi16(xmm1[9], xmm1[11]);
+    xmm0[10] = _mm_unpacklo_epi16(xmm1[9], xmm1[11]);
+    xmm0[11] = _mm_unpackhi_epi16(xmm1[9], xmm1[11]);
 
-		xmm0[12] = _mm_unpacklo_epi16(xmm1[12], xmm1[14]);
-		xmm0[13] = _mm_unpackhi_epi16(xmm1[12], xmm1[14]);
+    xmm0[12] = _mm_unpacklo_epi16(xmm1[12], xmm1[14]);
+    xmm0[13] = _mm_unpackhi_epi16(xmm1[12], xmm1[14]);
 
-		xmm0[14] = _mm_unpacklo_epi16(xmm1[13], xmm1[15]);
-		xmm0[15] = _mm_unpackhi_epi16(xmm1[13], xmm1[15]);
+    xmm0[14] = _mm_unpacklo_epi16(xmm1[13], xmm1[15]);
+    xmm0[15] = _mm_unpackhi_epi16(xmm1[13], xmm1[15]);
 
-		/* Transpose double words */
-		xmm1[0] = _mm_unpacklo_epi32(xmm0[0], xmm0[4]);
-		xmm1[1] = _mm_unpackhi_epi32(xmm0[0], xmm0[4]);
+    /* Transpose double words */
+    xmm1[0] = _mm_unpacklo_epi32(xmm0[0], xmm0[4]);
+    xmm1[1] = _mm_unpackhi_epi32(xmm0[0], xmm0[4]);
 
-		xmm1[2] = _mm_unpacklo_epi32(xmm0[1], xmm0[5]);
-		xmm1[3] = _mm_unpackhi_epi32(xmm0[1], xmm0[5]);
+    xmm1[2] = _mm_unpacklo_epi32(xmm0[1], xmm0[5]);
+    xmm1[3] = _mm_unpackhi_epi32(xmm0[1], xmm0[5]);
 
-		xmm1[4] = _mm_unpacklo_epi32(xmm0[2], xmm0[6]);
-		xmm1[5] = _mm_unpackhi_epi32(xmm0[2], xmm0[6]);
+    xmm1[4] = _mm_unpacklo_epi32(xmm0[2], xmm0[6]);
+    xmm1[5] = _mm_unpackhi_epi32(xmm0[2], xmm0[6]);
 
-		xmm1[6] = _mm_unpacklo_epi32(xmm0[3], xmm0[7]);
-		xmm1[7] = _mm_unpackhi_epi32(xmm0[3], xmm0[7]);
+    xmm1[6] = _mm_unpacklo_epi32(xmm0[3], xmm0[7]);
+    xmm1[7] = _mm_unpackhi_epi32(xmm0[3], xmm0[7]);
 
-		xmm1[8] = _mm_unpacklo_epi32(xmm0[8], xmm0[12]);
-		xmm1[9] = _mm_unpackhi_epi32(xmm0[8], xmm0[12]);
+    xmm1[8] = _mm_unpacklo_epi32(xmm0[8], xmm0[12]);
+    xmm1[9] = _mm_unpackhi_epi32(xmm0[8], xmm0[12]);
 
-		xmm1[10] = _mm_unpacklo_epi32(xmm0[9], xmm0[13]);
-		xmm1[11] = _mm_unpackhi_epi32(xmm0[9], xmm0[13]);
+    xmm1[10] = _mm_unpacklo_epi32(xmm0[9], xmm0[13]);
+    xmm1[11] = _mm_unpackhi_epi32(xmm0[9], xmm0[13]);
 
-		xmm1[12] = _mm_unpacklo_epi32(xmm0[10], xmm0[14]);
-		xmm1[13] = _mm_unpackhi_epi32(xmm0[10], xmm0[14]);
+    xmm1[12] = _mm_unpacklo_epi32(xmm0[10], xmm0[14]);
+    xmm1[13] = _mm_unpackhi_epi32(xmm0[10], xmm0[14]);
 
-		xmm1[14] = _mm_unpacklo_epi32(xmm0[11], xmm0[15]);
-		xmm1[15] = _mm_unpackhi_epi32(xmm0[11], xmm0[15]);
+    xmm1[14] = _mm_unpacklo_epi32(xmm0[11], xmm0[15]);
+    xmm1[15] = _mm_unpackhi_epi32(xmm0[11], xmm0[15]);
 
-		/* Transpose quad words */
-		xmm0[0] = _mm_unpacklo_epi64(xmm1[0], xmm1[8]);
-		xmm0[1] = _mm_unpackhi_epi64(xmm1[0], xmm1[8]);
+    /* Transpose quad words */
+    xmm0[0] = _mm_unpacklo_epi64(xmm1[0], xmm1[8]);
+    xmm0[1] = _mm_unpackhi_epi64(xmm1[0], xmm1[8]);
 
-		xmm0[2] = _mm_unpacklo_epi64(xmm1[1], xmm1[9]);
-		xmm0[3] = _mm_unpackhi_epi64(xmm1[1], xmm1[9]);
+    xmm0[2] = _mm_unpacklo_epi64(xmm1[1], xmm1[9]);
+    xmm0[3] = _mm_unpackhi_epi64(xmm1[1], xmm1[9]);
 
-		xmm0[4] = _mm_unpacklo_epi64(xmm1[2], xmm1[10]);
-		xmm0[5] = _mm_unpackhi_epi64(xmm1[2], xmm1[10]);
+    xmm0[4] = _mm_unpacklo_epi64(xmm1[2], xmm1[10]);
+    xmm0[5] = _mm_unpackhi_epi64(xmm1[2], xmm1[10]);
 
-		xmm0[6] = _mm_unpacklo_epi64(xmm1[3], xmm1[11]);
-		xmm0[7] = _mm_unpackhi_epi64(xmm1[3], xmm1[11]);
+    xmm0[6] = _mm_unpacklo_epi64(xmm1[3], xmm1[11]);
+    xmm0[7] = _mm_unpackhi_epi64(xmm1[3], xmm1[11]);
 
-		xmm0[8] = _mm_unpacklo_epi64(xmm1[4], xmm1[12]);
-		xmm0[9] = _mm_unpackhi_epi64(xmm1[4], xmm1[12]);
+    xmm0[8] = _mm_unpacklo_epi64(xmm1[4], xmm1[12]);
+    xmm0[9] = _mm_unpackhi_epi64(xmm1[4], xmm1[12]);
 
-		xmm0[10] = _mm_unpacklo_epi64(xmm1[5], xmm1[13]);
-		xmm0[11] = _mm_unpackhi_epi64(xmm1[5], xmm1[13]);
+    xmm0[10] = _mm_unpacklo_epi64(xmm1[5], xmm1[13]);
+    xmm0[11] = _mm_unpackhi_epi64(xmm1[5], xmm1[13]);
 
-		xmm0[12] = _mm_unpacklo_epi64(xmm1[6], xmm1[14]);
-		xmm0[13] = _mm_unpackhi_epi64(xmm1[6], xmm1[14]);
+    xmm0[12] = _mm_unpacklo_epi64(xmm1[6], xmm1[14]);
+    xmm0[13] = _mm_unpackhi_epi64(xmm1[6], xmm1[14]);
 
-		xmm0[14] = _mm_unpacklo_epi64(xmm1[7], xmm1[15]);
-		xmm0[15] = _mm_unpackhi_epi64(xmm1[7], xmm1[15]);
+    xmm0[14] = _mm_unpacklo_epi64(xmm1[7], xmm1[15]);
+    xmm0[15] = _mm_unpackhi_epi64(xmm1[7], xmm1[15]);
 
-		/* Store the result vectors */
-		_mm_storeu_si128(((__m128i*)dest) + (0 * numof16belem + i), xmm0[0]);
-		_mm_storeu_si128(((__m128i*)dest) + (1 * numof16belem + i), xmm0[1]);
-		_mm_storeu_si128(((__m128i*)dest) + (2 * numof16belem + i), xmm0[2]);
-		_mm_storeu_si128(((__m128i*)dest) + (3 * numof16belem + i), xmm0[3]);
-		_mm_storeu_si128(((__m128i*)dest) + (4 * numof16belem + i), xmm0[4]);
-		_mm_storeu_si128(((__m128i*)dest) + (5 * numof16belem + i), xmm0[5]);
-		_mm_storeu_si128(((__m128i*)dest) + (6 * numof16belem + i), xmm0[6]);
-		_mm_storeu_si128(((__m128i*)dest) + (7 * numof16belem + i), xmm0[7]);
-		_mm_storeu_si128(((__m128i*)dest) + (8 * numof16belem + i), xmm0[8]);
-		_mm_storeu_si128(((__m128i*)dest) + (9 * numof16belem + i), xmm0[9]);
-		_mm_storeu_si128(((__m128i*)dest) + (10 * numof16belem + i), xmm0[10]);
-		_mm_storeu_si128(((__m128i*)dest) + (11 * numof16belem + i), xmm0[11]);
-		_mm_storeu_si128(((__m128i*)dest) + (12 * numof16belem + i), xmm0[12]);
-		_mm_storeu_si128(((__m128i*)dest) + (13 * numof16belem + i), xmm0[13]);
-		_mm_storeu_si128(((__m128i*)dest) + (14 * numof16belem + i), xmm0[14]);
-		_mm_storeu_si128(((__m128i*)dest) + (15 * numof16belem + i), xmm0[15]);
-	}
+    /* Store the result vectors */
+    _mm_storeu_si128(((__m128i*)dest) + (0 * numof16belem + i), xmm0[0]);
+    _mm_storeu_si128(((__m128i*)dest) + (1 * numof16belem + i), xmm0[1]);
+    _mm_storeu_si128(((__m128i*)dest) + (2 * numof16belem + i), xmm0[2]);
+    _mm_storeu_si128(((__m128i*)dest) + (3 * numof16belem + i), xmm0[3]);
+    _mm_storeu_si128(((__m128i*)dest) + (4 * numof16belem + i), xmm0[4]);
+    _mm_storeu_si128(((__m128i*)dest) + (5 * numof16belem + i), xmm0[5]);
+    _mm_storeu_si128(((__m128i*)dest) + (6 * numof16belem + i), xmm0[6]);
+    _mm_storeu_si128(((__m128i*)dest) + (7 * numof16belem + i), xmm0[7]);
+    _mm_storeu_si128(((__m128i*)dest) + (8 * numof16belem + i), xmm0[8]);
+    _mm_storeu_si128(((__m128i*)dest) + (9 * numof16belem + i), xmm0[9]);
+    _mm_storeu_si128(((__m128i*)dest) + (10 * numof16belem + i), xmm0[10]);
+    _mm_storeu_si128(((__m128i*)dest) + (11 * numof16belem + i), xmm0[11]);
+    _mm_storeu_si128(((__m128i*)dest) + (12 * numof16belem + i), xmm0[12]);
+    _mm_storeu_si128(((__m128i*)dest) + (13 * numof16belem + i), xmm0[13]);
+    _mm_storeu_si128(((__m128i*)dest) + (14 * numof16belem + i), xmm0[14]);
+    _mm_storeu_si128(((__m128i*)dest) + (15 * numof16belem + i), xmm0[15]);
+  }
 }
 
 
@@ -436,203 +436,203 @@ shuffle16(uint8_t* dest, const uint8_t* src, size_t size)
 static void
 shuffle_multipart(uint8_t* dest, const uint8_t* src, size_t size, size_t bytesoftype)
 {
-	size_t j;
-	const size_t num_elements = size / bytesoftype;
-	const lldiv_t vecs_per_el = lldiv(bytesoftype, sizeof(__m128i));
+  size_t j;
+  const size_t num_elements = size / bytesoftype;
+  const lldiv_t vecs_per_el = lldiv(bytesoftype, sizeof(__m128i));
 
-	for (j = 0; j < num_elements; j += sizeof(__m128i)) {
-		/* Advance the offset into the type by the vector size (in bytes), unless this is
-		the initial iteration and the type size is not a multiple of the vector size.
-		In that case, only advance by the number of bytes necessary so that the number
-		of remaining bytes in the type will be a multiple of the vector size. */
-		size_t offset_into_type;
-		for (offset_into_type = 0; offset_into_type < bytesoftype;
-			offset_into_type += (offset_into_type == 0 && vecs_per_el.rem > 0 ? vecs_per_el.rem : sizeof(__m128i))) {
-			__m128i xmm0[16], xmm1[16];
+  for (j = 0; j < num_elements; j += sizeof(__m128i)) {
+    /* Advance the offset into the type by the vector size (in bytes), unless this is
+    the initial iteration and the type size is not a multiple of the vector size.
+    In that case, only advance by the number of bytes necessary so that the number
+    of remaining bytes in the type will be a multiple of the vector size. */
+    size_t offset_into_type;
+    for (offset_into_type = 0; offset_into_type < bytesoftype;
+      offset_into_type += (offset_into_type == 0 && vecs_per_el.rem > 0 ? vecs_per_el.rem : sizeof(__m128i))) {
+      __m128i xmm0[16], xmm1[16];
 
-			/* Fetch elements in groups of 256 bytes */
-			const uint8_t* const src_with_offset = src + offset_into_type;
-			xmm0[0] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 0) * bytesoftype));
-			xmm0[1] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 1) * bytesoftype));
-			xmm0[2] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 2) * bytesoftype));
-			xmm0[3] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 3) * bytesoftype));
-			xmm0[4] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 4) * bytesoftype));
-			xmm0[5] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 5) * bytesoftype));
-			xmm0[6] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 6) * bytesoftype));
-			xmm0[7] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 7) * bytesoftype));
-			xmm0[8] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 8) * bytesoftype));
-			xmm0[9] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 9) * bytesoftype));
-			xmm0[10] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 10) * bytesoftype));
-			xmm0[11] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 11) * bytesoftype));
-			xmm0[12] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 12) * bytesoftype));
-			xmm0[13] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 13) * bytesoftype));
-			xmm0[14] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 14) * bytesoftype));
-			xmm0[15] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 15) * bytesoftype));
+      /* Fetch elements in groups of 256 bytes */
+      const uint8_t* const src_with_offset = src + offset_into_type;
+      xmm0[0] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 0) * bytesoftype));
+      xmm0[1] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 1) * bytesoftype));
+      xmm0[2] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 2) * bytesoftype));
+      xmm0[3] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 3) * bytesoftype));
+      xmm0[4] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 4) * bytesoftype));
+      xmm0[5] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 5) * bytesoftype));
+      xmm0[6] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 6) * bytesoftype));
+      xmm0[7] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 7) * bytesoftype));
+      xmm0[8] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 8) * bytesoftype));
+      xmm0[9] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 9) * bytesoftype));
+      xmm0[10] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 10) * bytesoftype));
+      xmm0[11] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 11) * bytesoftype));
+      xmm0[12] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 12) * bytesoftype));
+      xmm0[13] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 13) * bytesoftype));
+      xmm0[14] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 14) * bytesoftype));
+      xmm0[15] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 15) * bytesoftype));
 
-			/* Transpose bytes */
-			xmm1[0] = _mm_unpacklo_epi8(xmm0[0], xmm0[1]);
-			xmm1[1] = _mm_unpackhi_epi8(xmm0[0], xmm0[1]);
+      /* Transpose bytes */
+      xmm1[0] = _mm_unpacklo_epi8(xmm0[0], xmm0[1]);
+      xmm1[1] = _mm_unpackhi_epi8(xmm0[0], xmm0[1]);
 
-			xmm1[2] = _mm_unpacklo_epi8(xmm0[2], xmm0[3]);
-			xmm1[3] = _mm_unpackhi_epi8(xmm0[2], xmm0[3]);
+      xmm1[2] = _mm_unpacklo_epi8(xmm0[2], xmm0[3]);
+      xmm1[3] = _mm_unpackhi_epi8(xmm0[2], xmm0[3]);
 
-			xmm1[4] = _mm_unpacklo_epi8(xmm0[4], xmm0[5]);
-			xmm1[5] = _mm_unpackhi_epi8(xmm0[4], xmm0[5]);
+      xmm1[4] = _mm_unpacklo_epi8(xmm0[4], xmm0[5]);
+      xmm1[5] = _mm_unpackhi_epi8(xmm0[4], xmm0[5]);
 
-			xmm1[6] = _mm_unpacklo_epi8(xmm0[6], xmm0[7]);
-			xmm1[7] = _mm_unpackhi_epi8(xmm0[6], xmm0[7]);
+      xmm1[6] = _mm_unpacklo_epi8(xmm0[6], xmm0[7]);
+      xmm1[7] = _mm_unpackhi_epi8(xmm0[6], xmm0[7]);
 
-			xmm1[8] = _mm_unpacklo_epi8(xmm0[8], xmm0[9]);
-			xmm1[9] = _mm_unpackhi_epi8(xmm0[8], xmm0[9]);
+      xmm1[8] = _mm_unpacklo_epi8(xmm0[8], xmm0[9]);
+      xmm1[9] = _mm_unpackhi_epi8(xmm0[8], xmm0[9]);
 
-			xmm1[10] = _mm_unpacklo_epi8(xmm0[10], xmm0[11]);
-			xmm1[11] = _mm_unpackhi_epi8(xmm0[10], xmm0[11]);
+      xmm1[10] = _mm_unpacklo_epi8(xmm0[10], xmm0[11]);
+      xmm1[11] = _mm_unpackhi_epi8(xmm0[10], xmm0[11]);
 
-			xmm1[12] = _mm_unpacklo_epi8(xmm0[12], xmm0[13]);
-			xmm1[13] = _mm_unpackhi_epi8(xmm0[12], xmm0[13]);
+      xmm1[12] = _mm_unpacklo_epi8(xmm0[12], xmm0[13]);
+      xmm1[13] = _mm_unpackhi_epi8(xmm0[12], xmm0[13]);
 
-			xmm1[14] = _mm_unpacklo_epi8(xmm0[14], xmm0[15]);
-			xmm1[15] = _mm_unpackhi_epi8(xmm0[14], xmm0[15]);
+      xmm1[14] = _mm_unpacklo_epi8(xmm0[14], xmm0[15]);
+      xmm1[15] = _mm_unpackhi_epi8(xmm0[14], xmm0[15]);
 
-			/* Transpose words */
-			xmm0[0] = _mm_unpacklo_epi16(xmm1[0], xmm1[2]);
-			xmm0[1] = _mm_unpackhi_epi16(xmm1[0], xmm1[2]);
+      /* Transpose words */
+      xmm0[0] = _mm_unpacklo_epi16(xmm1[0], xmm1[2]);
+      xmm0[1] = _mm_unpackhi_epi16(xmm1[0], xmm1[2]);
 
-			xmm0[2] = _mm_unpacklo_epi16(xmm1[1], xmm1[3]);
-			xmm0[3] = _mm_unpackhi_epi16(xmm1[1], xmm1[3]);
+      xmm0[2] = _mm_unpacklo_epi16(xmm1[1], xmm1[3]);
+      xmm0[3] = _mm_unpackhi_epi16(xmm1[1], xmm1[3]);
 
-			xmm0[4] = _mm_unpacklo_epi16(xmm1[4], xmm1[6]);
-			xmm0[5] = _mm_unpackhi_epi16(xmm1[4], xmm1[6]);
+      xmm0[4] = _mm_unpacklo_epi16(xmm1[4], xmm1[6]);
+      xmm0[5] = _mm_unpackhi_epi16(xmm1[4], xmm1[6]);
 
-			xmm0[6] = _mm_unpacklo_epi16(xmm1[5], xmm1[7]);
-			xmm0[7] = _mm_unpackhi_epi16(xmm1[5], xmm1[7]);
+      xmm0[6] = _mm_unpacklo_epi16(xmm1[5], xmm1[7]);
+      xmm0[7] = _mm_unpackhi_epi16(xmm1[5], xmm1[7]);
 
-			xmm0[8] = _mm_unpacklo_epi16(xmm1[8], xmm1[10]);
-			xmm0[9] = _mm_unpackhi_epi16(xmm1[8], xmm1[10]);
+      xmm0[8] = _mm_unpacklo_epi16(xmm1[8], xmm1[10]);
+      xmm0[9] = _mm_unpackhi_epi16(xmm1[8], xmm1[10]);
 
-			xmm0[10] = _mm_unpacklo_epi16(xmm1[9], xmm1[11]);
-			xmm0[11] = _mm_unpackhi_epi16(xmm1[9], xmm1[11]);
+      xmm0[10] = _mm_unpacklo_epi16(xmm1[9], xmm1[11]);
+      xmm0[11] = _mm_unpackhi_epi16(xmm1[9], xmm1[11]);
 
-			xmm0[12] = _mm_unpacklo_epi16(xmm1[12], xmm1[14]);
-			xmm0[13] = _mm_unpackhi_epi16(xmm1[12], xmm1[14]);
+      xmm0[12] = _mm_unpacklo_epi16(xmm1[12], xmm1[14]);
+      xmm0[13] = _mm_unpackhi_epi16(xmm1[12], xmm1[14]);
 
-			xmm0[14] = _mm_unpacklo_epi16(xmm1[13], xmm1[15]);
-			xmm0[15] = _mm_unpackhi_epi16(xmm1[13], xmm1[15]);
+      xmm0[14] = _mm_unpacklo_epi16(xmm1[13], xmm1[15]);
+      xmm0[15] = _mm_unpackhi_epi16(xmm1[13], xmm1[15]);
 
-			/* Transpose double words */
-			xmm1[0] = _mm_unpacklo_epi32(xmm0[0], xmm0[4]);
-			xmm1[1] = _mm_unpackhi_epi32(xmm0[0], xmm0[4]);
+      /* Transpose double words */
+      xmm1[0] = _mm_unpacklo_epi32(xmm0[0], xmm0[4]);
+      xmm1[1] = _mm_unpackhi_epi32(xmm0[0], xmm0[4]);
 
-			xmm1[2] = _mm_unpacklo_epi32(xmm0[1], xmm0[5]);
-			xmm1[3] = _mm_unpackhi_epi32(xmm0[1], xmm0[5]);
+      xmm1[2] = _mm_unpacklo_epi32(xmm0[1], xmm0[5]);
+      xmm1[3] = _mm_unpackhi_epi32(xmm0[1], xmm0[5]);
 
-			xmm1[4] = _mm_unpacklo_epi32(xmm0[2], xmm0[6]);
-			xmm1[5] = _mm_unpackhi_epi32(xmm0[2], xmm0[6]);
+      xmm1[4] = _mm_unpacklo_epi32(xmm0[2], xmm0[6]);
+      xmm1[5] = _mm_unpackhi_epi32(xmm0[2], xmm0[6]);
 
-			xmm1[6] = _mm_unpacklo_epi32(xmm0[3], xmm0[7]);
-			xmm1[7] = _mm_unpackhi_epi32(xmm0[3], xmm0[7]);
+      xmm1[6] = _mm_unpacklo_epi32(xmm0[3], xmm0[7]);
+      xmm1[7] = _mm_unpackhi_epi32(xmm0[3], xmm0[7]);
 
-			xmm1[8] = _mm_unpacklo_epi32(xmm0[8], xmm0[12]);
-			xmm1[9] = _mm_unpackhi_epi32(xmm0[8], xmm0[12]);
+      xmm1[8] = _mm_unpacklo_epi32(xmm0[8], xmm0[12]);
+      xmm1[9] = _mm_unpackhi_epi32(xmm0[8], xmm0[12]);
 
-			xmm1[10] = _mm_unpacklo_epi32(xmm0[9], xmm0[13]);
-			xmm1[11] = _mm_unpackhi_epi32(xmm0[9], xmm0[13]);
+      xmm1[10] = _mm_unpacklo_epi32(xmm0[9], xmm0[13]);
+      xmm1[11] = _mm_unpackhi_epi32(xmm0[9], xmm0[13]);
 
-			xmm1[12] = _mm_unpacklo_epi32(xmm0[10], xmm0[14]);
-			xmm1[13] = _mm_unpackhi_epi32(xmm0[10], xmm0[14]);
+      xmm1[12] = _mm_unpacklo_epi32(xmm0[10], xmm0[14]);
+      xmm1[13] = _mm_unpackhi_epi32(xmm0[10], xmm0[14]);
 
-			xmm1[14] = _mm_unpacklo_epi32(xmm0[11], xmm0[15]);
-			xmm1[15] = _mm_unpackhi_epi32(xmm0[11], xmm0[15]);
+      xmm1[14] = _mm_unpacklo_epi32(xmm0[11], xmm0[15]);
+      xmm1[15] = _mm_unpackhi_epi32(xmm0[11], xmm0[15]);
 
-			/* Transpose quad words */
-			xmm0[0] = _mm_unpacklo_epi64(xmm1[0], xmm1[8]);
-			xmm0[1] = _mm_unpackhi_epi64(xmm1[0], xmm1[8]);
+      /* Transpose quad words */
+      xmm0[0] = _mm_unpacklo_epi64(xmm1[0], xmm1[8]);
+      xmm0[1] = _mm_unpackhi_epi64(xmm1[0], xmm1[8]);
 
-			xmm0[2] = _mm_unpacklo_epi64(xmm1[1], xmm1[9]);
-			xmm0[3] = _mm_unpackhi_epi64(xmm1[1], xmm1[9]);
+      xmm0[2] = _mm_unpacklo_epi64(xmm1[1], xmm1[9]);
+      xmm0[3] = _mm_unpackhi_epi64(xmm1[1], xmm1[9]);
 
-			xmm0[4] = _mm_unpacklo_epi64(xmm1[2], xmm1[10]);
-			xmm0[5] = _mm_unpackhi_epi64(xmm1[2], xmm1[10]);
+      xmm0[4] = _mm_unpacklo_epi64(xmm1[2], xmm1[10]);
+      xmm0[5] = _mm_unpackhi_epi64(xmm1[2], xmm1[10]);
 
-			xmm0[6] = _mm_unpacklo_epi64(xmm1[3], xmm1[11]);
-			xmm0[7] = _mm_unpackhi_epi64(xmm1[3], xmm1[11]);
+      xmm0[6] = _mm_unpacklo_epi64(xmm1[3], xmm1[11]);
+      xmm0[7] = _mm_unpackhi_epi64(xmm1[3], xmm1[11]);
 
-			xmm0[8] = _mm_unpacklo_epi64(xmm1[4], xmm1[12]);
-			xmm0[9] = _mm_unpackhi_epi64(xmm1[4], xmm1[12]);
+      xmm0[8] = _mm_unpacklo_epi64(xmm1[4], xmm1[12]);
+      xmm0[9] = _mm_unpackhi_epi64(xmm1[4], xmm1[12]);
 
-			xmm0[10] = _mm_unpacklo_epi64(xmm1[5], xmm1[13]);
-			xmm0[11] = _mm_unpackhi_epi64(xmm1[5], xmm1[13]);
+      xmm0[10] = _mm_unpacklo_epi64(xmm1[5], xmm1[13]);
+      xmm0[11] = _mm_unpackhi_epi64(xmm1[5], xmm1[13]);
 
-			xmm0[12] = _mm_unpacklo_epi64(xmm1[6], xmm1[14]);
-			xmm0[13] = _mm_unpackhi_epi64(xmm1[6], xmm1[14]);
+      xmm0[12] = _mm_unpacklo_epi64(xmm1[6], xmm1[14]);
+      xmm0[13] = _mm_unpackhi_epi64(xmm1[6], xmm1[14]);
 
-			xmm0[14] = _mm_unpacklo_epi64(xmm1[7], xmm1[15]);
-			xmm0[15] = _mm_unpackhi_epi64(xmm1[7], xmm1[15]);
+      xmm0[14] = _mm_unpacklo_epi64(xmm1[7], xmm1[15]);
+      xmm0[15] = _mm_unpackhi_epi64(xmm1[7], xmm1[15]);
 
-			/* Store the result vectors */
-			uint8_t* const dest_for_jth_element = dest + j;
-			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 0))), xmm0[0]);
-			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 1))), xmm0[1]);
-			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 2))), xmm0[2]);
-			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 3))), xmm0[3]);
-			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 4))), xmm0[4]);
-			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 5))), xmm0[5]);
-			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 6))), xmm0[6]);
-			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 7))), xmm0[7]);
-			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 8))), xmm0[8]);
-			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 9))), xmm0[9]);
-			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 10))), xmm0[10]);
-			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 11))), xmm0[11]);
-			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 12))), xmm0[12]);
-			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 13))), xmm0[13]);
-			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 14))), xmm0[14]);
-			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 15))), xmm0[15]);
-		}
-	}
+      /* Store the result vectors */
+      uint8_t* const dest_for_jth_element = dest + j;
+      _mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 0))), xmm0[0]);
+      _mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 1))), xmm0[1]);
+      _mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 2))), xmm0[2]);
+      _mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 3))), xmm0[3]);
+      _mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 4))), xmm0[4]);
+      _mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 5))), xmm0[5]);
+      _mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 6))), xmm0[6]);
+      _mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 7))), xmm0[7]);
+      _mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 8))), xmm0[8]);
+      _mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 9))), xmm0[9]);
+      _mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 10))), xmm0[10]);
+      _mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 11))), xmm0[11]);
+      _mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 12))), xmm0[12]);
+      _mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 13))), xmm0[13]);
+      _mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 14))), xmm0[14]);
+      _mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 15))), xmm0[15]);
+    }
+  }
 }
 
 
 /* Shuffle a block.  This can never fail. */
 void shuffle(size_t bytesoftype, size_t blocksize,
-	const uint8_t* _src, uint8_t* _dest) {
-	int unaligned_dest = (int)((uintptr_t)_dest % sizeof(__m128i));
-	int multiple_of_block = (blocksize % (sizeof(__m128i) * bytesoftype)) == 0;
-	int too_small = (blocksize < 256);
+  const uint8_t* _src, uint8_t* _dest) {
+  int unaligned_dest = (int)((uintptr_t)_dest % sizeof(__m128i));
+  int multiple_of_block = (blocksize % (sizeof(__m128i) * bytesoftype)) == 0;
+  int too_small = (blocksize < 256);
 
-	if (unaligned_dest || !multiple_of_block || too_small) {
-		/* _dest buffer is not aligned, not multiple of the vectorization size
-		* or is too small.  Call the non-sse2 version. */
-		_shuffle(bytesoftype, blocksize, _src, _dest);
-		return;
-	}
+  if (unaligned_dest || !multiple_of_block || too_small) {
+    /* _dest buffer is not aligned, not multiple of the vectorization size
+    * or is too small.  Call the non-sse2 version. */
+    _shuffle(bytesoftype, blocksize, _src, _dest);
+    return;
+  }
 
-	/* Optimized shuffle */
-	/* The buffer must be aligned on a 16 bytes boundary, have a power */
-	/* of 2 size and be larger or equal than 256 bytes. */
-	switch (bytesoftype)
-	{
-	case 2:
-		shuffle2(_dest, _src, blocksize);
-		break;
-	case 4:
-		shuffle4(_dest, _src, blocksize);
-		break;
-	case 8:
-		shuffle8(_dest, _src, blocksize);
-		break;
-	case 16:
-		shuffle16(_dest, _src, blocksize);
-		break;
-	default:
-		if (bytesoftype > sizeof(__m128i)) {
-			shuffle_multipart(_dest, _src, blocksize, bytesoftype);
-		}
-		else {
-			/* Non-optimized shuffle */
-			_shuffle(bytesoftype, blocksize, _src, _dest);
-		}
-		break;
-	}
+  /* Optimized shuffle */
+  /* The buffer must be aligned on a 16 bytes boundary, have a power */
+  /* of 2 size and be larger or equal than 256 bytes. */
+  switch (bytesoftype)
+  {
+  case 2:
+    shuffle2(_dest, _src, blocksize);
+    break;
+  case 4:
+    shuffle4(_dest, _src, blocksize);
+    break;
+  case 8:
+    shuffle8(_dest, _src, blocksize);
+    break;
+  case 16:
+    shuffle16(_dest, _src, blocksize);
+    break;
+  default:
+    if (bytesoftype > sizeof(__m128i)) {
+      shuffle_multipart(_dest, _src, blocksize, bytesoftype);
+    }
+    else {
+      /* Non-optimized shuffle */
+      _shuffle(bytesoftype, blocksize, _src, _dest);
+    }
+    break;
+  }
 }
 
 
@@ -640,24 +640,24 @@ void shuffle(size_t bytesoftype, size_t blocksize,
 static void
 unshuffle2(uint8_t* dest, const uint8_t* orig, size_t size)
 {
-	size_t i, j;
-	const size_t numof16belem = size / (2 * sizeof(__m128i));
+  size_t i, j;
+  const size_t numof16belem = size / (2 * sizeof(__m128i));
 
-	for (i = 0, j = 0; i < numof16belem; i++, j += 2) {
-		__m128i xmm1[2], xmm2[2];
+  for (i = 0, j = 0; i < numof16belem; i++, j += 2) {
+    __m128i xmm1[2], xmm2[2];
 
-		/* Load the first 32 bytes in 2 XMM registers */
-		xmm1[0] = ((__m128i *)orig)[0 * numof16belem + i];
-		xmm1[1] = ((__m128i *)orig)[1 * numof16belem + i];
-		/* Unshuffle bytes */
-		/* Compute the low 32 bytes */
-		xmm2[0] = _mm_unpacklo_epi8(xmm1[0], xmm1[1]);
-		/* Compute the hi 32 bytes */
-		xmm2[1] = _mm_unpackhi_epi8(xmm1[0], xmm1[1]);
-		/* Store the result vectors in proper order */
-		((__m128i *)dest)[j + 0] = xmm2[0];
-		((__m128i *)dest)[j + 1] = xmm2[1];
-	}
+    /* Load the first 32 bytes in 2 XMM registers */
+    xmm1[0] = ((__m128i *)orig)[0 * numof16belem + i];
+    xmm1[1] = ((__m128i *)orig)[1 * numof16belem + i];
+    /* Unshuffle bytes */
+    /* Compute the low 32 bytes */
+    xmm2[0] = _mm_unpacklo_epi8(xmm1[0], xmm1[1]);
+    /* Compute the hi 32 bytes */
+    xmm2[1] = _mm_unpackhi_epi8(xmm1[0], xmm1[1]);
+    /* Store the result vectors in proper order */
+    ((__m128i *)dest)[j + 0] = xmm2[0];
+    ((__m128i *)dest)[j + 1] = xmm2[1];
+  }
 }
 
 
@@ -665,38 +665,38 @@ unshuffle2(uint8_t* dest, const uint8_t* orig, size_t size)
 static void
 unshuffle4(uint8_t* dest, const uint8_t* orig, size_t size)
 {
-	size_t i, j;
-	const size_t numof16belem = size / (4 * sizeof(__m128i));
+  size_t i, j;
+  const size_t numof16belem = size / (4 * sizeof(__m128i));
 
-	for (i = 0, j = 0; i < numof16belem; i++, j += 4) {
-		__m128i xmm0[4], xmm1[4];
+  for (i = 0, j = 0; i < numof16belem; i++, j += 4) {
+    __m128i xmm0[4], xmm1[4];
 
-		/* Load the first 64 bytes in 4 XMM registers */
-		xmm0[0] = ((__m128i *)orig)[0 * numof16belem + i];
-		xmm0[1] = ((__m128i *)orig)[1 * numof16belem + i];
-		xmm0[2] = ((__m128i *)orig)[2 * numof16belem + i];
-		xmm0[3] = ((__m128i *)orig)[3 * numof16belem + i];
+    /* Load the first 64 bytes in 4 XMM registers */
+    xmm0[0] = ((__m128i *)orig)[0 * numof16belem + i];
+    xmm0[1] = ((__m128i *)orig)[1 * numof16belem + i];
+    xmm0[2] = ((__m128i *)orig)[2 * numof16belem + i];
+    xmm0[3] = ((__m128i *)orig)[3 * numof16belem + i];
 
-		/* Unshuffle bytes */
-		xmm1[0] = _mm_unpacklo_epi8(xmm0[0], xmm0[1]);
-		xmm1[2] = _mm_unpackhi_epi8(xmm0[0], xmm0[1]);
+    /* Unshuffle bytes */
+    xmm1[0] = _mm_unpacklo_epi8(xmm0[0], xmm0[1]);
+    xmm1[2] = _mm_unpackhi_epi8(xmm0[0], xmm0[1]);
 
-		xmm1[1] = _mm_unpacklo_epi8(xmm0[2], xmm0[3]);
-		xmm1[3] = _mm_unpackhi_epi8(xmm0[2], xmm0[3]);
+    xmm1[1] = _mm_unpacklo_epi8(xmm0[2], xmm0[3]);
+    xmm1[3] = _mm_unpackhi_epi8(xmm0[2], xmm0[3]);
 
-		/* Unshuffle 2-byte words */
-		xmm0[0] = _mm_unpacklo_epi16(xmm1[0], xmm1[1]);
-		xmm0[2] = _mm_unpackhi_epi16(xmm1[0], xmm1[1]);
+    /* Unshuffle 2-byte words */
+    xmm0[0] = _mm_unpacklo_epi16(xmm1[0], xmm1[1]);
+    xmm0[2] = _mm_unpackhi_epi16(xmm1[0], xmm1[1]);
 
-		xmm0[1] = _mm_unpacklo_epi16(xmm1[2], xmm1[3]);
-		xmm0[3] = _mm_unpackhi_epi16(xmm1[2], xmm1[3]);
+    xmm0[1] = _mm_unpacklo_epi16(xmm1[2], xmm1[3]);
+    xmm0[3] = _mm_unpackhi_epi16(xmm1[2], xmm1[3]);
 
-		/* Store the result vectors in proper order */
-		((__m128i *)dest)[j + 0] = xmm0[0];
-		((__m128i *)dest)[j + 1] = xmm0[2];
-		((__m128i *)dest)[j + 2] = xmm0[1];
-		((__m128i *)dest)[j + 3] = xmm0[3];
-	}
+    /* Store the result vectors in proper order */
+    ((__m128i *)dest)[j + 0] = xmm0[0];
+    ((__m128i *)dest)[j + 1] = xmm0[2];
+    ((__m128i *)dest)[j + 2] = xmm0[1];
+    ((__m128i *)dest)[j + 3] = xmm0[3];
+  }
 }
 
 
@@ -704,71 +704,71 @@ unshuffle4(uint8_t* dest, const uint8_t* orig, size_t size)
 static void
 unshuffle8(uint8_t* dest, const uint8_t* orig, size_t size)
 {
-	size_t i, j;
-	const size_t numof16belem = size / (8 * sizeof(__m128i));
+  size_t i, j;
+  const size_t numof16belem = size / (8 * sizeof(__m128i));
 
-	for (i = 0, j = 0; i < numof16belem; i++, j += 8) {
-		__m128i xmm0[8], xmm1[8];
+  for (i = 0, j = 0; i < numof16belem; i++, j += 8) {
+    __m128i xmm0[8], xmm1[8];
 
-		/* Load the first 64 bytes in 8 XMM registers */
-		xmm0[0] = ((__m128i *)orig)[0 * numof16belem + i];
-		xmm0[1] = ((__m128i *)orig)[1 * numof16belem + i];
-		xmm0[2] = ((__m128i *)orig)[2 * numof16belem + i];
-		xmm0[3] = ((__m128i *)orig)[3 * numof16belem + i];
-		xmm0[4] = ((__m128i *)orig)[4 * numof16belem + i];
-		xmm0[5] = ((__m128i *)orig)[5 * numof16belem + i];
-		xmm0[6] = ((__m128i *)orig)[6 * numof16belem + i];
-		xmm0[7] = ((__m128i *)orig)[7 * numof16belem + i];
+    /* Load the first 64 bytes in 8 XMM registers */
+    xmm0[0] = ((__m128i *)orig)[0 * numof16belem + i];
+    xmm0[1] = ((__m128i *)orig)[1 * numof16belem + i];
+    xmm0[2] = ((__m128i *)orig)[2 * numof16belem + i];
+    xmm0[3] = ((__m128i *)orig)[3 * numof16belem + i];
+    xmm0[4] = ((__m128i *)orig)[4 * numof16belem + i];
+    xmm0[5] = ((__m128i *)orig)[5 * numof16belem + i];
+    xmm0[6] = ((__m128i *)orig)[6 * numof16belem + i];
+    xmm0[7] = ((__m128i *)orig)[7 * numof16belem + i];
 
-		/* Unshuffle bytes */
-		xmm1[0] = _mm_unpacklo_epi8(xmm0[0], xmm0[1]);
-		xmm1[4] = _mm_unpackhi_epi8(xmm0[0], xmm0[1]);
+    /* Unshuffle bytes */
+    xmm1[0] = _mm_unpacklo_epi8(xmm0[0], xmm0[1]);
+    xmm1[4] = _mm_unpackhi_epi8(xmm0[0], xmm0[1]);
 
-		xmm1[1] = _mm_unpacklo_epi8(xmm0[2], xmm0[3]);
-		xmm1[5] = _mm_unpackhi_epi8(xmm0[2], xmm0[3]);
+    xmm1[1] = _mm_unpacklo_epi8(xmm0[2], xmm0[3]);
+    xmm1[5] = _mm_unpackhi_epi8(xmm0[2], xmm0[3]);
 
-		xmm1[2] = _mm_unpacklo_epi8(xmm0[4], xmm0[5]);
-		xmm1[6] = _mm_unpackhi_epi8(xmm0[4], xmm0[5]);
+    xmm1[2] = _mm_unpacklo_epi8(xmm0[4], xmm0[5]);
+    xmm1[6] = _mm_unpackhi_epi8(xmm0[4], xmm0[5]);
 
-		xmm1[3] = _mm_unpacklo_epi8(xmm0[6], xmm0[7]);
-		xmm1[7] = _mm_unpackhi_epi8(xmm0[6], xmm0[7]);
+    xmm1[3] = _mm_unpacklo_epi8(xmm0[6], xmm0[7]);
+    xmm1[7] = _mm_unpackhi_epi8(xmm0[6], xmm0[7]);
 
-		/* Unshuffle 2-byte words */
-		xmm0[0] = _mm_unpacklo_epi16(xmm1[0], xmm1[1]);
-		xmm0[4] = _mm_unpackhi_epi16(xmm1[0], xmm1[1]);
+    /* Unshuffle 2-byte words */
+    xmm0[0] = _mm_unpacklo_epi16(xmm1[0], xmm1[1]);
+    xmm0[4] = _mm_unpackhi_epi16(xmm1[0], xmm1[1]);
 
-		xmm0[1] = _mm_unpacklo_epi16(xmm1[2], xmm1[3]);
-		xmm0[5] = _mm_unpackhi_epi16(xmm1[2], xmm1[3]);
+    xmm0[1] = _mm_unpacklo_epi16(xmm1[2], xmm1[3]);
+    xmm0[5] = _mm_unpackhi_epi16(xmm1[2], xmm1[3]);
 
-		xmm0[2] = _mm_unpacklo_epi16(xmm1[4], xmm1[5]);
-		xmm0[6] = _mm_unpackhi_epi16(xmm1[4], xmm1[5]);
+    xmm0[2] = _mm_unpacklo_epi16(xmm1[4], xmm1[5]);
+    xmm0[6] = _mm_unpackhi_epi16(xmm1[4], xmm1[5]);
 
-		xmm0[3] = _mm_unpacklo_epi16(xmm1[6], xmm1[7]);
-		xmm0[7] = _mm_unpackhi_epi16(xmm1[6], xmm1[7]);
+    xmm0[3] = _mm_unpacklo_epi16(xmm1[6], xmm1[7]);
+    xmm0[7] = _mm_unpackhi_epi16(xmm1[6], xmm1[7]);
 
-		/* Unshuffle 4-byte dwords */
-		xmm1[0] = _mm_unpacklo_epi32(xmm0[0], xmm0[1]);
-		xmm1[4] = _mm_unpackhi_epi32(xmm0[0], xmm0[1]);
+    /* Unshuffle 4-byte dwords */
+    xmm1[0] = _mm_unpacklo_epi32(xmm0[0], xmm0[1]);
+    xmm1[4] = _mm_unpackhi_epi32(xmm0[0], xmm0[1]);
 
-		xmm1[1] = _mm_unpacklo_epi32(xmm0[2], xmm0[3]);
-		xmm1[5] = _mm_unpackhi_epi32(xmm0[2], xmm0[3]);
+    xmm1[1] = _mm_unpacklo_epi32(xmm0[2], xmm0[3]);
+    xmm1[5] = _mm_unpackhi_epi32(xmm0[2], xmm0[3]);
 
-		xmm1[2] = _mm_unpacklo_epi32(xmm0[4], xmm0[5]);
-		xmm1[6] = _mm_unpackhi_epi32(xmm0[4], xmm0[5]);
+    xmm1[2] = _mm_unpacklo_epi32(xmm0[4], xmm0[5]);
+    xmm1[6] = _mm_unpackhi_epi32(xmm0[4], xmm0[5]);
 
-		xmm1[3] = _mm_unpacklo_epi32(xmm0[6], xmm0[7]);
-		xmm1[7] = _mm_unpackhi_epi32(xmm0[6], xmm0[7]);
+    xmm1[3] = _mm_unpacklo_epi32(xmm0[6], xmm0[7]);
+    xmm1[7] = _mm_unpackhi_epi32(xmm0[6], xmm0[7]);
 
-		/* Store the result vectors in proper order */
-		((__m128i *)dest)[j + 0] = xmm1[0];
-		((__m128i *)dest)[j + 1] = xmm1[4];
-		((__m128i *)dest)[j + 2] = xmm1[2];
-		((__m128i *)dest)[j + 3] = xmm1[6];
-		((__m128i *)dest)[j + 4] = xmm1[1];
-		((__m128i *)dest)[j + 5] = xmm1[5];
-		((__m128i *)dest)[j + 6] = xmm1[3];
-		((__m128i *)dest)[j + 7] = xmm1[7];
-	}
+    /* Store the result vectors in proper order */
+    ((__m128i *)dest)[j + 0] = xmm1[0];
+    ((__m128i *)dest)[j + 1] = xmm1[4];
+    ((__m128i *)dest)[j + 2] = xmm1[2];
+    ((__m128i *)dest)[j + 3] = xmm1[6];
+    ((__m128i *)dest)[j + 4] = xmm1[1];
+    ((__m128i *)dest)[j + 5] = xmm1[5];
+    ((__m128i *)dest)[j + 6] = xmm1[3];
+    ((__m128i *)dest)[j + 7] = xmm1[7];
+  }
 }
 
 
@@ -776,148 +776,148 @@ unshuffle8(uint8_t* dest, const uint8_t* orig, size_t size)
 static void
 unshuffle16(uint8_t* dest, const uint8_t* orig, size_t size)
 {
-	size_t i, j;
-	const size_t numof16belem = size / (16 * sizeof(__m128i));
+  size_t i, j;
+  const size_t numof16belem = size / (16 * sizeof(__m128i));
 
-	for (i = 0, j = 0; i < numof16belem; i++, j += 16) {
-		__m128i xmm1[16], xmm2[16];
+  for (i = 0, j = 0; i < numof16belem; i++, j += 16) {
+    __m128i xmm1[16], xmm2[16];
 
-		/* Load the first 128 bytes in 16 XMM registers */
-		xmm1[0] = ((__m128i *)orig)[0 * numof16belem + i];
-		xmm1[1] = ((__m128i *)orig)[1 * numof16belem + i];
-		xmm1[2] = ((__m128i *)orig)[2 * numof16belem + i];
-		xmm1[3] = ((__m128i *)orig)[3 * numof16belem + i];
-		xmm1[4] = ((__m128i *)orig)[4 * numof16belem + i];
-		xmm1[5] = ((__m128i *)orig)[5 * numof16belem + i];
-		xmm1[6] = ((__m128i *)orig)[6 * numof16belem + i];
-		xmm1[7] = ((__m128i *)orig)[7 * numof16belem + i];
-		xmm1[8] = ((__m128i *)orig)[8 * numof16belem + i];
-		xmm1[9] = ((__m128i *)orig)[9 * numof16belem + i];
-		xmm1[10] = ((__m128i *)orig)[10 * numof16belem + i];
-		xmm1[11] = ((__m128i *)orig)[11 * numof16belem + i];
-		xmm1[12] = ((__m128i *)orig)[12 * numof16belem + i];
-		xmm1[13] = ((__m128i *)orig)[13 * numof16belem + i];
-		xmm1[14] = ((__m128i *)orig)[14 * numof16belem + i];
-		xmm1[15] = ((__m128i *)orig)[15 * numof16belem + i];
+    /* Load the first 128 bytes in 16 XMM registers */
+    xmm1[0] = ((__m128i *)orig)[0 * numof16belem + i];
+    xmm1[1] = ((__m128i *)orig)[1 * numof16belem + i];
+    xmm1[2] = ((__m128i *)orig)[2 * numof16belem + i];
+    xmm1[3] = ((__m128i *)orig)[3 * numof16belem + i];
+    xmm1[4] = ((__m128i *)orig)[4 * numof16belem + i];
+    xmm1[5] = ((__m128i *)orig)[5 * numof16belem + i];
+    xmm1[6] = ((__m128i *)orig)[6 * numof16belem + i];
+    xmm1[7] = ((__m128i *)orig)[7 * numof16belem + i];
+    xmm1[8] = ((__m128i *)orig)[8 * numof16belem + i];
+    xmm1[9] = ((__m128i *)orig)[9 * numof16belem + i];
+    xmm1[10] = ((__m128i *)orig)[10 * numof16belem + i];
+    xmm1[11] = ((__m128i *)orig)[11 * numof16belem + i];
+    xmm1[12] = ((__m128i *)orig)[12 * numof16belem + i];
+    xmm1[13] = ((__m128i *)orig)[13 * numof16belem + i];
+    xmm1[14] = ((__m128i *)orig)[14 * numof16belem + i];
+    xmm1[15] = ((__m128i *)orig)[15 * numof16belem + i];
 
-		/* Unshuffle bytes */
-		xmm2[0] = _mm_unpacklo_epi8(xmm1[0], xmm1[1]);
-		xmm2[8] = _mm_unpackhi_epi8(xmm1[0], xmm1[1]);
+    /* Unshuffle bytes */
+    xmm2[0] = _mm_unpacklo_epi8(xmm1[0], xmm1[1]);
+    xmm2[8] = _mm_unpackhi_epi8(xmm1[0], xmm1[1]);
 
-		xmm2[1] = _mm_unpacklo_epi8(xmm1[2], xmm1[3]);
-		xmm2[9] = _mm_unpackhi_epi8(xmm1[2], xmm1[3]);
+    xmm2[1] = _mm_unpacklo_epi8(xmm1[2], xmm1[3]);
+    xmm2[9] = _mm_unpackhi_epi8(xmm1[2], xmm1[3]);
 
-		xmm2[2] = _mm_unpacklo_epi8(xmm1[4], xmm1[5]);
-		xmm2[10] = _mm_unpackhi_epi8(xmm1[4], xmm1[5]);
+    xmm2[2] = _mm_unpacklo_epi8(xmm1[4], xmm1[5]);
+    xmm2[10] = _mm_unpackhi_epi8(xmm1[4], xmm1[5]);
 
-		xmm2[3] = _mm_unpacklo_epi8(xmm1[6], xmm1[7]);
-		xmm2[11] = _mm_unpackhi_epi8(xmm1[6], xmm1[7]);
+    xmm2[3] = _mm_unpacklo_epi8(xmm1[6], xmm1[7]);
+    xmm2[11] = _mm_unpackhi_epi8(xmm1[6], xmm1[7]);
 
-		xmm2[4] = _mm_unpacklo_epi8(xmm1[8], xmm1[9]);
-		xmm2[12] = _mm_unpackhi_epi8(xmm1[8], xmm1[9]);
+    xmm2[4] = _mm_unpacklo_epi8(xmm1[8], xmm1[9]);
+    xmm2[12] = _mm_unpackhi_epi8(xmm1[8], xmm1[9]);
 
-		xmm2[5] = _mm_unpacklo_epi8(xmm1[10], xmm1[11]);
-		xmm2[13] = _mm_unpackhi_epi8(xmm1[10], xmm1[11]);
+    xmm2[5] = _mm_unpacklo_epi8(xmm1[10], xmm1[11]);
+    xmm2[13] = _mm_unpackhi_epi8(xmm1[10], xmm1[11]);
 
-		xmm2[6] = _mm_unpacklo_epi8(xmm1[12], xmm1[13]);
-		xmm2[14] = _mm_unpackhi_epi8(xmm1[12], xmm1[13]);
+    xmm2[6] = _mm_unpacklo_epi8(xmm1[12], xmm1[13]);
+    xmm2[14] = _mm_unpackhi_epi8(xmm1[12], xmm1[13]);
 
-		xmm2[7] = _mm_unpacklo_epi8(xmm1[14], xmm1[15]);
-		xmm2[15] = _mm_unpackhi_epi8(xmm1[14], xmm1[15]);
+    xmm2[7] = _mm_unpacklo_epi8(xmm1[14], xmm1[15]);
+    xmm2[15] = _mm_unpackhi_epi8(xmm1[14], xmm1[15]);
 
-		/* Unshuffle 2-byte words */
-		xmm1[0] = _mm_unpacklo_epi16(xmm2[0], xmm2[1]);
-		xmm1[8] = _mm_unpackhi_epi16(xmm2[0], xmm2[1]);
+    /* Unshuffle 2-byte words */
+    xmm1[0] = _mm_unpacklo_epi16(xmm2[0], xmm2[1]);
+    xmm1[8] = _mm_unpackhi_epi16(xmm2[0], xmm2[1]);
 
-		xmm1[1] = _mm_unpacklo_epi16(xmm2[2], xmm2[3]);
-		xmm1[9] = _mm_unpackhi_epi16(xmm2[2], xmm2[3]);
+    xmm1[1] = _mm_unpacklo_epi16(xmm2[2], xmm2[3]);
+    xmm1[9] = _mm_unpackhi_epi16(xmm2[2], xmm2[3]);
 
-		xmm1[2] = _mm_unpacklo_epi16(xmm2[4], xmm2[5]);
-		xmm1[10] = _mm_unpackhi_epi16(xmm2[4], xmm2[5]);
+    xmm1[2] = _mm_unpacklo_epi16(xmm2[4], xmm2[5]);
+    xmm1[10] = _mm_unpackhi_epi16(xmm2[4], xmm2[5]);
 
-		xmm1[3] = _mm_unpacklo_epi16(xmm2[6], xmm2[7]);
-		xmm1[11] = _mm_unpackhi_epi16(xmm2[6], xmm2[7]);
+    xmm1[3] = _mm_unpacklo_epi16(xmm2[6], xmm2[7]);
+    xmm1[11] = _mm_unpackhi_epi16(xmm2[6], xmm2[7]);
 
-		xmm1[4] = _mm_unpacklo_epi16(xmm2[8], xmm2[9]);
-		xmm1[12] = _mm_unpackhi_epi16(xmm2[8], xmm2[9]);
+    xmm1[4] = _mm_unpacklo_epi16(xmm2[8], xmm2[9]);
+    xmm1[12] = _mm_unpackhi_epi16(xmm2[8], xmm2[9]);
 
-		xmm1[5] = _mm_unpacklo_epi16(xmm2[10], xmm2[11]);
-		xmm1[13] = _mm_unpackhi_epi16(xmm2[10], xmm2[11]);
+    xmm1[5] = _mm_unpacklo_epi16(xmm2[10], xmm2[11]);
+    xmm1[13] = _mm_unpackhi_epi16(xmm2[10], xmm2[11]);
 
-		xmm1[6] = _mm_unpacklo_epi16(xmm2[12], xmm2[13]);
-		xmm1[14] = _mm_unpackhi_epi16(xmm2[12], xmm2[13]);
+    xmm1[6] = _mm_unpacklo_epi16(xmm2[12], xmm2[13]);
+    xmm1[14] = _mm_unpackhi_epi16(xmm2[12], xmm2[13]);
 
-		xmm1[7] = _mm_unpacklo_epi16(xmm2[14], xmm2[15]);
-		xmm1[15] = _mm_unpackhi_epi16(xmm2[14], xmm2[15]);
+    xmm1[7] = _mm_unpacklo_epi16(xmm2[14], xmm2[15]);
+    xmm1[15] = _mm_unpackhi_epi16(xmm2[14], xmm2[15]);
 
-		/* Unshuffle 4-byte dwords */
-		xmm2[0] = _mm_unpacklo_epi32(xmm1[0], xmm1[1]);
-		xmm2[8] = _mm_unpackhi_epi32(xmm1[0], xmm1[1]);
+    /* Unshuffle 4-byte dwords */
+    xmm2[0] = _mm_unpacklo_epi32(xmm1[0], xmm1[1]);
+    xmm2[8] = _mm_unpackhi_epi32(xmm1[0], xmm1[1]);
 
-		xmm2[1] = _mm_unpacklo_epi32(xmm1[2], xmm1[3]);
-		xmm2[9] = _mm_unpackhi_epi32(xmm1[2], xmm1[3]);
+    xmm2[1] = _mm_unpacklo_epi32(xmm1[2], xmm1[3]);
+    xmm2[9] = _mm_unpackhi_epi32(xmm1[2], xmm1[3]);
 
-		xmm2[2] = _mm_unpacklo_epi32(xmm1[4], xmm1[5]);
-		xmm2[10] = _mm_unpackhi_epi32(xmm1[4], xmm1[5]);
+    xmm2[2] = _mm_unpacklo_epi32(xmm1[4], xmm1[5]);
+    xmm2[10] = _mm_unpackhi_epi32(xmm1[4], xmm1[5]);
 
-		xmm2[3] = _mm_unpacklo_epi32(xmm1[6], xmm1[7]);
-		xmm2[11] = _mm_unpackhi_epi32(xmm1[6], xmm1[7]);
+    xmm2[3] = _mm_unpacklo_epi32(xmm1[6], xmm1[7]);
+    xmm2[11] = _mm_unpackhi_epi32(xmm1[6], xmm1[7]);
 
-		xmm2[4] = _mm_unpacklo_epi32(xmm1[8], xmm1[9]);
-		xmm2[12] = _mm_unpackhi_epi32(xmm1[8], xmm1[9]);
+    xmm2[4] = _mm_unpacklo_epi32(xmm1[8], xmm1[9]);
+    xmm2[12] = _mm_unpackhi_epi32(xmm1[8], xmm1[9]);
 
-		xmm2[5] = _mm_unpacklo_epi32(xmm1[10], xmm1[11]);
-		xmm2[13] = _mm_unpackhi_epi32(xmm1[10], xmm1[11]);
+    xmm2[5] = _mm_unpacklo_epi32(xmm1[10], xmm1[11]);
+    xmm2[13] = _mm_unpackhi_epi32(xmm1[10], xmm1[11]);
 
-		xmm2[6] = _mm_unpacklo_epi32(xmm1[12], xmm1[13]);
-		xmm2[14] = _mm_unpackhi_epi32(xmm1[12], xmm1[13]);
+    xmm2[6] = _mm_unpacklo_epi32(xmm1[12], xmm1[13]);
+    xmm2[14] = _mm_unpackhi_epi32(xmm1[12], xmm1[13]);
 
-		xmm2[7] = _mm_unpacklo_epi32(xmm1[14], xmm1[15]);
-		xmm2[15] = _mm_unpackhi_epi32(xmm1[14], xmm1[15]);
+    xmm2[7] = _mm_unpacklo_epi32(xmm1[14], xmm1[15]);
+    xmm2[15] = _mm_unpackhi_epi32(xmm1[14], xmm1[15]);
 
-		/* Unshuffle 8-byte qwords */
-		xmm1[0] = _mm_unpacklo_epi64(xmm2[0], xmm2[1]);
-		xmm1[8] = _mm_unpackhi_epi64(xmm2[0], xmm2[1]);
+    /* Unshuffle 8-byte qwords */
+    xmm1[0] = _mm_unpacklo_epi64(xmm2[0], xmm2[1]);
+    xmm1[8] = _mm_unpackhi_epi64(xmm2[0], xmm2[1]);
 
-		xmm1[1] = _mm_unpacklo_epi64(xmm2[2], xmm2[3]);
-		xmm1[9] = _mm_unpackhi_epi64(xmm2[2], xmm2[3]);
+    xmm1[1] = _mm_unpacklo_epi64(xmm2[2], xmm2[3]);
+    xmm1[9] = _mm_unpackhi_epi64(xmm2[2], xmm2[3]);
 
-		xmm1[2] = _mm_unpacklo_epi64(xmm2[4], xmm2[5]);
-		xmm1[10] = _mm_unpackhi_epi64(xmm2[4], xmm2[5]);
+    xmm1[2] = _mm_unpacklo_epi64(xmm2[4], xmm2[5]);
+    xmm1[10] = _mm_unpackhi_epi64(xmm2[4], xmm2[5]);
 
-		xmm1[3] = _mm_unpacklo_epi64(xmm2[6], xmm2[7]);
-		xmm1[11] = _mm_unpackhi_epi64(xmm2[6], xmm2[7]);
+    xmm1[3] = _mm_unpacklo_epi64(xmm2[6], xmm2[7]);
+    xmm1[11] = _mm_unpackhi_epi64(xmm2[6], xmm2[7]);
 
-		xmm1[4] = _mm_unpacklo_epi64(xmm2[8], xmm2[9]);
-		xmm1[12] = _mm_unpackhi_epi64(xmm2[8], xmm2[9]);
+    xmm1[4] = _mm_unpacklo_epi64(xmm2[8], xmm2[9]);
+    xmm1[12] = _mm_unpackhi_epi64(xmm2[8], xmm2[9]);
 
-		xmm1[5] = _mm_unpacklo_epi64(xmm2[10], xmm2[11]);
-		xmm1[13] = _mm_unpackhi_epi64(xmm2[10], xmm2[11]);
+    xmm1[5] = _mm_unpacklo_epi64(xmm2[10], xmm2[11]);
+    xmm1[13] = _mm_unpackhi_epi64(xmm2[10], xmm2[11]);
 
-		xmm1[6] = _mm_unpacklo_epi64(xmm2[12], xmm2[13]);
-		xmm1[14] = _mm_unpackhi_epi64(xmm2[12], xmm2[13]);
+    xmm1[6] = _mm_unpacklo_epi64(xmm2[12], xmm2[13]);
+    xmm1[14] = _mm_unpackhi_epi64(xmm2[12], xmm2[13]);
 
-		xmm1[7] = _mm_unpacklo_epi64(xmm2[14], xmm2[15]);
-		xmm1[15] = _mm_unpackhi_epi64(xmm2[14], xmm2[15]);
+    xmm1[7] = _mm_unpacklo_epi64(xmm2[14], xmm2[15]);
+    xmm1[15] = _mm_unpackhi_epi64(xmm2[14], xmm2[15]);
 
-		/* Store the result vectors in proper order */
-		((__m128i *)dest)[j + 0] = xmm1[0];
-		((__m128i *)dest)[j + 1] = xmm1[8];
-		((__m128i *)dest)[j + 2] = xmm1[4];
-		((__m128i *)dest)[j + 3] = xmm1[12];
-		((__m128i *)dest)[j + 4] = xmm1[2];
-		((__m128i *)dest)[j + 5] = xmm1[10];
-		((__m128i *)dest)[j + 6] = xmm1[6];
-		((__m128i *)dest)[j + 7] = xmm1[14];
-		((__m128i *)dest)[j + 8] = xmm1[1];
-		((__m128i *)dest)[j + 9] = xmm1[9];
-		((__m128i *)dest)[j + 10] = xmm1[5];
-		((__m128i *)dest)[j + 11] = xmm1[13];
-		((__m128i *)dest)[j + 12] = xmm1[3];
-		((__m128i *)dest)[j + 13] = xmm1[11];
-		((__m128i *)dest)[j + 14] = xmm1[7];
-		((__m128i *)dest)[j + 15] = xmm1[15];
-	}
+    /* Store the result vectors in proper order */
+    ((__m128i *)dest)[j + 0] = xmm1[0];
+    ((__m128i *)dest)[j + 1] = xmm1[8];
+    ((__m128i *)dest)[j + 2] = xmm1[4];
+    ((__m128i *)dest)[j + 3] = xmm1[12];
+    ((__m128i *)dest)[j + 4] = xmm1[2];
+    ((__m128i *)dest)[j + 5] = xmm1[10];
+    ((__m128i *)dest)[j + 6] = xmm1[6];
+    ((__m128i *)dest)[j + 7] = xmm1[14];
+    ((__m128i *)dest)[j + 8] = xmm1[1];
+    ((__m128i *)dest)[j + 9] = xmm1[9];
+    ((__m128i *)dest)[j + 10] = xmm1[5];
+    ((__m128i *)dest)[j + 11] = xmm1[13];
+    ((__m128i *)dest)[j + 12] = xmm1[3];
+    ((__m128i *)dest)[j + 13] = xmm1[11];
+    ((__m128i *)dest)[j + 14] = xmm1[7];
+    ((__m128i *)dest)[j + 15] = xmm1[15];
+  }
 }
 
 
@@ -925,213 +925,213 @@ unshuffle16(uint8_t* dest, const uint8_t* orig, size_t size)
 static void
 unshuffle_multipart(uint8_t* dest, const uint8_t* orig, size_t size, size_t bytesoftype)
 {
-	const size_t num_elements = size / bytesoftype;
-	const lldiv_t vecs_per_el = lldiv(bytesoftype, sizeof(__m128i));
+  const size_t num_elements = size / bytesoftype;
+  const lldiv_t vecs_per_el = lldiv(bytesoftype, sizeof(__m128i));
 
-	/* The unshuffle loops are inverted (compared to shuffle_multipart)
-		 to optimize cache utilization. */
-	size_t offset_into_type;
-	for (offset_into_type = 0; offset_into_type < bytesoftype;
-		offset_into_type += (offset_into_type == 0 && vecs_per_el.rem > 0 ? vecs_per_el.rem : sizeof(__m128i))) {
-		size_t j;
-		for (j = 0; j < num_elements; j += sizeof(__m128i)) {
-			__m128i xmm1[16], xmm2[16];
+  /* The unshuffle loops are inverted (compared to shuffle_multipart)
+  to optimize cache utilization. */
+  size_t offset_into_type;
+  for (offset_into_type = 0; offset_into_type < bytesoftype;
+    offset_into_type += (offset_into_type == 0 && vecs_per_el.rem > 0 ? vecs_per_el.rem : sizeof(__m128i))) {
+    size_t j;
+    for (j = 0; j < num_elements; j += sizeof(__m128i)) {
+      __m128i xmm1[16], xmm2[16];
 
-			/* Load the first 128 bytes in 16 XMM registers */
-			uint8_t* const src_for_jth_element = orig + j;
-			xmm1[0] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 0))));
-			xmm1[1] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 1))));
-			xmm1[2] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 2))));
-			xmm1[3] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 3))));
-			xmm1[4] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 4))));
-			xmm1[5] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 5))));
-			xmm1[6] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 6))));
-			xmm1[7] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 7))));
-			xmm1[8] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 8))));
-			xmm1[9] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 9))));
-			xmm1[10] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 10))));
-			xmm1[11] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 11))));
-			xmm1[12] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 12))));
-			xmm1[13] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 13))));
-			xmm1[14] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 14))));
-			xmm1[15] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 15))));
+      /* Load the first 128 bytes in 16 XMM registers */
+      uint8_t* const src_for_jth_element = orig + j;
+      xmm1[0] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 0))));
+      xmm1[1] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 1))));
+      xmm1[2] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 2))));
+      xmm1[3] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 3))));
+      xmm1[4] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 4))));
+      xmm1[5] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 5))));
+      xmm1[6] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 6))));
+      xmm1[7] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 7))));
+      xmm1[8] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 8))));
+      xmm1[9] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 9))));
+      xmm1[10] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 10))));
+      xmm1[11] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 11))));
+      xmm1[12] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 12))));
+      xmm1[13] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 13))));
+      xmm1[14] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 14))));
+      xmm1[15] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 15))));
 
-			/* Unshuffle bytes */
-			xmm2[0] = _mm_unpacklo_epi8(xmm1[0], xmm1[1]);
-			xmm2[8] = _mm_unpackhi_epi8(xmm1[0], xmm1[1]);
+      /* Unshuffle bytes */
+      xmm2[0] = _mm_unpacklo_epi8(xmm1[0], xmm1[1]);
+      xmm2[8] = _mm_unpackhi_epi8(xmm1[0], xmm1[1]);
 
-			xmm2[1] = _mm_unpacklo_epi8(xmm1[2], xmm1[3]);
-			xmm2[9] = _mm_unpackhi_epi8(xmm1[2], xmm1[3]);
+      xmm2[1] = _mm_unpacklo_epi8(xmm1[2], xmm1[3]);
+      xmm2[9] = _mm_unpackhi_epi8(xmm1[2], xmm1[3]);
 
-			xmm2[2] = _mm_unpacklo_epi8(xmm1[4], xmm1[5]);
-			xmm2[10] = _mm_unpackhi_epi8(xmm1[4], xmm1[5]);
+      xmm2[2] = _mm_unpacklo_epi8(xmm1[4], xmm1[5]);
+      xmm2[10] = _mm_unpackhi_epi8(xmm1[4], xmm1[5]);
 
-			xmm2[3] = _mm_unpacklo_epi8(xmm1[6], xmm1[7]);
-			xmm2[11] = _mm_unpackhi_epi8(xmm1[6], xmm1[7]);
+      xmm2[3] = _mm_unpacklo_epi8(xmm1[6], xmm1[7]);
+      xmm2[11] = _mm_unpackhi_epi8(xmm1[6], xmm1[7]);
 
-			xmm2[4] = _mm_unpacklo_epi8(xmm1[8], xmm1[9]);
-			xmm2[12] = _mm_unpackhi_epi8(xmm1[8], xmm1[9]);
+      xmm2[4] = _mm_unpacklo_epi8(xmm1[8], xmm1[9]);
+      xmm2[12] = _mm_unpackhi_epi8(xmm1[8], xmm1[9]);
 
-			xmm2[5] = _mm_unpacklo_epi8(xmm1[10], xmm1[11]);
-			xmm2[13] = _mm_unpackhi_epi8(xmm1[10], xmm1[11]);
+      xmm2[5] = _mm_unpacklo_epi8(xmm1[10], xmm1[11]);
+      xmm2[13] = _mm_unpackhi_epi8(xmm1[10], xmm1[11]);
 
-			xmm2[6] = _mm_unpacklo_epi8(xmm1[12], xmm1[13]);
-			xmm2[14] = _mm_unpackhi_epi8(xmm1[12], xmm1[13]);
+      xmm2[6] = _mm_unpacklo_epi8(xmm1[12], xmm1[13]);
+      xmm2[14] = _mm_unpackhi_epi8(xmm1[12], xmm1[13]);
 
-			xmm2[7] = _mm_unpacklo_epi8(xmm1[14], xmm1[15]);
-			xmm2[15] = _mm_unpackhi_epi8(xmm1[14], xmm1[15]);
+      xmm2[7] = _mm_unpacklo_epi8(xmm1[14], xmm1[15]);
+      xmm2[15] = _mm_unpackhi_epi8(xmm1[14], xmm1[15]);
 
-			/* Unshuffle 2-byte words */
-			xmm1[0] = _mm_unpacklo_epi16(xmm2[0], xmm2[1]);
-			xmm1[8] = _mm_unpackhi_epi16(xmm2[0], xmm2[1]);
+      /* Unshuffle 2-byte words */
+      xmm1[0] = _mm_unpacklo_epi16(xmm2[0], xmm2[1]);
+      xmm1[8] = _mm_unpackhi_epi16(xmm2[0], xmm2[1]);
 
-			xmm1[1] = _mm_unpacklo_epi16(xmm2[2], xmm2[3]);
-			xmm1[9] = _mm_unpackhi_epi16(xmm2[2], xmm2[3]);
+      xmm1[1] = _mm_unpacklo_epi16(xmm2[2], xmm2[3]);
+      xmm1[9] = _mm_unpackhi_epi16(xmm2[2], xmm2[3]);
 
-			xmm1[2] = _mm_unpacklo_epi16(xmm2[4], xmm2[5]);
-			xmm1[10] = _mm_unpackhi_epi16(xmm2[4], xmm2[5]);
+      xmm1[2] = _mm_unpacklo_epi16(xmm2[4], xmm2[5]);
+      xmm1[10] = _mm_unpackhi_epi16(xmm2[4], xmm2[5]);
 
-			xmm1[3] = _mm_unpacklo_epi16(xmm2[6], xmm2[7]);
-			xmm1[11] = _mm_unpackhi_epi16(xmm2[6], xmm2[7]);
+      xmm1[3] = _mm_unpacklo_epi16(xmm2[6], xmm2[7]);
+      xmm1[11] = _mm_unpackhi_epi16(xmm2[6], xmm2[7]);
 
-			xmm1[4] = _mm_unpacklo_epi16(xmm2[8], xmm2[9]);
-			xmm1[12] = _mm_unpackhi_epi16(xmm2[8], xmm2[9]);
+      xmm1[4] = _mm_unpacklo_epi16(xmm2[8], xmm2[9]);
+      xmm1[12] = _mm_unpackhi_epi16(xmm2[8], xmm2[9]);
 
-			xmm1[5] = _mm_unpacklo_epi16(xmm2[10], xmm2[11]);
-			xmm1[13] = _mm_unpackhi_epi16(xmm2[10], xmm2[11]);
+      xmm1[5] = _mm_unpacklo_epi16(xmm2[10], xmm2[11]);
+      xmm1[13] = _mm_unpackhi_epi16(xmm2[10], xmm2[11]);
 
-			xmm1[6] = _mm_unpacklo_epi16(xmm2[12], xmm2[13]);
-			xmm1[14] = _mm_unpackhi_epi16(xmm2[12], xmm2[13]);
+      xmm1[6] = _mm_unpacklo_epi16(xmm2[12], xmm2[13]);
+      xmm1[14] = _mm_unpackhi_epi16(xmm2[12], xmm2[13]);
 
-			xmm1[7] = _mm_unpacklo_epi16(xmm2[14], xmm2[15]);
-			xmm1[15] = _mm_unpackhi_epi16(xmm2[14], xmm2[15]);
+      xmm1[7] = _mm_unpacklo_epi16(xmm2[14], xmm2[15]);
+      xmm1[15] = _mm_unpackhi_epi16(xmm2[14], xmm2[15]);
 
-			/* Unshuffle 4-byte dwords */
-			xmm2[0] = _mm_unpacklo_epi32(xmm1[0], xmm1[1]);
-			xmm2[8] = _mm_unpackhi_epi32(xmm1[0], xmm1[1]);
+      /* Unshuffle 4-byte dwords */
+      xmm2[0] = _mm_unpacklo_epi32(xmm1[0], xmm1[1]);
+      xmm2[8] = _mm_unpackhi_epi32(xmm1[0], xmm1[1]);
 
-			xmm2[1] = _mm_unpacklo_epi32(xmm1[2], xmm1[3]);
-			xmm2[9] = _mm_unpackhi_epi32(xmm1[2], xmm1[3]);
+      xmm2[1] = _mm_unpacklo_epi32(xmm1[2], xmm1[3]);
+      xmm2[9] = _mm_unpackhi_epi32(xmm1[2], xmm1[3]);
 
-			xmm2[2] = _mm_unpacklo_epi32(xmm1[4], xmm1[5]);
-			xmm2[10] = _mm_unpackhi_epi32(xmm1[4], xmm1[5]);
+      xmm2[2] = _mm_unpacklo_epi32(xmm1[4], xmm1[5]);
+      xmm2[10] = _mm_unpackhi_epi32(xmm1[4], xmm1[5]);
 
-			xmm2[3] = _mm_unpacklo_epi32(xmm1[6], xmm1[7]);
-			xmm2[11] = _mm_unpackhi_epi32(xmm1[6], xmm1[7]);
+      xmm2[3] = _mm_unpacklo_epi32(xmm1[6], xmm1[7]);
+      xmm2[11] = _mm_unpackhi_epi32(xmm1[6], xmm1[7]);
 
-			xmm2[4] = _mm_unpacklo_epi32(xmm1[8], xmm1[9]);
-			xmm2[12] = _mm_unpackhi_epi32(xmm1[8], xmm1[9]);
+      xmm2[4] = _mm_unpacklo_epi32(xmm1[8], xmm1[9]);
+      xmm2[12] = _mm_unpackhi_epi32(xmm1[8], xmm1[9]);
 
-			xmm2[5] = _mm_unpacklo_epi32(xmm1[10], xmm1[11]);
-			xmm2[13] = _mm_unpackhi_epi32(xmm1[10], xmm1[11]);
+      xmm2[5] = _mm_unpacklo_epi32(xmm1[10], xmm1[11]);
+      xmm2[13] = _mm_unpackhi_epi32(xmm1[10], xmm1[11]);
 
-			xmm2[6] = _mm_unpacklo_epi32(xmm1[12], xmm1[13]);
-			xmm2[14] = _mm_unpackhi_epi32(xmm1[12], xmm1[13]);
+      xmm2[6] = _mm_unpacklo_epi32(xmm1[12], xmm1[13]);
+      xmm2[14] = _mm_unpackhi_epi32(xmm1[12], xmm1[13]);
 
-			xmm2[7] = _mm_unpacklo_epi32(xmm1[14], xmm1[15]);
-			xmm2[15] = _mm_unpackhi_epi32(xmm1[14], xmm1[15]);
+      xmm2[7] = _mm_unpacklo_epi32(xmm1[14], xmm1[15]);
+      xmm2[15] = _mm_unpackhi_epi32(xmm1[14], xmm1[15]);
 
-			/* Unshuffle 8-byte qwords */
-			xmm1[0] = _mm_unpacklo_epi64(xmm2[0], xmm2[1]);
-			xmm1[8] = _mm_unpackhi_epi64(xmm2[0], xmm2[1]);
+      /* Unshuffle 8-byte qwords */
+      xmm1[0] = _mm_unpacklo_epi64(xmm2[0], xmm2[1]);
+      xmm1[8] = _mm_unpackhi_epi64(xmm2[0], xmm2[1]);
 
-			xmm1[1] = _mm_unpacklo_epi64(xmm2[2], xmm2[3]);
-			xmm1[9] = _mm_unpackhi_epi64(xmm2[2], xmm2[3]);
+      xmm1[1] = _mm_unpacklo_epi64(xmm2[2], xmm2[3]);
+      xmm1[9] = _mm_unpackhi_epi64(xmm2[2], xmm2[3]);
 
-			xmm1[2] = _mm_unpacklo_epi64(xmm2[4], xmm2[5]);
-			xmm1[10] = _mm_unpackhi_epi64(xmm2[4], xmm2[5]);
+      xmm1[2] = _mm_unpacklo_epi64(xmm2[4], xmm2[5]);
+      xmm1[10] = _mm_unpackhi_epi64(xmm2[4], xmm2[5]);
 
-			xmm1[3] = _mm_unpacklo_epi64(xmm2[6], xmm2[7]);
-			xmm1[11] = _mm_unpackhi_epi64(xmm2[6], xmm2[7]);
+      xmm1[3] = _mm_unpacklo_epi64(xmm2[6], xmm2[7]);
+      xmm1[11] = _mm_unpackhi_epi64(xmm2[6], xmm2[7]);
 
-			xmm1[4] = _mm_unpacklo_epi64(xmm2[8], xmm2[9]);
-			xmm1[12] = _mm_unpackhi_epi64(xmm2[8], xmm2[9]);
+      xmm1[4] = _mm_unpacklo_epi64(xmm2[8], xmm2[9]);
+      xmm1[12] = _mm_unpackhi_epi64(xmm2[8], xmm2[9]);
 
-			xmm1[5] = _mm_unpacklo_epi64(xmm2[10], xmm2[11]);
-			xmm1[13] = _mm_unpackhi_epi64(xmm2[10], xmm2[11]);
+      xmm1[5] = _mm_unpacklo_epi64(xmm2[10], xmm2[11]);
+      xmm1[13] = _mm_unpackhi_epi64(xmm2[10], xmm2[11]);
 
-			xmm1[6] = _mm_unpacklo_epi64(xmm2[12], xmm2[13]);
-			xmm1[14] = _mm_unpackhi_epi64(xmm2[12], xmm2[13]);
+      xmm1[6] = _mm_unpacklo_epi64(xmm2[12], xmm2[13]);
+      xmm1[14] = _mm_unpackhi_epi64(xmm2[12], xmm2[13]);
 
-			xmm1[7] = _mm_unpacklo_epi64(xmm2[14], xmm2[15]);
-			xmm1[15] = _mm_unpackhi_epi64(xmm2[14], xmm2[15]);
+      xmm1[7] = _mm_unpacklo_epi64(xmm2[14], xmm2[15]);
+      xmm1[15] = _mm_unpackhi_epi64(xmm2[14], xmm2[15]);
 
-			/* Store the result vectors in proper order */
-			const uint8_t* const dest_with_offset = dest + offset_into_type;
-			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 0) * bytesoftype), xmm1[0]);
-			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 1) * bytesoftype), xmm1[8]);
-			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 2) * bytesoftype), xmm1[4]);
-			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 3) * bytesoftype), xmm1[12]);
-			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 4) * bytesoftype), xmm1[2]);
-			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 5) * bytesoftype), xmm1[10]);
-			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 6) * bytesoftype), xmm1[6]);
-			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 7) * bytesoftype), xmm1[14]);
-			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 8) * bytesoftype), xmm1[1]);
-			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 9) * bytesoftype), xmm1[9]);
-			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 10) * bytesoftype), xmm1[5]);
-			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 11) * bytesoftype), xmm1[13]);
-			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 12) * bytesoftype), xmm1[3]);
-			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 13) * bytesoftype), xmm1[11]);
-			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 14) * bytesoftype), xmm1[7]);
-			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 15) * bytesoftype), xmm1[15]);
-		}
-	}
+      /* Store the result vectors in proper order */
+      const uint8_t* const dest_with_offset = dest + offset_into_type;
+      _mm_storeu_si128((__m128i*)(dest_with_offset + (j + 0) * bytesoftype), xmm1[0]);
+      _mm_storeu_si128((__m128i*)(dest_with_offset + (j + 1) * bytesoftype), xmm1[8]);
+      _mm_storeu_si128((__m128i*)(dest_with_offset + (j + 2) * bytesoftype), xmm1[4]);
+      _mm_storeu_si128((__m128i*)(dest_with_offset + (j + 3) * bytesoftype), xmm1[12]);
+      _mm_storeu_si128((__m128i*)(dest_with_offset + (j + 4) * bytesoftype), xmm1[2]);
+      _mm_storeu_si128((__m128i*)(dest_with_offset + (j + 5) * bytesoftype), xmm1[10]);
+      _mm_storeu_si128((__m128i*)(dest_with_offset + (j + 6) * bytesoftype), xmm1[6]);
+      _mm_storeu_si128((__m128i*)(dest_with_offset + (j + 7) * bytesoftype), xmm1[14]);
+      _mm_storeu_si128((__m128i*)(dest_with_offset + (j + 8) * bytesoftype), xmm1[1]);
+      _mm_storeu_si128((__m128i*)(dest_with_offset + (j + 9) * bytesoftype), xmm1[9]);
+      _mm_storeu_si128((__m128i*)(dest_with_offset + (j + 10) * bytesoftype), xmm1[5]);
+      _mm_storeu_si128((__m128i*)(dest_with_offset + (j + 11) * bytesoftype), xmm1[13]);
+      _mm_storeu_si128((__m128i*)(dest_with_offset + (j + 12) * bytesoftype), xmm1[3]);
+      _mm_storeu_si128((__m128i*)(dest_with_offset + (j + 13) * bytesoftype), xmm1[11]);
+      _mm_storeu_si128((__m128i*)(dest_with_offset + (j + 14) * bytesoftype), xmm1[7]);
+      _mm_storeu_si128((__m128i*)(dest_with_offset + (j + 15) * bytesoftype), xmm1[15]);
+    }
+  }
 }
 
 /* Unshuffle a block.  This can never fail. */
 void unshuffle(size_t bytesoftype, size_t blocksize,
-	const uint8_t* _src, uint8_t* _dest) {
-	int unaligned_src = (int)((uintptr_t)_src % sizeof(__m128i));
-	int unaligned_dest = (int)((uintptr_t)_dest % sizeof(__m128i));
-	int multiple_of_block = (blocksize % (sizeof(__m128i) * bytesoftype)) == 0;
-	int too_small = (blocksize < 256);
+  const uint8_t* _src, uint8_t* _dest) {
+  int unaligned_src = (int)((uintptr_t)_src % sizeof(__m128i));
+  int unaligned_dest = (int)((uintptr_t)_dest % sizeof(__m128i));
+  int multiple_of_block = (blocksize % (sizeof(__m128i) * bytesoftype)) == 0;
+  int too_small = (blocksize < 256);
 
-	if (unaligned_src || unaligned_dest || !multiple_of_block || too_small) {
-		/* _src or _dest buffer is not aligned, not multiple of the vectorization
-		* size or is not too small.  Call the non-sse2 version. */
-		_unshuffle(bytesoftype, blocksize, _src, _dest);
-		return;
-	}
+  if (unaligned_src || unaligned_dest || !multiple_of_block || too_small) {
+    /* _src or _dest buffer is not aligned, not multiple of the vectorization
+    * size or is not too small.  Call the non-sse2 version. */
+    _unshuffle(bytesoftype, blocksize, _src, _dest);
+    return;
+  }
 
-	/* Optimized unshuffle */
-	/* The buffers must be aligned on a 16 bytes boundary, have a power */
-	/* of 2 size and be larger or equal than 256 bytes. */
-	switch (bytesoftype)
-	{
-	case 2:
-		unshuffle2(_dest, _src, blocksize);
-		break;
-	case 4:
-		unshuffle4(_dest, _src, blocksize);
-		break;
-	case 8:
-		unshuffle8(_dest, _src, blocksize);
-		break;
-	case 16:
-		unshuffle16(_dest, _src, blocksize);
-		break;
-	default:
-		if (bytesoftype > sizeof(__m128i)) {
-			unshuffle_multipart(_dest, _src, blocksize, bytesoftype);
-		}
-		else {
-			/* Non-optimized unshuffle */
-			_unshuffle(bytesoftype, blocksize, _src, _dest);
-		}
-		break;
-	}
+  /* Optimized unshuffle */
+  /* The buffers must be aligned on a 16 bytes boundary, have a power */
+  /* of 2 size and be larger or equal than 256 bytes. */
+  switch (bytesoftype)
+  {
+  case 2:
+    unshuffle2(_dest, _src, blocksize);
+    break;
+  case 4:
+    unshuffle4(_dest, _src, blocksize);
+    break;
+  case 8:
+    unshuffle8(_dest, _src, blocksize);
+    break;
+  case 16:
+    unshuffle16(_dest, _src, blocksize);
+    break;
+  default:
+    if (bytesoftype > sizeof(__m128i)) {
+      unshuffle_multipart(_dest, _src, blocksize, bytesoftype);
+    }
+    else {
+      /* Non-optimized unshuffle */
+      _unshuffle(bytesoftype, blocksize, _src, _dest);
+    }
+    break;
+  }
 }
 
 #else   /* no __SSE2__ available */
 
 void shuffle(size_t bytesoftype, size_t blocksize,
-	const uint8_t* _src, uint8_t* _dest) {
-	_shuffle(bytesoftype, blocksize, _src, _dest);
+  const uint8_t* _src, uint8_t* _dest) {
+  _shuffle(bytesoftype, blocksize, _src, _dest);
 }
 
 void unshuffle(size_t bytesoftype, size_t blocksize,
-	const uint8_t* _src, uint8_t* _dest) {
-	_unshuffle(bytesoftype, blocksize, _src, _dest);
+  const uint8_t* _src, uint8_t* _dest) {
+  _unshuffle(bytesoftype, blocksize, _src, _dest);
 }
 
 #endif  /* __SSE2__ */

--- a/blosc/shuffle.c
+++ b/blosc/shuffle.c
@@ -1,10 +1,10 @@
 /*********************************************************************
-  Blosc - Blocked Suffling and Compression Library
+Blosc - Blocked Suffling and Compression Library
 
-  Author: Francesc Alted <francesc@blosc.org>
-  Creation date: 2009-05-20
+Author: Francesc Alted <francesc@blosc.org>
+Creation date: 2009-05-20
 
-  See LICENSES/BLOSC.txt for details about copyright and rights to use.
+See LICENSES/BLOSC.txt for details about copyright and rights to use.
 **********************************************************************/
 
 #include <stdio.h>
@@ -12,19 +12,12 @@
 #include "shuffle.h"
 
 #if defined(_WIN32) && !defined(__MINGW32__)
-  #include <windows.h>
-  #include "win32/stdint-windows.h"
-
-  /* Define the __SSE2__ symbol if compiling with Visual C++ and
-     targeting the minimum architecture level supporting SSE2.
-     Other compilers define this as expected and emit warnings
-     when it is re-defined. */
-  #if defined(_MSC_VER) && (defined(_M_X64) || (defined(_M_IX86) && _M_IX86_FP >= 2))
-    #define __SSE2__
-  #endif
+#include <windows.h>
+#include "win32/stdint-windows.h"
+#define __SSE2__          /* Windows does not define this by default */
 #else
-  #include <stdint.h>
-  #include <inttypes.h>
+#include <stdint.h>
+#include <inttypes.h>
 #endif  /* _WIN32 */
 
 
@@ -32,36 +25,36 @@
 
 /* Shuffle a block.  This can never fail. */
 static void _shuffle(size_t bytesoftype, size_t blocksize,
-                     const uint8_t* _src, uint8_t* _dest)
+	const uint8_t* _src, uint8_t* _dest)
 {
-  size_t i, j, neblock, leftover;
+	size_t i, j, neblock, leftover;
 
-  /* Non-optimized shuffle */
-  neblock = blocksize / bytesoftype;  /* Number of elements in a block */
-  for (j = 0; j < bytesoftype; j++) {
-    for (i = 0; i < neblock; i++) {
-      _dest[j*neblock+i] = _src[i*bytesoftype+j];
-    }
-  }
-  leftover = blocksize % bytesoftype;
-  memcpy(_dest + neblock*bytesoftype, _src + neblock*bytesoftype, leftover);
+	/* Non-optimized shuffle */
+	neblock = blocksize / bytesoftype;  /* Number of elements in a block */
+	for (j = 0; j < bytesoftype; j++) {
+		for (i = 0; i < neblock; i++) {
+			_dest[j*neblock + i] = _src[i*bytesoftype + j];
+		}
+	}
+	leftover = blocksize % bytesoftype;
+	memcpy(_dest + neblock*bytesoftype, _src + neblock*bytesoftype, leftover);
 }
 
 /* Unshuffle a block.  This can never fail. */
 static void _unshuffle(size_t bytesoftype, size_t blocksize,
-                       const uint8_t* _src, uint8_t* _dest)
+	const uint8_t* _src, uint8_t* _dest)
 {
-  size_t i, j, neblock, leftover;
+	size_t i, j, neblock, leftover;
 
-  /* Non-optimized unshuffle */
-  neblock = blocksize / bytesoftype;  /* Number of elements in a block */
-  for (i = 0; i < neblock; i++) {
-    for (j = 0; j < bytesoftype; j++) {
-      _dest[i*bytesoftype+j] = _src[j*neblock+i];
-    }
-  }
-  leftover = blocksize % bytesoftype;
-  memcpy(_dest+neblock*bytesoftype, _src+neblock*bytesoftype, leftover);
+	/* Non-optimized unshuffle */
+	neblock = blocksize / bytesoftype;  /* Number of elements in a block */
+	for (i = 0; i < neblock; i++) {
+		for (j = 0; j < bytesoftype; j++) {
+			_dest[i*bytesoftype + j] = _src[j*neblock + i];
+		}
+	}
+	leftover = blocksize % bytesoftype;
+	memcpy(_dest + neblock*bytesoftype, _src + neblock*bytesoftype, leftover);
 }
 
 
@@ -71,18 +64,21 @@ static void _unshuffle(size_t bytesoftype, size_t blocksize,
 
 #include <emmintrin.h>
 
+/* The size of an SSE2 vector (XMM register), in bytes. */
+#define VECTOR_SIZE 16
+
 /* The next is useful for debugging purposes */
 #if 0
 static void printxmm(__m128i xmm0)
 {
-  uint8_t buf[16];
+	uint8_t buf[16];
 
-  ((__m128i *)buf)[0] = xmm0;
-  printf("%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x\n",
-          buf[0], buf[1], buf[2], buf[3],
-          buf[4], buf[5], buf[6], buf[7],
-          buf[8], buf[9], buf[10], buf[11],
-          buf[12], buf[13], buf[14], buf[15]);
+	((__m128i *)buf)[0] = xmm0;
+	printf("%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x\n",
+		buf[0], buf[1], buf[2], buf[3],
+		buf[4], buf[5], buf[6], buf[7],
+		buf[8], buf[9], buf[10], buf[11],
+		buf[12], buf[13], buf[14], buf[15]);
 }
 #endif
 
@@ -91,36 +87,43 @@ static void printxmm(__m128i xmm0)
 static void
 shuffle2(uint8_t* dest, const uint8_t* src, size_t size)
 {
-  size_t i, j, k;
-  size_t numof16belem;
-  __m128i xmm0[2], xmm1[2];
+	size_t i, j;
+	const size_t numof16belem = size / (2 * VECTOR_SIZE);
+	__m128i xmm0[2], xmm1[2];
 
-  numof16belem = size / (16*2);
-  for (i = 0, j = 0; i < numof16belem; i++, j += 16*2) {
-    /* Fetch and transpose bytes, words and double words in groups of
-       32 bytes */
-    for (k = 0; k < 2; k++) {
-      xmm0[k] = _mm_loadu_si128((__m128i*)(src+j+k*16));
-      xmm0[k] = _mm_shufflelo_epi16(xmm0[k], 0xd8);
-      xmm0[k] = _mm_shufflehi_epi16(xmm0[k], 0xd8);
-      xmm0[k] = _mm_shuffle_epi32(xmm0[k], 0xd8);
-      xmm1[k] = _mm_shuffle_epi32(xmm0[k], 0x4e);
-      xmm0[k] = _mm_unpacklo_epi8(xmm0[k], xmm1[k]);
-      xmm0[k] = _mm_shuffle_epi32(xmm0[k], 0xd8);
-      xmm1[k] = _mm_shuffle_epi32(xmm0[k], 0x4e);
-      xmm0[k] = _mm_unpacklo_epi16(xmm0[k], xmm1[k]);
-      xmm0[k] = _mm_shuffle_epi32(xmm0[k], 0xd8);
-    }
-    /* Transpose quad words */
-    for (k = 0; k < 1; k++) {
-      xmm1[k*2] = _mm_unpacklo_epi64(xmm0[k], xmm0[k+1]);
-      xmm1[k*2+1] = _mm_unpackhi_epi64(xmm0[k], xmm0[k+1]);
-    }
-    /* Store the result vectors */
-    for (k = 0; k < 2; k++) {
-      ((__m128i *)dest)[k*numof16belem+i] = xmm1[k];
-    }
-  }
+	for (i = 0, j = 0; i < numof16belem; i++, j += 2) {
+		/* Fetch and transpose bytes, words and double words in groups of
+		32 bytes */
+		xmm0[0] = _mm_loadu_si128((__m128i*)(src + (j + 0) * VECTOR_SIZE));
+		xmm0[0] = _mm_shufflelo_epi16(xmm0[0], 0xd8);
+		xmm0[0] = _mm_shufflehi_epi16(xmm0[0], 0xd8);
+		xmm0[0] = _mm_shuffle_epi32(xmm0[0], 0xd8);
+		xmm1[0] = _mm_shuffle_epi32(xmm0[0], 0x4e);
+		xmm0[0] = _mm_unpacklo_epi8(xmm0[0], xmm1[0]);
+		xmm0[0] = _mm_shuffle_epi32(xmm0[0], 0xd8);
+		xmm1[0] = _mm_shuffle_epi32(xmm0[0], 0x4e);
+		xmm0[0] = _mm_unpacklo_epi16(xmm0[0], xmm1[0]);
+		xmm0[0] = _mm_shuffle_epi32(xmm0[0], 0xd8);
+
+		xmm0[1] = _mm_loadu_si128((__m128i*)(src + (j + 1) * VECTOR_SIZE));
+		xmm0[1] = _mm_shufflelo_epi16(xmm0[1], 0xd8);
+		xmm0[1] = _mm_shufflehi_epi16(xmm0[1], 0xd8);
+		xmm0[1] = _mm_shuffle_epi32(xmm0[1], 0xd8);
+		xmm1[1] = _mm_shuffle_epi32(xmm0[1], 0x4e);
+		xmm0[1] = _mm_unpacklo_epi8(xmm0[1], xmm1[1]);
+		xmm0[1] = _mm_shuffle_epi32(xmm0[1], 0xd8);
+		xmm1[1] = _mm_shuffle_epi32(xmm0[1], 0x4e);
+		xmm0[1] = _mm_unpacklo_epi16(xmm0[1], xmm1[1]);
+		xmm0[1] = _mm_shuffle_epi32(xmm0[1], 0xd8);
+
+		/* Transpose quad words */
+		xmm1[0] = _mm_unpacklo_epi64(xmm0[0], xmm0[1]);
+		xmm1[1] = _mm_unpackhi_epi64(xmm0[0], xmm0[1]);
+
+		/* Store the result vectors */
+		((__m128i *)dest)[0 * numof16belem + i] = xmm1[0];
+		((__m128i *)dest)[1 * numof16belem + i] = xmm1[1];
+	}
 }
 
 
@@ -128,36 +131,60 @@ shuffle2(uint8_t* dest, const uint8_t* src, size_t size)
 static void
 shuffle4(uint8_t* dest, const uint8_t* src, size_t size)
 {
-  size_t i, j, k;
-  size_t numof16belem;
-  __m128i xmm0[4], xmm1[4];
+	size_t i, j;
+	const size_t numof16belem = size / (4 * VECTOR_SIZE);
+	__m128i xmm0[4], xmm1[4];
 
-  numof16belem = size / (16*4);
-  for (i = 0, j = 0; i < numof16belem; i++, j += 16*4) {
-    /* Fetch and transpose bytes and words in groups of 64 bytes */
-    for (k = 0; k < 4; k++) {
-      xmm0[k] = _mm_loadu_si128((__m128i*)(src+j+k*16));
-      xmm1[k] = _mm_shuffle_epi32(xmm0[k], 0xd8);
-      xmm0[k] = _mm_shuffle_epi32(xmm0[k], 0x8d);
-      xmm0[k] = _mm_unpacklo_epi8(xmm1[k], xmm0[k]);
-      xmm1[k] = _mm_shuffle_epi32(xmm0[k], 0x04e);
-      xmm0[k] = _mm_unpacklo_epi16(xmm0[k], xmm1[k]);
-    }
-    /* Transpose double words */
-    for (k = 0; k < 2; k++) {
-      xmm1[k*2] = _mm_unpacklo_epi32(xmm0[k*2], xmm0[k*2+1]);
-      xmm1[k*2+1] = _mm_unpackhi_epi32(xmm0[k*2], xmm0[k*2+1]);
-    }
-    /* Transpose quad words */
-    for (k = 0; k < 2; k++) {
-      xmm0[k*2] = _mm_unpacklo_epi64(xmm1[k], xmm1[k+2]);
-      xmm0[k*2+1] = _mm_unpackhi_epi64(xmm1[k], xmm1[k+2]);
-    }
-    /* Store the result vectors */
-    for (k = 0; k < 4; k++) {
-      ((__m128i *)dest)[k*numof16belem+i] = xmm0[k];
-    }
-  }
+	for (i = 0, j = 0; i < numof16belem; i++, j += 4) {
+		/* Fetch and transpose bytes and words in groups of 64 bytes */
+		xmm0[0] = _mm_loadu_si128((__m128i*)(src + (j + 0) * 16));
+		xmm1[0] = _mm_shuffle_epi32(xmm0[0], 0xd8);
+		xmm0[0] = _mm_shuffle_epi32(xmm0[0], 0x8d);
+		xmm0[0] = _mm_unpacklo_epi8(xmm1[0], xmm0[0]);
+		xmm1[0] = _mm_shuffle_epi32(xmm0[0], 0x04e);
+		xmm0[0] = _mm_unpacklo_epi16(xmm0[0], xmm1[0]);
+
+		xmm0[1] = _mm_loadu_si128((__m128i*)(src + (j + 1) * 16));
+		xmm1[1] = _mm_shuffle_epi32(xmm0[1], 0xd8);
+		xmm0[1] = _mm_shuffle_epi32(xmm0[1], 0x8d);
+		xmm0[1] = _mm_unpacklo_epi8(xmm1[1], xmm0[1]);
+		xmm1[1] = _mm_shuffle_epi32(xmm0[1], 0x04e);
+		xmm0[1] = _mm_unpacklo_epi16(xmm0[1], xmm1[1]);
+
+		xmm0[2] = _mm_loadu_si128((__m128i*)(src + (j + 2) * 16));
+		xmm1[2] = _mm_shuffle_epi32(xmm0[2], 0xd8);
+		xmm0[2] = _mm_shuffle_epi32(xmm0[2], 0x8d);
+		xmm0[2] = _mm_unpacklo_epi8(xmm1[2], xmm0[2]);
+		xmm1[2] = _mm_shuffle_epi32(xmm0[2], 0x04e);
+		xmm0[2] = _mm_unpacklo_epi16(xmm0[2], xmm1[2]);
+
+		xmm0[3] = _mm_loadu_si128((__m128i*)(src + (j + 3) * 16));
+		xmm1[3] = _mm_shuffle_epi32(xmm0[3], 0xd8);
+		xmm0[3] = _mm_shuffle_epi32(xmm0[3], 0x8d);
+		xmm0[3] = _mm_unpacklo_epi8(xmm1[3], xmm0[3]);
+		xmm1[3] = _mm_shuffle_epi32(xmm0[3], 0x04e);
+		xmm0[3] = _mm_unpacklo_epi16(xmm0[3], xmm1[3]);
+
+		/* Transpose double words */
+		xmm1[0] = _mm_unpacklo_epi32(xmm0[0], xmm0[1]);
+		xmm1[1] = _mm_unpackhi_epi32(xmm0[0], xmm0[1]);
+
+		xmm1[2] = _mm_unpacklo_epi32(xmm0[2], xmm0[3]);
+		xmm1[3] = _mm_unpackhi_epi32(xmm0[2], xmm0[3]);
+
+		/* Transpose quad words */
+		xmm0[0] = _mm_unpacklo_epi64(xmm1[0], xmm1[2]);
+		xmm0[1] = _mm_unpackhi_epi64(xmm1[0], xmm1[2]);
+
+		xmm0[2] = _mm_unpacklo_epi64(xmm1[1], xmm1[3]);
+		xmm0[3] = _mm_unpackhi_epi64(xmm1[1], xmm1[3]);
+
+		/* Store the result vectors */
+		((__m128i *)dest)[0 * numof16belem + i] = xmm0[0];
+		((__m128i *)dest)[1 * numof16belem + i] = xmm0[1];
+		((__m128i *)dest)[2 * numof16belem + i] = xmm0[2];
+		((__m128i *)dest)[3 * numof16belem + i] = xmm0[3];
+	}
 }
 
 
@@ -165,39 +192,93 @@ shuffle4(uint8_t* dest, const uint8_t* src, size_t size)
 static void
 shuffle8(uint8_t* dest, const uint8_t* src, size_t size)
 {
-  size_t i, j, k, l;
-  size_t numof16belem;
-  __m128i xmm0[8], xmm1[8];
+	size_t i, j;
+	const size_t numof16belem = size / (8 * VECTOR_SIZE);
+	__m128i xmm0[8], xmm1[8];
 
-  numof16belem = size / (16*8);
-  for (i = 0, j = 0; i < numof16belem; i++, j += 16*8) {
-    /* Fetch and transpose bytes in groups of 128 bytes */
-    for (k = 0; k < 8; k++) {
-      xmm0[k] = _mm_loadu_si128((__m128i*)(src+j+k*16));
-      xmm1[k] = _mm_shuffle_epi32(xmm0[k], 0x4e);
-      xmm1[k] = _mm_unpacklo_epi8(xmm0[k], xmm1[k]);
-    }
-    /* Transpose words */
-    for (k = 0, l = 0; k < 4; k++, l +=2) {
-      xmm0[k*2] = _mm_unpacklo_epi16(xmm1[l], xmm1[l+1]);
-      xmm0[k*2+1] = _mm_unpackhi_epi16(xmm1[l], xmm1[l+1]);
-    }
-    /* Transpose double words */
-    for (k = 0, l = 0; k < 4; k++, l++) {
-      if (k == 2) l += 2;
-      xmm1[k*2] = _mm_unpacklo_epi32(xmm0[l], xmm0[l+2]);
-      xmm1[k*2+1] = _mm_unpackhi_epi32(xmm0[l], xmm0[l+2]);
-    }
-    /* Transpose quad words */
-    for (k = 0; k < 4; k++) {
-      xmm0[k*2] = _mm_unpacklo_epi64(xmm1[k], xmm1[k+4]);
-      xmm0[k*2+1] = _mm_unpackhi_epi64(xmm1[k], xmm1[k+4]);
-    }
-    /* Store the result vectors */
-    for (k = 0; k < 8; k++) {
-      ((__m128i *)dest)[k*numof16belem+i] = xmm0[k];
-    }
-  }
+	for (i = 0, j = 0; i < numof16belem; i++, j += 8) {
+		/* Fetch and transpose bytes in groups of 128 bytes */
+		xmm0[0] = _mm_loadu_si128((__m128i*)(src + (j + 0) * VECTOR_SIZE));
+		xmm1[0] = _mm_shuffle_epi32(xmm0[0], 0x4e);
+		xmm1[0] = _mm_unpacklo_epi8(xmm0[0], xmm1[0]);
+
+		xmm0[1] = _mm_loadu_si128((__m128i*)(src + (j + 1) * VECTOR_SIZE));
+		xmm1[1] = _mm_shuffle_epi32(xmm0[1], 0x4e);
+		xmm1[1] = _mm_unpacklo_epi8(xmm0[1], xmm1[1]);
+
+		xmm0[2] = _mm_loadu_si128((__m128i*)(src + (j + 2) * VECTOR_SIZE));
+		xmm1[2] = _mm_shuffle_epi32(xmm0[2], 0x4e);
+		xmm1[2] = _mm_unpacklo_epi8(xmm0[2], xmm1[2]);
+
+		xmm0[3] = _mm_loadu_si128((__m128i*)(src + (j + 3) * VECTOR_SIZE));
+		xmm1[3] = _mm_shuffle_epi32(xmm0[3], 0x4e);
+		xmm1[3] = _mm_unpacklo_epi8(xmm0[3], xmm1[3]);
+
+		xmm0[4] = _mm_loadu_si128((__m128i*)(src + (j + 4) * VECTOR_SIZE));
+		xmm1[4] = _mm_shuffle_epi32(xmm0[4], 0x4e);
+		xmm1[4] = _mm_unpacklo_epi8(xmm0[4], xmm1[4]);
+
+		xmm0[5] = _mm_loadu_si128((__m128i*)(src + (j + 5) * VECTOR_SIZE));
+		xmm1[5] = _mm_shuffle_epi32(xmm0[5], 0x4e);
+		xmm1[5] = _mm_unpacklo_epi8(xmm0[5], xmm1[5]);
+
+		xmm0[6] = _mm_loadu_si128((__m128i*)(src + (j + 6) * VECTOR_SIZE));
+		xmm1[6] = _mm_shuffle_epi32(xmm0[6], 0x4e);
+		xmm1[6] = _mm_unpacklo_epi8(xmm0[6], xmm1[6]);
+
+		xmm0[7] = _mm_loadu_si128((__m128i*)(src + (j + 7) * VECTOR_SIZE));
+		xmm1[7] = _mm_shuffle_epi32(xmm0[7], 0x4e);
+		xmm1[7] = _mm_unpacklo_epi8(xmm0[7], xmm1[7]);
+
+		/* Transpose words */
+		xmm0[0] = _mm_unpacklo_epi16(xmm1[0], xmm1[1]);
+		xmm0[1] = _mm_unpackhi_epi16(xmm1[0], xmm1[1]);
+
+		xmm0[2] = _mm_unpacklo_epi16(xmm1[2], xmm1[3]);
+		xmm0[3] = _mm_unpackhi_epi16(xmm1[2], xmm1[3]);
+
+		xmm0[4] = _mm_unpacklo_epi16(xmm1[4], xmm1[5]);
+		xmm0[5] = _mm_unpackhi_epi16(xmm1[4], xmm1[5]);
+
+		xmm0[6] = _mm_unpacklo_epi16(xmm1[6], xmm1[7]);
+		xmm0[7] = _mm_unpackhi_epi16(xmm1[6], xmm1[7]);
+
+		/* Transpose double words */
+		xmm1[0] = _mm_unpacklo_epi32(xmm0[0], xmm0[2]);
+		xmm1[1] = _mm_unpackhi_epi32(xmm0[0], xmm0[2]);
+
+		xmm1[2] = _mm_unpacklo_epi32(xmm0[1], xmm0[3]);
+		xmm1[3] = _mm_unpackhi_epi32(xmm0[1], xmm0[3]);
+
+		xmm1[4] = _mm_unpacklo_epi32(xmm0[4], xmm0[6]);
+		xmm1[5] = _mm_unpackhi_epi32(xmm0[4], xmm0[6]);
+
+		xmm1[6] = _mm_unpacklo_epi32(xmm0[5], xmm0[7]);
+		xmm1[7] = _mm_unpackhi_epi32(xmm0[5], xmm0[7]);
+
+		/* Transpose quad words */
+		xmm0[0] = _mm_unpacklo_epi64(xmm1[0], xmm1[4]);
+		xmm0[1] = _mm_unpackhi_epi64(xmm1[0], xmm1[4]);
+
+		xmm0[2] = _mm_unpacklo_epi64(xmm1[1], xmm1[5]);
+		xmm0[3] = _mm_unpackhi_epi64(xmm1[1], xmm1[5]);
+
+		xmm0[4] = _mm_unpacklo_epi64(xmm1[2], xmm1[6]);
+		xmm0[5] = _mm_unpackhi_epi64(xmm1[2], xmm1[6]);
+
+		xmm0[6] = _mm_unpacklo_epi64(xmm1[3], xmm1[7]);
+		xmm0[7] = _mm_unpackhi_epi64(xmm1[3], xmm1[7]);
+
+		/* Store the result vectors */
+		((__m128i *)dest)[0 * numof16belem + i] = xmm0[0];
+		((__m128i *)dest)[1 * numof16belem + i] = xmm0[1];
+		((__m128i *)dest)[2 * numof16belem + i] = xmm0[2];
+		((__m128i *)dest)[3 * numof16belem + i] = xmm0[3];
+		((__m128i *)dest)[4 * numof16belem + i] = xmm0[4];
+		((__m128i *)dest)[5 * numof16belem + i] = xmm0[5];
+		((__m128i *)dest)[6 * numof16belem + i] = xmm0[6];
+		((__m128i *)dest)[7 * numof16belem + i] = xmm0[7];
+	}
 }
 
 
@@ -205,79 +286,183 @@ shuffle8(uint8_t* dest, const uint8_t* src, size_t size)
 static void
 shuffle16(uint8_t* dest, const uint8_t* src, size_t size)
 {
-  size_t i, j, k, l;
-  size_t numof16belem;
-  __m128i xmm0[16], xmm1[16];
+	size_t i, j;
+	const size_t numof16belem = size / (16 * VECTOR_SIZE);
+	__m128i xmm0[16], xmm1[16];
 
-  numof16belem = size / (16*16);
-  for (i = 0, j = 0; i < numof16belem; i++, j += 16*16) {
-    /* Fetch elements in groups of 256 bytes */
-    for (k = 0; k < 16; k++) {
-      xmm0[k] = _mm_loadu_si128((__m128i*)(src+j+k*16));
-    }
-    /* Transpose bytes */
-    for (k = 0, l = 0; k < 8; k++, l +=2) {
-      xmm1[k*2] = _mm_unpacklo_epi8(xmm0[l], xmm0[l+1]);
-      xmm1[k*2+1] = _mm_unpackhi_epi8(xmm0[l], xmm0[l+1]);
-    }
-    /* Transpose words */
-    for (k = 0, l = -2; k < 8; k++, l++) {
-      if ((k%2) == 0) l += 2;
-      xmm0[k*2] = _mm_unpacklo_epi16(xmm1[l], xmm1[l+2]);
-      xmm0[k*2+1] = _mm_unpackhi_epi16(xmm1[l], xmm1[l+2]);
-    }
-    /* Transpose double words */
-    for (k = 0, l = -4; k < 8; k++, l++) {
-      if ((k%4) == 0) l += 4;
-      xmm1[k*2] = _mm_unpacklo_epi32(xmm0[l], xmm0[l+4]);
-      xmm1[k*2+1] = _mm_unpackhi_epi32(xmm0[l], xmm0[l+4]);
-    }
-    /* Transpose quad words */
-    for (k = 0; k < 8; k++) {
-      xmm0[k*2] = _mm_unpacklo_epi64(xmm1[k], xmm1[k+8]);
-      xmm0[k*2+1] = _mm_unpackhi_epi64(xmm1[k], xmm1[k+8]);
-    }
-    /* Store the result vectors */
-    for (k = 0; k < 16; k++) {
-      ((__m128i *)dest)[k*numof16belem+i] = xmm0[k];
-    }
-  }
+	for (i = 0, j = 0; i < numof16belem; i++, j += 16) {
+		/* Fetch elements in groups of 256 bytes */
+		xmm0[0] = _mm_loadu_si128((__m128i*)(src + (j + 0) * VECTOR_SIZE));
+		xmm0[1] = _mm_loadu_si128((__m128i*)(src + (j + 1) * VECTOR_SIZE));
+		xmm0[2] = _mm_loadu_si128((__m128i*)(src + (j + 2) * VECTOR_SIZE));
+		xmm0[3] = _mm_loadu_si128((__m128i*)(src + (j + 3) * VECTOR_SIZE));
+		xmm0[4] = _mm_loadu_si128((__m128i*)(src + (j + 4) * VECTOR_SIZE));
+		xmm0[5] = _mm_loadu_si128((__m128i*)(src + (j + 5) * VECTOR_SIZE));
+		xmm0[6] = _mm_loadu_si128((__m128i*)(src + (j + 6) * VECTOR_SIZE));
+		xmm0[7] = _mm_loadu_si128((__m128i*)(src + (j + 7) * VECTOR_SIZE));
+		xmm0[8] = _mm_loadu_si128((__m128i*)(src + (j + 8) * VECTOR_SIZE));
+		xmm0[9] = _mm_loadu_si128((__m128i*)(src + (j + 9) * VECTOR_SIZE));
+		xmm0[10] = _mm_loadu_si128((__m128i*)(src + (j + 10) * VECTOR_SIZE));
+		xmm0[11] = _mm_loadu_si128((__m128i*)(src + (j + 11) * VECTOR_SIZE));
+		xmm0[12] = _mm_loadu_si128((__m128i*)(src + (j + 12) * VECTOR_SIZE));
+		xmm0[13] = _mm_loadu_si128((__m128i*)(src + (j + 13) * VECTOR_SIZE));
+		xmm0[14] = _mm_loadu_si128((__m128i*)(src + (j + 14) * VECTOR_SIZE));
+		xmm0[15] = _mm_loadu_si128((__m128i*)(src + (j + 15) * VECTOR_SIZE));
+
+		/* Transpose bytes */
+		xmm1[0] = _mm_unpacklo_epi8(xmm0[0], xmm0[1]);
+		xmm1[1] = _mm_unpackhi_epi8(xmm0[0], xmm0[1]);
+
+		xmm1[2] = _mm_unpacklo_epi8(xmm0[2], xmm0[3]);
+		xmm1[3] = _mm_unpackhi_epi8(xmm0[2], xmm0[3]);
+
+		xmm1[4] = _mm_unpacklo_epi8(xmm0[4], xmm0[5]);
+		xmm1[5] = _mm_unpackhi_epi8(xmm0[4], xmm0[5]);
+
+		xmm1[6] = _mm_unpacklo_epi8(xmm0[6], xmm0[7]);
+		xmm1[7] = _mm_unpackhi_epi8(xmm0[6], xmm0[7]);
+
+		xmm1[8] = _mm_unpacklo_epi8(xmm0[8], xmm0[9]);
+		xmm1[9] = _mm_unpackhi_epi8(xmm0[8], xmm0[9]);
+
+		xmm1[10] = _mm_unpacklo_epi8(xmm0[10], xmm0[11]);
+		xmm1[11] = _mm_unpackhi_epi8(xmm0[10], xmm0[11]);
+
+		xmm1[12] = _mm_unpacklo_epi8(xmm0[12], xmm0[13]);
+		xmm1[13] = _mm_unpackhi_epi8(xmm0[12], xmm0[13]);
+
+		xmm1[14] = _mm_unpacklo_epi8(xmm0[14], xmm0[15]);
+		xmm1[15] = _mm_unpackhi_epi8(xmm0[14], xmm0[15]);
+
+		/* Transpose words */
+		xmm0[0] = _mm_unpacklo_epi16(xmm1[0], xmm1[2]);
+		xmm0[1] = _mm_unpackhi_epi16(xmm1[0], xmm1[2]);
+
+		xmm0[2] = _mm_unpacklo_epi16(xmm1[1], xmm1[3]);
+		xmm0[3] = _mm_unpackhi_epi16(xmm1[1], xmm1[3]);
+
+		xmm0[4] = _mm_unpacklo_epi16(xmm1[4], xmm1[6]);
+		xmm0[5] = _mm_unpackhi_epi16(xmm1[4], xmm1[6]);
+
+		xmm0[6] = _mm_unpacklo_epi16(xmm1[5], xmm1[7]);
+		xmm0[7] = _mm_unpackhi_epi16(xmm1[5], xmm1[7]);
+
+		xmm0[8] = _mm_unpacklo_epi16(xmm1[8], xmm1[10]);
+		xmm0[9] = _mm_unpackhi_epi16(xmm1[8], xmm1[10]);
+
+		xmm0[10] = _mm_unpacklo_epi16(xmm1[9], xmm1[11]);
+		xmm0[11] = _mm_unpackhi_epi16(xmm1[9], xmm1[11]);
+
+		xmm0[12] = _mm_unpacklo_epi16(xmm1[12], xmm1[14]);
+		xmm0[13] = _mm_unpackhi_epi16(xmm1[12], xmm1[14]);
+
+		xmm0[14] = _mm_unpacklo_epi16(xmm1[13], xmm1[15]);
+		xmm0[15] = _mm_unpackhi_epi16(xmm1[13], xmm1[15]);
+
+		/* Transpose double words */
+		xmm1[0] = _mm_unpacklo_epi32(xmm0[0], xmm0[4]);
+		xmm1[1] = _mm_unpackhi_epi32(xmm0[0], xmm0[4]);
+
+		xmm1[2] = _mm_unpacklo_epi32(xmm0[1], xmm0[5]);
+		xmm1[3] = _mm_unpackhi_epi32(xmm0[1], xmm0[5]);
+
+		xmm1[4] = _mm_unpacklo_epi32(xmm0[2], xmm0[6]);
+		xmm1[5] = _mm_unpackhi_epi32(xmm0[2], xmm0[6]);
+
+		xmm1[6] = _mm_unpacklo_epi32(xmm0[3], xmm0[7]);
+		xmm1[7] = _mm_unpackhi_epi32(xmm0[3], xmm0[7]);
+
+		xmm1[8] = _mm_unpacklo_epi32(xmm0[8], xmm0[12]);
+		xmm1[9] = _mm_unpackhi_epi32(xmm0[8], xmm0[12]);
+
+		xmm1[10] = _mm_unpacklo_epi32(xmm0[9], xmm0[13]);
+		xmm1[11] = _mm_unpackhi_epi32(xmm0[9], xmm0[13]);
+
+		xmm1[12] = _mm_unpacklo_epi32(xmm0[10], xmm0[14]);
+		xmm1[13] = _mm_unpackhi_epi32(xmm0[10], xmm0[14]);
+
+		xmm1[14] = _mm_unpacklo_epi32(xmm0[11], xmm0[15]);
+		xmm1[15] = _mm_unpackhi_epi32(xmm0[11], xmm0[15]);
+
+		/* Transpose quad words */
+		xmm0[0] = _mm_unpacklo_epi64(xmm1[0], xmm1[8]);
+		xmm0[1] = _mm_unpackhi_epi64(xmm1[0], xmm1[8]);
+
+		xmm0[2] = _mm_unpacklo_epi64(xmm1[1], xmm1[9]);
+		xmm0[3] = _mm_unpackhi_epi64(xmm1[1], xmm1[9]);
+
+		xmm0[4] = _mm_unpacklo_epi64(xmm1[2], xmm1[10]);
+		xmm0[5] = _mm_unpackhi_epi64(xmm1[2], xmm1[10]);
+
+		xmm0[6] = _mm_unpacklo_epi64(xmm1[3], xmm1[11]);
+		xmm0[7] = _mm_unpackhi_epi64(xmm1[3], xmm1[11]);
+
+		xmm0[8] = _mm_unpacklo_epi64(xmm1[4], xmm1[12]);
+		xmm0[9] = _mm_unpackhi_epi64(xmm1[4], xmm1[12]);
+
+		xmm0[10] = _mm_unpacklo_epi64(xmm1[5], xmm1[13]);
+		xmm0[11] = _mm_unpackhi_epi64(xmm1[5], xmm1[13]);
+
+		xmm0[12] = _mm_unpacklo_epi64(xmm1[6], xmm1[14]);
+		xmm0[13] = _mm_unpackhi_epi64(xmm1[6], xmm1[14]);
+
+		xmm0[14] = _mm_unpacklo_epi64(xmm1[7], xmm1[15]);
+		xmm0[15] = _mm_unpackhi_epi64(xmm1[7], xmm1[15]);
+
+		/* Store the result vectors */
+		((__m128i *)dest)[0 * numof16belem + i] = xmm0[0];
+		((__m128i *)dest)[1 * numof16belem + i] = xmm0[1];
+		((__m128i *)dest)[2 * numof16belem + i] = xmm0[2];
+		((__m128i *)dest)[3 * numof16belem + i] = xmm0[3];
+		((__m128i *)dest)[4 * numof16belem + i] = xmm0[4];
+		((__m128i *)dest)[5 * numof16belem + i] = xmm0[5];
+		((__m128i *)dest)[6 * numof16belem + i] = xmm0[6];
+		((__m128i *)dest)[7 * numof16belem + i] = xmm0[7];
+		((__m128i *)dest)[8 * numof16belem + i] = xmm0[8];
+		((__m128i *)dest)[9 * numof16belem + i] = xmm0[9];
+		((__m128i *)dest)[10 * numof16belem + i] = xmm0[10];
+		((__m128i *)dest)[11 * numof16belem + i] = xmm0[11];
+		((__m128i *)dest)[12 * numof16belem + i] = xmm0[12];
+		((__m128i *)dest)[13 * numof16belem + i] = xmm0[13];
+		((__m128i *)dest)[14 * numof16belem + i] = xmm0[14];
+		((__m128i *)dest)[15 * numof16belem + i] = xmm0[15];
+	}
 }
 
 
 /* Shuffle a block.  This can never fail. */
 void shuffle(size_t bytesoftype, size_t blocksize,
-             const uint8_t* _src, uint8_t* _dest) {
-  int unaligned_dest = (int)((uintptr_t)_dest % 16);
-  int multiple_of_block = (blocksize % (16 * bytesoftype)) == 0;
-  int too_small = (blocksize < 256);
+	const uint8_t* _src, uint8_t* _dest) {
+	int unaligned_dest = (int)((uintptr_t)_dest % 16);
+	int multiple_of_block = (blocksize % (16 * bytesoftype)) == 0;
+	int too_small = (blocksize < 256);
 
-  if (unaligned_dest || !multiple_of_block || too_small) {
-    /* _dest buffer is not aligned, not multiple of the vectorization size
-     * or is too small.  Call the non-sse2 version. */
-    _shuffle(bytesoftype, blocksize, _src, _dest);
-    return;
-  }
+	if (unaligned_dest || !multiple_of_block || too_small) {
+		/* _dest buffer is not aligned, not multiple of the vectorization size
+		* or is too small.  Call the non-sse2 version. */
+		_shuffle(bytesoftype, blocksize, _src, _dest);
+		return;
+	}
 
-  /* Optimized shuffle */
-  /* The buffer must be aligned on a 16 bytes boundary, have a power */
-  /* of 2 size and be larger or equal than 256 bytes. */
-  if (bytesoftype == 4) {
-    shuffle4(_dest, _src, blocksize);
-  }
-  else if (bytesoftype == 8) {
-    shuffle8(_dest, _src, blocksize);
-  }
-  else if (bytesoftype == 16) {
-    shuffle16(_dest, _src, blocksize);
-  }
-  else if (bytesoftype == 2) {
-    shuffle2(_dest, _src, blocksize);
-  }
-  else {
-    /* Non-optimized shuffle */
-    _shuffle(bytesoftype, blocksize, _src, _dest);
-  }
+	/* Optimized shuffle */
+	/* The buffer must be aligned on a 16 bytes boundary, have a power */
+	/* of 2 size and be larger or equal than 256 bytes. */
+	if (bytesoftype == 4) {
+		shuffle4(_dest, _src, blocksize);
+	}
+	else if (bytesoftype == 8) {
+		shuffle8(_dest, _src, blocksize);
+	}
+	else if (bytesoftype == 16) {
+		shuffle16(_dest, _src, blocksize);
+	}
+	else if (bytesoftype == 2) {
+		shuffle2(_dest, _src, blocksize);
+	}
+	else {
+		/* Non-optimized shuffle */
+		_shuffle(bytesoftype, blocksize, _src, _dest);
+	}
 }
 
 
@@ -285,25 +470,25 @@ void shuffle(size_t bytesoftype, size_t blocksize,
 static void
 unshuffle2(uint8_t* dest, const uint8_t* orig, size_t size)
 {
-  size_t i, k;
-  size_t neblock, numof16belem;
-  __m128i xmm1[2], xmm2[2];
+	size_t i, k;
+	size_t neblock, numof16belem;
+	__m128i xmm1[2], xmm2[2];
 
-  neblock = size / 2;
-  numof16belem = neblock / 16;
-  for (i = 0, k = 0; i < numof16belem; i++, k += 2) {
-    /* Load the first 32 bytes in 2 XMM registrers */
-    xmm1[0] = ((__m128i *)orig)[0*numof16belem+i];
-    xmm1[1] = ((__m128i *)orig)[1*numof16belem+i];
-    /* Shuffle bytes */
-    /* Compute the low 32 bytes */
-    xmm2[0] = _mm_unpacklo_epi8(xmm1[0], xmm1[1]);
-    /* Compute the hi 32 bytes */
-    xmm2[1] = _mm_unpackhi_epi8(xmm1[0], xmm1[1]);
-    /* Store the result vectors in proper order */
-    ((__m128i *)dest)[k+0] = xmm2[0];
-    ((__m128i *)dest)[k+1] = xmm2[1];
-  }
+	neblock = size / 2;
+	numof16belem = neblock / 16;
+	for (i = 0, k = 0; i < numof16belem; i++, k += 2) {
+		/* Load the first 32 bytes in 2 XMM registrers */
+		xmm1[0] = ((__m128i *)orig)[0 * numof16belem + i];
+		xmm1[1] = ((__m128i *)orig)[1 * numof16belem + i];
+		/* Shuffle bytes */
+		/* Compute the low 32 bytes */
+		xmm2[0] = _mm_unpacklo_epi8(xmm1[0], xmm1[1]);
+		/* Compute the hi 32 bytes */
+		xmm2[1] = _mm_unpackhi_epi8(xmm1[0], xmm1[1]);
+		/* Store the result vectors in proper order */
+		((__m128i *)dest)[k + 0] = xmm2[0];
+		((__m128i *)dest)[k + 1] = xmm2[1];
+	}
 }
 
 
@@ -311,37 +496,37 @@ unshuffle2(uint8_t* dest, const uint8_t* orig, size_t size)
 static void
 unshuffle4(uint8_t* dest, const uint8_t* orig, size_t size)
 {
-  size_t i, j, k;
-  size_t neblock, numof16belem;
-  __m128i xmm0[4], xmm1[4];
+	size_t i, j, k;
+	size_t neblock, numof16belem;
+	__m128i xmm0[4], xmm1[4];
 
-  neblock = size / 4;
-  numof16belem = neblock / 16;
-  for (i = 0, k = 0; i < numof16belem; i++, k += 4) {
-    /* Load the first 64 bytes in 4 XMM registrers */
-    for (j = 0; j < 4; j++) {
-      xmm0[j] = ((__m128i *)orig)[j*numof16belem+i];
-    }
-    /* Shuffle bytes */
-    for (j = 0; j < 2; j++) {
-      /* Compute the low 32 bytes */
-      xmm1[j] = _mm_unpacklo_epi8(xmm0[j*2], xmm0[j*2+1]);
-      /* Compute the hi 32 bytes */
-      xmm1[2+j] = _mm_unpackhi_epi8(xmm0[j*2], xmm0[j*2+1]);
-    }
-    /* Shuffle 2-byte words */
-    for (j = 0; j < 2; j++) {
-      /* Compute the low 32 bytes */
-      xmm0[j] = _mm_unpacklo_epi16(xmm1[j*2], xmm1[j*2+1]);
-      /* Compute the hi 32 bytes */
-      xmm0[2+j] = _mm_unpackhi_epi16(xmm1[j*2], xmm1[j*2+1]);
-    }
-    /* Store the result vectors in proper order */
-    ((__m128i *)dest)[k+0] = xmm0[0];
-    ((__m128i *)dest)[k+1] = xmm0[2];
-    ((__m128i *)dest)[k+2] = xmm0[1];
-    ((__m128i *)dest)[k+3] = xmm0[3];
-  }
+	neblock = size / 4;
+	numof16belem = neblock / 16;
+	for (i = 0, k = 0; i < numof16belem; i++, k += 4) {
+		/* Load the first 64 bytes in 4 XMM registrers */
+		for (j = 0; j < 4; j++) {
+			xmm0[j] = ((__m128i *)orig)[j*numof16belem + i];
+		}
+		/* Shuffle bytes */
+		for (j = 0; j < 2; j++) {
+			/* Compute the low 32 bytes */
+			xmm1[j] = _mm_unpacklo_epi8(xmm0[j * 2], xmm0[j * 2 + 1]);
+			/* Compute the hi 32 bytes */
+			xmm1[2 + j] = _mm_unpackhi_epi8(xmm0[j * 2], xmm0[j * 2 + 1]);
+		}
+		/* Shuffle 2-byte words */
+		for (j = 0; j < 2; j++) {
+			/* Compute the low 32 bytes */
+			xmm0[j] = _mm_unpacklo_epi16(xmm1[j * 2], xmm1[j * 2 + 1]);
+			/* Compute the hi 32 bytes */
+			xmm0[2 + j] = _mm_unpackhi_epi16(xmm1[j * 2], xmm1[j * 2 + 1]);
+		}
+		/* Store the result vectors in proper order */
+		((__m128i *)dest)[k + 0] = xmm0[0];
+		((__m128i *)dest)[k + 1] = xmm0[2];
+		((__m128i *)dest)[k + 2] = xmm0[1];
+		((__m128i *)dest)[k + 3] = xmm0[3];
+	}
 }
 
 
@@ -349,48 +534,48 @@ unshuffle4(uint8_t* dest, const uint8_t* orig, size_t size)
 static void
 unshuffle8(uint8_t* dest, const uint8_t* orig, size_t size)
 {
-  size_t i, j, k;
-  size_t neblock, numof16belem;
-  __m128i xmm0[8], xmm1[8];
+	size_t i, j, k;
+	size_t neblock, numof16belem;
+	__m128i xmm0[8], xmm1[8];
 
-  neblock = size / 8;
-  numof16belem = neblock / 16;
-  for (i = 0, k = 0; i < numof16belem; i++, k += 8) {
-    /* Load the first 64 bytes in 8 XMM registrers */
-    for (j = 0; j < 8; j++) {
-      xmm0[j] = ((__m128i *)orig)[j*numof16belem+i];
-    }
-    /* Shuffle bytes */
-    for (j = 0; j < 4; j++) {
-      /* Compute the low 32 bytes */
-      xmm1[j] = _mm_unpacklo_epi8(xmm0[j*2], xmm0[j*2+1]);
-      /* Compute the hi 32 bytes */
-      xmm1[4+j] = _mm_unpackhi_epi8(xmm0[j*2], xmm0[j*2+1]);
-    }
-    /* Shuffle 2-byte words */
-    for (j = 0; j < 4; j++) {
-      /* Compute the low 32 bytes */
-      xmm0[j] = _mm_unpacklo_epi16(xmm1[j*2], xmm1[j*2+1]);
-      /* Compute the hi 32 bytes */
-      xmm0[4+j] = _mm_unpackhi_epi16(xmm1[j*2], xmm1[j*2+1]);
-    }
-    /* Shuffle 4-byte dwords */
-    for (j = 0; j < 4; j++) {
-      /* Compute the low 32 bytes */
-      xmm1[j] = _mm_unpacklo_epi32(xmm0[j*2], xmm0[j*2+1]);
-      /* Compute the hi 32 bytes */
-      xmm1[4+j] = _mm_unpackhi_epi32(xmm0[j*2], xmm0[j*2+1]);
-    }
-    /* Store the result vectors in proper order */
-    ((__m128i *)dest)[k+0] = xmm1[0];
-    ((__m128i *)dest)[k+1] = xmm1[4];
-    ((__m128i *)dest)[k+2] = xmm1[2];
-    ((__m128i *)dest)[k+3] = xmm1[6];
-    ((__m128i *)dest)[k+4] = xmm1[1];
-    ((__m128i *)dest)[k+5] = xmm1[5];
-    ((__m128i *)dest)[k+6] = xmm1[3];
-    ((__m128i *)dest)[k+7] = xmm1[7];
-  }
+	neblock = size / 8;
+	numof16belem = neblock / 16;
+	for (i = 0, k = 0; i < numof16belem; i++, k += 8) {
+		/* Load the first 64 bytes in 8 XMM registrers */
+		for (j = 0; j < 8; j++) {
+			xmm0[j] = ((__m128i *)orig)[j*numof16belem + i];
+		}
+		/* Shuffle bytes */
+		for (j = 0; j < 4; j++) {
+			/* Compute the low 32 bytes */
+			xmm1[j] = _mm_unpacklo_epi8(xmm0[j * 2], xmm0[j * 2 + 1]);
+			/* Compute the hi 32 bytes */
+			xmm1[4 + j] = _mm_unpackhi_epi8(xmm0[j * 2], xmm0[j * 2 + 1]);
+		}
+		/* Shuffle 2-byte words */
+		for (j = 0; j < 4; j++) {
+			/* Compute the low 32 bytes */
+			xmm0[j] = _mm_unpacklo_epi16(xmm1[j * 2], xmm1[j * 2 + 1]);
+			/* Compute the hi 32 bytes */
+			xmm0[4 + j] = _mm_unpackhi_epi16(xmm1[j * 2], xmm1[j * 2 + 1]);
+		}
+		/* Shuffle 4-byte dwords */
+		for (j = 0; j < 4; j++) {
+			/* Compute the low 32 bytes */
+			xmm1[j] = _mm_unpacklo_epi32(xmm0[j * 2], xmm0[j * 2 + 1]);
+			/* Compute the hi 32 bytes */
+			xmm1[4 + j] = _mm_unpackhi_epi32(xmm0[j * 2], xmm0[j * 2 + 1]);
+		}
+		/* Store the result vectors in proper order */
+		((__m128i *)dest)[k + 0] = xmm1[0];
+		((__m128i *)dest)[k + 1] = xmm1[4];
+		((__m128i *)dest)[k + 2] = xmm1[2];
+		((__m128i *)dest)[k + 3] = xmm1[6];
+		((__m128i *)dest)[k + 4] = xmm1[1];
+		((__m128i *)dest)[k + 5] = xmm1[5];
+		((__m128i *)dest)[k + 6] = xmm1[3];
+		((__m128i *)dest)[k + 7] = xmm1[7];
+	}
 }
 
 
@@ -398,112 +583,112 @@ unshuffle8(uint8_t* dest, const uint8_t* orig, size_t size)
 static void
 unshuffle16(uint8_t* dest, const uint8_t* orig, size_t size)
 {
-  size_t i, j, k;
-  size_t neblock, numof16belem;
-  __m128i xmm1[16], xmm2[16];
+	size_t i, j, k;
+	size_t neblock, numof16belem;
+	__m128i xmm1[16], xmm2[16];
 
-  neblock = size / 16;
-  numof16belem = neblock / 16;
-  for (i = 0, k = 0; i < numof16belem; i++, k += 16) {
-    /* Load the first 128 bytes in 16 XMM registrers */
-    for (j = 0; j < 16; j++) {
-      xmm1[j] = ((__m128i *)orig)[j*numof16belem+i];
-    }
-    /* Shuffle bytes */
-    for (j = 0; j < 8; j++) {
-      /* Compute the low 32 bytes */
-      xmm2[j] = _mm_unpacklo_epi8(xmm1[j*2], xmm1[j*2+1]);
-      /* Compute the hi 32 bytes */
-      xmm2[8+j] = _mm_unpackhi_epi8(xmm1[j*2], xmm1[j*2+1]);
-    }
-    /* Shuffle 2-byte words */
-    for (j = 0; j < 8; j++) {
-      /* Compute the low 32 bytes */
-      xmm1[j] = _mm_unpacklo_epi16(xmm2[j*2], xmm2[j*2+1]);
-      /* Compute the hi 32 bytes */
-      xmm1[8+j] = _mm_unpackhi_epi16(xmm2[j*2], xmm2[j*2+1]);
-    }
-    /* Shuffle 4-byte dwords */
-    for (j = 0; j < 8; j++) {
-      /* Compute the low 32 bytes */
-      xmm2[j] = _mm_unpacklo_epi32(xmm1[j*2], xmm1[j*2+1]);
-      /* Compute the hi 32 bytes */
-      xmm2[8+j] = _mm_unpackhi_epi32(xmm1[j*2], xmm1[j*2+1]);
-    }
-    /* Shuffle 8-byte qwords */
-    for (j = 0; j < 8; j++) {
-      /* Compute the low 32 bytes */
-      xmm1[j] = _mm_unpacklo_epi64(xmm2[j*2], xmm2[j*2+1]);
-      /* Compute the hi 32 bytes */
-      xmm1[8+j] = _mm_unpackhi_epi64(xmm2[j*2], xmm2[j*2+1]);
-    }
-    /* Store the result vectors in proper order */
-    ((__m128i *)dest)[k+0] = xmm1[0];
-    ((__m128i *)dest)[k+1] = xmm1[8];
-    ((__m128i *)dest)[k+2] = xmm1[4];
-    ((__m128i *)dest)[k+3] = xmm1[12];
-    ((__m128i *)dest)[k+4] = xmm1[2];
-    ((__m128i *)dest)[k+5] = xmm1[10];
-    ((__m128i *)dest)[k+6] = xmm1[6];
-    ((__m128i *)dest)[k+7] = xmm1[14];
-    ((__m128i *)dest)[k+8] = xmm1[1];
-    ((__m128i *)dest)[k+9] = xmm1[9];
-    ((__m128i *)dest)[k+10] = xmm1[5];
-    ((__m128i *)dest)[k+11] = xmm1[13];
-    ((__m128i *)dest)[k+12] = xmm1[3];
-    ((__m128i *)dest)[k+13] = xmm1[11];
-    ((__m128i *)dest)[k+14] = xmm1[7];
-    ((__m128i *)dest)[k+15] = xmm1[15];
-  }
+	neblock = size / 16;
+	numof16belem = neblock / 16;
+	for (i = 0, k = 0; i < numof16belem; i++, k += 16) {
+		/* Load the first 128 bytes in 16 XMM registrers */
+		for (j = 0; j < 16; j++) {
+			xmm1[j] = ((__m128i *)orig)[j*numof16belem + i];
+		}
+		/* Shuffle bytes */
+		for (j = 0; j < 8; j++) {
+			/* Compute the low 32 bytes */
+			xmm2[j] = _mm_unpacklo_epi8(xmm1[j * 2], xmm1[j * 2 + 1]);
+			/* Compute the hi 32 bytes */
+			xmm2[8 + j] = _mm_unpackhi_epi8(xmm1[j * 2], xmm1[j * 2 + 1]);
+		}
+		/* Shuffle 2-byte words */
+		for (j = 0; j < 8; j++) {
+			/* Compute the low 32 bytes */
+			xmm1[j] = _mm_unpacklo_epi16(xmm2[j * 2], xmm2[j * 2 + 1]);
+			/* Compute the hi 32 bytes */
+			xmm1[8 + j] = _mm_unpackhi_epi16(xmm2[j * 2], xmm2[j * 2 + 1]);
+		}
+		/* Shuffle 4-byte dwords */
+		for (j = 0; j < 8; j++) {
+			/* Compute the low 32 bytes */
+			xmm2[j] = _mm_unpacklo_epi32(xmm1[j * 2], xmm1[j * 2 + 1]);
+			/* Compute the hi 32 bytes */
+			xmm2[8 + j] = _mm_unpackhi_epi32(xmm1[j * 2], xmm1[j * 2 + 1]);
+		}
+		/* Shuffle 8-byte qwords */
+		for (j = 0; j < 8; j++) {
+			/* Compute the low 32 bytes */
+			xmm1[j] = _mm_unpacklo_epi64(xmm2[j * 2], xmm2[j * 2 + 1]);
+			/* Compute the hi 32 bytes */
+			xmm1[8 + j] = _mm_unpackhi_epi64(xmm2[j * 2], xmm2[j * 2 + 1]);
+		}
+		/* Store the result vectors in proper order */
+		((__m128i *)dest)[k + 0] = xmm1[0];
+		((__m128i *)dest)[k + 1] = xmm1[8];
+		((__m128i *)dest)[k + 2] = xmm1[4];
+		((__m128i *)dest)[k + 3] = xmm1[12];
+		((__m128i *)dest)[k + 4] = xmm1[2];
+		((__m128i *)dest)[k + 5] = xmm1[10];
+		((__m128i *)dest)[k + 6] = xmm1[6];
+		((__m128i *)dest)[k + 7] = xmm1[14];
+		((__m128i *)dest)[k + 8] = xmm1[1];
+		((__m128i *)dest)[k + 9] = xmm1[9];
+		((__m128i *)dest)[k + 10] = xmm1[5];
+		((__m128i *)dest)[k + 11] = xmm1[13];
+		((__m128i *)dest)[k + 12] = xmm1[3];
+		((__m128i *)dest)[k + 13] = xmm1[11];
+		((__m128i *)dest)[k + 14] = xmm1[7];
+		((__m128i *)dest)[k + 15] = xmm1[15];
+	}
 }
 
 
 /* Unshuffle a block.  This can never fail. */
 void unshuffle(size_t bytesoftype, size_t blocksize,
-               const uint8_t* _src, uint8_t* _dest) {
-  int unaligned_src = (int)((uintptr_t)_src % 16);
-  int unaligned_dest = (int)((uintptr_t)_dest % 16);
-  int multiple_of_block = (blocksize % (16 * bytesoftype)) == 0;
-  int too_small = (blocksize < 256);
+	const uint8_t* _src, uint8_t* _dest) {
+	int unaligned_src = (int)((uintptr_t)_src % 16);
+	int unaligned_dest = (int)((uintptr_t)_dest % 16);
+	int multiple_of_block = (blocksize % (16 * bytesoftype)) == 0;
+	int too_small = (blocksize < 256);
 
-  if (unaligned_src || unaligned_dest || !multiple_of_block || too_small) {
-    /* _src or _dest buffer is not aligned, not multiple of the vectorization
-     * size or is not too small.  Call the non-sse2 version. */
-    _unshuffle(bytesoftype, blocksize, _src, _dest);
-    return;
-  }
+	if (unaligned_src || unaligned_dest || !multiple_of_block || too_small) {
+		/* _src or _dest buffer is not aligned, not multiple of the vectorization
+		* size or is not too small.  Call the non-sse2 version. */
+		_unshuffle(bytesoftype, blocksize, _src, _dest);
+		return;
+	}
 
-  /* Optimized unshuffle */
-  /* The buffers must be aligned on a 16 bytes boundary, have a power */
-  /* of 2 size and be larger or equal than 256 bytes. */
-  if (bytesoftype == 4) {
-    unshuffle4(_dest, _src, blocksize);
-  }
-  else if (bytesoftype == 8) {
-    unshuffle8(_dest, _src, blocksize);
-  }
-  else if (bytesoftype == 16) {
-    unshuffle16(_dest, _src, blocksize);
-  }
-  else if (bytesoftype == 2) {
-    unshuffle2(_dest, _src, blocksize);
-  }
-  else {
-    /* Non-optimized unshuffle */
-    _unshuffle(bytesoftype, blocksize, _src, _dest);
-  }
+	/* Optimized unshuffle */
+	/* The buffers must be aligned on a 16 bytes boundary, have a power */
+	/* of 2 size and be larger or equal than 256 bytes. */
+	if (bytesoftype == 4) {
+		unshuffle4(_dest, _src, blocksize);
+	}
+	else if (bytesoftype == 8) {
+		unshuffle8(_dest, _src, blocksize);
+	}
+	else if (bytesoftype == 16) {
+		unshuffle16(_dest, _src, blocksize);
+	}
+	else if (bytesoftype == 2) {
+		unshuffle2(_dest, _src, blocksize);
+	}
+	else {
+		/* Non-optimized unshuffle */
+		_unshuffle(bytesoftype, blocksize, _src, _dest);
+	}
 }
 
 #else   /* no __SSE2__ available */
 
 void shuffle(size_t bytesoftype, size_t blocksize,
-             const uint8_t* _src, uint8_t* _dest) {
-  _shuffle(bytesoftype, blocksize, _src, _dest);
+	const uint8_t* _src, uint8_t* _dest) {
+	_shuffle(bytesoftype, blocksize, _src, _dest);
 }
 
 void unshuffle(size_t bytesoftype, size_t blocksize,
-               const uint8_t* _src, uint8_t* _dest) {
-  _unshuffle(bytesoftype, blocksize, _src, _dest);
+	const uint8_t* _src, uint8_t* _dest) {
+	_unshuffle(bytesoftype, blocksize, _src, _dest);
 }
 
 #endif  /* __SSE2__ */

--- a/blosc/shuffle.c
+++ b/blosc/shuffle.c
@@ -64,9 +64,6 @@ static void _unshuffle(size_t bytesoftype, size_t blocksize,
 
 #include <emmintrin.h>
 
-/* The size of an SSE2 vector (XMM register), in bytes. */
-#define VECTOR_SIZE 16
-
 /* The next is useful for debugging purposes */
 #if 0
 static void printxmm(__m128i xmm0)
@@ -88,13 +85,15 @@ static void
 shuffle2(uint8_t* dest, const uint8_t* src, size_t size)
 {
 	size_t i, j;
-	const size_t numof16belem = size / (2 * VECTOR_SIZE);
-	__m128i xmm0[2], xmm1[2];
+	const size_t numof16belem = size / (2 * sizeof(__m128i));
+	
 
 	for (i = 0, j = 0; i < numof16belem; i++, j += 2) {
+		__m128i xmm0[2], xmm1[2];
+
 		/* Fetch and transpose bytes, words and double words in groups of
 		32 bytes */
-		xmm0[0] = _mm_loadu_si128((__m128i*)(src + (j + 0) * VECTOR_SIZE));
+		xmm0[0] = _mm_loadu_si128((__m128i*)(src + (j + 0) * sizeof(__m128i)));
 		xmm0[0] = _mm_shufflelo_epi16(xmm0[0], 0xd8);
 		xmm0[0] = _mm_shufflehi_epi16(xmm0[0], 0xd8);
 		xmm0[0] = _mm_shuffle_epi32(xmm0[0], 0xd8);
@@ -105,7 +104,7 @@ shuffle2(uint8_t* dest, const uint8_t* src, size_t size)
 		xmm0[0] = _mm_unpacklo_epi16(xmm0[0], xmm1[0]);
 		xmm0[0] = _mm_shuffle_epi32(xmm0[0], 0xd8);
 
-		xmm0[1] = _mm_loadu_si128((__m128i*)(src + (j + 1) * VECTOR_SIZE));
+		xmm0[1] = _mm_loadu_si128((__m128i*)(src + (j + 1) * sizeof(__m128i)));
 		xmm0[1] = _mm_shufflelo_epi16(xmm0[1], 0xd8);
 		xmm0[1] = _mm_shufflehi_epi16(xmm0[1], 0xd8);
 		xmm0[1] = _mm_shuffle_epi32(xmm0[1], 0xd8);
@@ -132,33 +131,34 @@ static void
 shuffle4(uint8_t* dest, const uint8_t* src, size_t size)
 {
 	size_t i, j;
-	const size_t numof16belem = size / (4 * VECTOR_SIZE);
-	__m128i xmm0[4], xmm1[4];
-
+	const size_t numof16belem = size / (4 * sizeof(__m128i));
+	
 	for (i = 0, j = 0; i < numof16belem; i++, j += 4) {
+		__m128i xmm0[4], xmm1[4];
+
 		/* Fetch and transpose bytes and words in groups of 64 bytes */
-		xmm0[0] = _mm_loadu_si128((__m128i*)(src + (j + 0) * 16));
+		xmm0[0] = _mm_loadu_si128((__m128i*)(src + (j + 0) * sizeof(__m128i)));
 		xmm1[0] = _mm_shuffle_epi32(xmm0[0], 0xd8);
 		xmm0[0] = _mm_shuffle_epi32(xmm0[0], 0x8d);
 		xmm0[0] = _mm_unpacklo_epi8(xmm1[0], xmm0[0]);
 		xmm1[0] = _mm_shuffle_epi32(xmm0[0], 0x04e);
 		xmm0[0] = _mm_unpacklo_epi16(xmm0[0], xmm1[0]);
 
-		xmm0[1] = _mm_loadu_si128((__m128i*)(src + (j + 1) * 16));
+		xmm0[1] = _mm_loadu_si128((__m128i*)(src + (j + 1) * sizeof(__m128i)));
 		xmm1[1] = _mm_shuffle_epi32(xmm0[1], 0xd8);
 		xmm0[1] = _mm_shuffle_epi32(xmm0[1], 0x8d);
 		xmm0[1] = _mm_unpacklo_epi8(xmm1[1], xmm0[1]);
 		xmm1[1] = _mm_shuffle_epi32(xmm0[1], 0x04e);
 		xmm0[1] = _mm_unpacklo_epi16(xmm0[1], xmm1[1]);
 
-		xmm0[2] = _mm_loadu_si128((__m128i*)(src + (j + 2) * 16));
+		xmm0[2] = _mm_loadu_si128((__m128i*)(src + (j + 2) * sizeof(__m128i)));
 		xmm1[2] = _mm_shuffle_epi32(xmm0[2], 0xd8);
 		xmm0[2] = _mm_shuffle_epi32(xmm0[2], 0x8d);
 		xmm0[2] = _mm_unpacklo_epi8(xmm1[2], xmm0[2]);
 		xmm1[2] = _mm_shuffle_epi32(xmm0[2], 0x04e);
 		xmm0[2] = _mm_unpacklo_epi16(xmm0[2], xmm1[2]);
 
-		xmm0[3] = _mm_loadu_si128((__m128i*)(src + (j + 3) * 16));
+		xmm0[3] = _mm_loadu_si128((__m128i*)(src + (j + 3) * sizeof(__m128i)));
 		xmm1[3] = _mm_shuffle_epi32(xmm0[3], 0xd8);
 		xmm0[3] = _mm_shuffle_epi32(xmm0[3], 0x8d);
 		xmm0[3] = _mm_unpacklo_epi8(xmm1[3], xmm0[3]);
@@ -193,40 +193,41 @@ static void
 shuffle8(uint8_t* dest, const uint8_t* src, size_t size)
 {
 	size_t i, j;
-	const size_t numof16belem = size / (8 * VECTOR_SIZE);
-	__m128i xmm0[8], xmm1[8];
+	const size_t numof16belem = size / (8 * sizeof(__m128i));
 
 	for (i = 0, j = 0; i < numof16belem; i++, j += 8) {
+		__m128i xmm0[8], xmm1[8];
+
 		/* Fetch and transpose bytes in groups of 128 bytes */
-		xmm0[0] = _mm_loadu_si128((__m128i*)(src + (j + 0) * VECTOR_SIZE));
+		xmm0[0] = _mm_loadu_si128((__m128i*)(src + (j + 0) * sizeof(__m128i)));
 		xmm1[0] = _mm_shuffle_epi32(xmm0[0], 0x4e);
 		xmm1[0] = _mm_unpacklo_epi8(xmm0[0], xmm1[0]);
 
-		xmm0[1] = _mm_loadu_si128((__m128i*)(src + (j + 1) * VECTOR_SIZE));
+		xmm0[1] = _mm_loadu_si128((__m128i*)(src + (j + 1) * sizeof(__m128i)));
 		xmm1[1] = _mm_shuffle_epi32(xmm0[1], 0x4e);
 		xmm1[1] = _mm_unpacklo_epi8(xmm0[1], xmm1[1]);
 
-		xmm0[2] = _mm_loadu_si128((__m128i*)(src + (j + 2) * VECTOR_SIZE));
+		xmm0[2] = _mm_loadu_si128((__m128i*)(src + (j + 2) * sizeof(__m128i)));
 		xmm1[2] = _mm_shuffle_epi32(xmm0[2], 0x4e);
 		xmm1[2] = _mm_unpacklo_epi8(xmm0[2], xmm1[2]);
 
-		xmm0[3] = _mm_loadu_si128((__m128i*)(src + (j + 3) * VECTOR_SIZE));
+		xmm0[3] = _mm_loadu_si128((__m128i*)(src + (j + 3) * sizeof(__m128i)));
 		xmm1[3] = _mm_shuffle_epi32(xmm0[3], 0x4e);
 		xmm1[3] = _mm_unpacklo_epi8(xmm0[3], xmm1[3]);
 
-		xmm0[4] = _mm_loadu_si128((__m128i*)(src + (j + 4) * VECTOR_SIZE));
+		xmm0[4] = _mm_loadu_si128((__m128i*)(src + (j + 4) * sizeof(__m128i)));
 		xmm1[4] = _mm_shuffle_epi32(xmm0[4], 0x4e);
 		xmm1[4] = _mm_unpacklo_epi8(xmm0[4], xmm1[4]);
 
-		xmm0[5] = _mm_loadu_si128((__m128i*)(src + (j + 5) * VECTOR_SIZE));
+		xmm0[5] = _mm_loadu_si128((__m128i*)(src + (j + 5) * sizeof(__m128i)));
 		xmm1[5] = _mm_shuffle_epi32(xmm0[5], 0x4e);
 		xmm1[5] = _mm_unpacklo_epi8(xmm0[5], xmm1[5]);
 
-		xmm0[6] = _mm_loadu_si128((__m128i*)(src + (j + 6) * VECTOR_SIZE));
+		xmm0[6] = _mm_loadu_si128((__m128i*)(src + (j + 6) * sizeof(__m128i)));
 		xmm1[6] = _mm_shuffle_epi32(xmm0[6], 0x4e);
 		xmm1[6] = _mm_unpacklo_epi8(xmm0[6], xmm1[6]);
 
-		xmm0[7] = _mm_loadu_si128((__m128i*)(src + (j + 7) * VECTOR_SIZE));
+		xmm0[7] = _mm_loadu_si128((__m128i*)(src + (j + 7) * sizeof(__m128i)));
 		xmm1[7] = _mm_shuffle_epi32(xmm0[7], 0x4e);
 		xmm1[7] = _mm_unpacklo_epi8(xmm0[7], xmm1[7]);
 
@@ -287,27 +288,28 @@ static void
 shuffle16(uint8_t* dest, const uint8_t* src, size_t size)
 {
 	size_t i, j;
-	const size_t numof16belem = size / (16 * VECTOR_SIZE);
-	__m128i xmm0[16], xmm1[16];
+	const size_t numof16belem = size / (16 * sizeof(__m128i));
 
 	for (i = 0, j = 0; i < numof16belem; i++, j += 16) {
+		__m128i xmm0[16], xmm1[16];
+
 		/* Fetch elements in groups of 256 bytes */
-		xmm0[0] = _mm_loadu_si128((__m128i*)(src + (j + 0) * VECTOR_SIZE));
-		xmm0[1] = _mm_loadu_si128((__m128i*)(src + (j + 1) * VECTOR_SIZE));
-		xmm0[2] = _mm_loadu_si128((__m128i*)(src + (j + 2) * VECTOR_SIZE));
-		xmm0[3] = _mm_loadu_si128((__m128i*)(src + (j + 3) * VECTOR_SIZE));
-		xmm0[4] = _mm_loadu_si128((__m128i*)(src + (j + 4) * VECTOR_SIZE));
-		xmm0[5] = _mm_loadu_si128((__m128i*)(src + (j + 5) * VECTOR_SIZE));
-		xmm0[6] = _mm_loadu_si128((__m128i*)(src + (j + 6) * VECTOR_SIZE));
-		xmm0[7] = _mm_loadu_si128((__m128i*)(src + (j + 7) * VECTOR_SIZE));
-		xmm0[8] = _mm_loadu_si128((__m128i*)(src + (j + 8) * VECTOR_SIZE));
-		xmm0[9] = _mm_loadu_si128((__m128i*)(src + (j + 9) * VECTOR_SIZE));
-		xmm0[10] = _mm_loadu_si128((__m128i*)(src + (j + 10) * VECTOR_SIZE));
-		xmm0[11] = _mm_loadu_si128((__m128i*)(src + (j + 11) * VECTOR_SIZE));
-		xmm0[12] = _mm_loadu_si128((__m128i*)(src + (j + 12) * VECTOR_SIZE));
-		xmm0[13] = _mm_loadu_si128((__m128i*)(src + (j + 13) * VECTOR_SIZE));
-		xmm0[14] = _mm_loadu_si128((__m128i*)(src + (j + 14) * VECTOR_SIZE));
-		xmm0[15] = _mm_loadu_si128((__m128i*)(src + (j + 15) * VECTOR_SIZE));
+		xmm0[0] = _mm_loadu_si128(((__m128i*)src) + (j + 0));
+		xmm0[1] = _mm_loadu_si128(((__m128i*)src) + (j + 1));
+		xmm0[2] = _mm_loadu_si128(((__m128i*)src) + (j + 2));
+		xmm0[3] = _mm_loadu_si128(((__m128i*)src) + (j + 3));
+		xmm0[4] = _mm_loadu_si128(((__m128i*)src) + (j + 4));
+		xmm0[5] = _mm_loadu_si128(((__m128i*)src) + (j + 5));
+		xmm0[6] = _mm_loadu_si128(((__m128i*)src) + (j + 6));
+		xmm0[7] = _mm_loadu_si128(((__m128i*)src) + (j + 7));
+		xmm0[8] = _mm_loadu_si128(((__m128i*)src) + (j + 8));
+		xmm0[9] = _mm_loadu_si128(((__m128i*)src) + (j + 9));
+		xmm0[10] = _mm_loadu_si128(((__m128i*)src) + (j + 10));
+		xmm0[11] = _mm_loadu_si128(((__m128i*)src) + (j + 11));
+		xmm0[12] = _mm_loadu_si128(((__m128i*)src) + (j + 12));
+		xmm0[13] = _mm_loadu_si128(((__m128i*)src) + (j + 13));
+		xmm0[14] = _mm_loadu_si128(((__m128i*)src) + (j + 14));
+		xmm0[15] = _mm_loadu_si128(((__m128i*)src) + (j + 15));
 
 		/* Transpose bytes */
 		xmm1[0] = _mm_unpacklo_epi8(xmm0[0], xmm0[1]);
@@ -410,22 +412,182 @@ shuffle16(uint8_t* dest, const uint8_t* src, size_t size)
 		xmm0[15] = _mm_unpackhi_epi64(xmm1[7], xmm1[15]);
 
 		/* Store the result vectors */
-		((__m128i *)dest)[0 * numof16belem + i] = xmm0[0];
-		((__m128i *)dest)[1 * numof16belem + i] = xmm0[1];
-		((__m128i *)dest)[2 * numof16belem + i] = xmm0[2];
-		((__m128i *)dest)[3 * numof16belem + i] = xmm0[3];
-		((__m128i *)dest)[4 * numof16belem + i] = xmm0[4];
-		((__m128i *)dest)[5 * numof16belem + i] = xmm0[5];
-		((__m128i *)dest)[6 * numof16belem + i] = xmm0[6];
-		((__m128i *)dest)[7 * numof16belem + i] = xmm0[7];
-		((__m128i *)dest)[8 * numof16belem + i] = xmm0[8];
-		((__m128i *)dest)[9 * numof16belem + i] = xmm0[9];
-		((__m128i *)dest)[10 * numof16belem + i] = xmm0[10];
-		((__m128i *)dest)[11 * numof16belem + i] = xmm0[11];
-		((__m128i *)dest)[12 * numof16belem + i] = xmm0[12];
-		((__m128i *)dest)[13 * numof16belem + i] = xmm0[13];
-		((__m128i *)dest)[14 * numof16belem + i] = xmm0[14];
-		((__m128i *)dest)[15 * numof16belem + i] = xmm0[15];
+		_mm_storeu_si128(((__m128i*)dest) + (0 * numof16belem + i), xmm0[0]);
+		_mm_storeu_si128(((__m128i*)dest) + (1 * numof16belem + i), xmm0[1]);
+		_mm_storeu_si128(((__m128i*)dest) + (2 * numof16belem + i), xmm0[2]);
+		_mm_storeu_si128(((__m128i*)dest) + (3 * numof16belem + i), xmm0[3]);
+		_mm_storeu_si128(((__m128i*)dest) + (4 * numof16belem + i), xmm0[4]);
+		_mm_storeu_si128(((__m128i*)dest) + (5 * numof16belem + i), xmm0[5]);
+		_mm_storeu_si128(((__m128i*)dest) + (6 * numof16belem + i), xmm0[6]);
+		_mm_storeu_si128(((__m128i*)dest) + (7 * numof16belem + i), xmm0[7]);
+		_mm_storeu_si128(((__m128i*)dest) + (8 * numof16belem + i), xmm0[8]);
+		_mm_storeu_si128(((__m128i*)dest) + (9 * numof16belem + i), xmm0[9]);
+		_mm_storeu_si128(((__m128i*)dest) + (10 * numof16belem + i), xmm0[10]);
+		_mm_storeu_si128(((__m128i*)dest) + (11 * numof16belem + i), xmm0[11]);
+		_mm_storeu_si128(((__m128i*)dest) + (12 * numof16belem + i), xmm0[12]);
+		_mm_storeu_si128(((__m128i*)dest) + (13 * numof16belem + i), xmm0[13]);
+		_mm_storeu_si128(((__m128i*)dest) + (14 * numof16belem + i), xmm0[14]);
+		_mm_storeu_si128(((__m128i*)dest) + (15 * numof16belem + i), xmm0[15]);
+	}
+}
+
+
+/* Routine optimized for shuffling a buffer for a type size larger than 16 bytes. */
+static void
+shuffle_multipart(uint8_t* dest, const uint8_t* src, size_t size, size_t bytesoftype)
+{
+	size_t j;
+	const size_t num_elements = size / bytesoftype;
+	const lldiv_t vecs_per_el = lldiv(bytesoftype, sizeof(__m128i));
+
+	for (j = 0; j < num_elements; j += sizeof(__m128i)) {
+		/* Advance the offset into the type by the vector size (in bytes), unless this is
+		   the initial iteration and the type size is not a multiple of the vector size.
+			 In that case, only advance by the number of bytes necessary so that the number
+			 of remaining bytes in the type will be a multiple of the vector size. */
+		size_t offset_into_type;
+		for (offset_into_type = 0; offset_into_type < bytesoftype;
+			offset_into_type += (offset_into_type == 0 && vecs_per_el.rem > 0 ? vecs_per_el.rem : sizeof(__m128i))) {
+			__m128i xmm0[16], xmm1[16];
+
+			/* Fetch elements in groups of 256 bytes */
+			const uint8_t* const src_with_offset = src + offset_into_type;
+			xmm0[0] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 0) * bytesoftype));
+			xmm0[1] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 1) * bytesoftype));
+			xmm0[2] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 2) * bytesoftype));
+			xmm0[3] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 3) * bytesoftype));
+			xmm0[4] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 4) * bytesoftype));
+			xmm0[5] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 5) * bytesoftype));
+			xmm0[6] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 6) * bytesoftype));
+			xmm0[7] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 7) * bytesoftype));
+			xmm0[8] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 8) * bytesoftype));
+			xmm0[9] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 9) * bytesoftype));
+			xmm0[10] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 10) * bytesoftype));
+			xmm0[11] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 11) * bytesoftype));
+			xmm0[12] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 12) * bytesoftype));
+			xmm0[13] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 13) * bytesoftype));
+			xmm0[14] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 14) * bytesoftype));
+			xmm0[15] = _mm_loadu_si128((__m128i*)(src_with_offset + (j + 15) * bytesoftype));
+
+			/* Transpose bytes */
+			xmm1[0] = _mm_unpacklo_epi8(xmm0[0], xmm0[1]);
+			xmm1[1] = _mm_unpackhi_epi8(xmm0[0], xmm0[1]);
+
+			xmm1[2] = _mm_unpacklo_epi8(xmm0[2], xmm0[3]);
+			xmm1[3] = _mm_unpackhi_epi8(xmm0[2], xmm0[3]);
+
+			xmm1[4] = _mm_unpacklo_epi8(xmm0[4], xmm0[5]);
+			xmm1[5] = _mm_unpackhi_epi8(xmm0[4], xmm0[5]);
+
+			xmm1[6] = _mm_unpacklo_epi8(xmm0[6], xmm0[7]);
+			xmm1[7] = _mm_unpackhi_epi8(xmm0[6], xmm0[7]);
+
+			xmm1[8] = _mm_unpacklo_epi8(xmm0[8], xmm0[9]);
+			xmm1[9] = _mm_unpackhi_epi8(xmm0[8], xmm0[9]);
+
+			xmm1[10] = _mm_unpacklo_epi8(xmm0[10], xmm0[11]);
+			xmm1[11] = _mm_unpackhi_epi8(xmm0[10], xmm0[11]);
+
+			xmm1[12] = _mm_unpacklo_epi8(xmm0[12], xmm0[13]);
+			xmm1[13] = _mm_unpackhi_epi8(xmm0[12], xmm0[13]);
+
+			xmm1[14] = _mm_unpacklo_epi8(xmm0[14], xmm0[15]);
+			xmm1[15] = _mm_unpackhi_epi8(xmm0[14], xmm0[15]);
+
+			/* Transpose words */
+			xmm0[0] = _mm_unpacklo_epi16(xmm1[0], xmm1[2]);
+			xmm0[1] = _mm_unpackhi_epi16(xmm1[0], xmm1[2]);
+
+			xmm0[2] = _mm_unpacklo_epi16(xmm1[1], xmm1[3]);
+			xmm0[3] = _mm_unpackhi_epi16(xmm1[1], xmm1[3]);
+
+			xmm0[4] = _mm_unpacklo_epi16(xmm1[4], xmm1[6]);
+			xmm0[5] = _mm_unpackhi_epi16(xmm1[4], xmm1[6]);
+
+			xmm0[6] = _mm_unpacklo_epi16(xmm1[5], xmm1[7]);
+			xmm0[7] = _mm_unpackhi_epi16(xmm1[5], xmm1[7]);
+
+			xmm0[8] = _mm_unpacklo_epi16(xmm1[8], xmm1[10]);
+			xmm0[9] = _mm_unpackhi_epi16(xmm1[8], xmm1[10]);
+
+			xmm0[10] = _mm_unpacklo_epi16(xmm1[9], xmm1[11]);
+			xmm0[11] = _mm_unpackhi_epi16(xmm1[9], xmm1[11]);
+
+			xmm0[12] = _mm_unpacklo_epi16(xmm1[12], xmm1[14]);
+			xmm0[13] = _mm_unpackhi_epi16(xmm1[12], xmm1[14]);
+
+			xmm0[14] = _mm_unpacklo_epi16(xmm1[13], xmm1[15]);
+			xmm0[15] = _mm_unpackhi_epi16(xmm1[13], xmm1[15]);
+
+			/* Transpose double words */
+			xmm1[0] = _mm_unpacklo_epi32(xmm0[0], xmm0[4]);
+			xmm1[1] = _mm_unpackhi_epi32(xmm0[0], xmm0[4]);
+
+			xmm1[2] = _mm_unpacklo_epi32(xmm0[1], xmm0[5]);
+			xmm1[3] = _mm_unpackhi_epi32(xmm0[1], xmm0[5]);
+
+			xmm1[4] = _mm_unpacklo_epi32(xmm0[2], xmm0[6]);
+			xmm1[5] = _mm_unpackhi_epi32(xmm0[2], xmm0[6]);
+
+			xmm1[6] = _mm_unpacklo_epi32(xmm0[3], xmm0[7]);
+			xmm1[7] = _mm_unpackhi_epi32(xmm0[3], xmm0[7]);
+
+			xmm1[8] = _mm_unpacklo_epi32(xmm0[8], xmm0[12]);
+			xmm1[9] = _mm_unpackhi_epi32(xmm0[8], xmm0[12]);
+
+			xmm1[10] = _mm_unpacklo_epi32(xmm0[9], xmm0[13]);
+			xmm1[11] = _mm_unpackhi_epi32(xmm0[9], xmm0[13]);
+
+			xmm1[12] = _mm_unpacklo_epi32(xmm0[10], xmm0[14]);
+			xmm1[13] = _mm_unpackhi_epi32(xmm0[10], xmm0[14]);
+
+			xmm1[14] = _mm_unpacklo_epi32(xmm0[11], xmm0[15]);
+			xmm1[15] = _mm_unpackhi_epi32(xmm0[11], xmm0[15]);
+
+			/* Transpose quad words */
+			xmm0[0] = _mm_unpacklo_epi64(xmm1[0], xmm1[8]);
+			xmm0[1] = _mm_unpackhi_epi64(xmm1[0], xmm1[8]);
+
+			xmm0[2] = _mm_unpacklo_epi64(xmm1[1], xmm1[9]);
+			xmm0[3] = _mm_unpackhi_epi64(xmm1[1], xmm1[9]);
+
+			xmm0[4] = _mm_unpacklo_epi64(xmm1[2], xmm1[10]);
+			xmm0[5] = _mm_unpackhi_epi64(xmm1[2], xmm1[10]);
+
+			xmm0[6] = _mm_unpacklo_epi64(xmm1[3], xmm1[11]);
+			xmm0[7] = _mm_unpackhi_epi64(xmm1[3], xmm1[11]);
+
+			xmm0[8] = _mm_unpacklo_epi64(xmm1[4], xmm1[12]);
+			xmm0[9] = _mm_unpackhi_epi64(xmm1[4], xmm1[12]);
+
+			xmm0[10] = _mm_unpacklo_epi64(xmm1[5], xmm1[13]);
+			xmm0[11] = _mm_unpackhi_epi64(xmm1[5], xmm1[13]);
+
+			xmm0[12] = _mm_unpacklo_epi64(xmm1[6], xmm1[14]);
+			xmm0[13] = _mm_unpackhi_epi64(xmm1[6], xmm1[14]);
+
+			xmm0[14] = _mm_unpacklo_epi64(xmm1[7], xmm1[15]);
+			xmm0[15] = _mm_unpackhi_epi64(xmm1[7], xmm1[15]);
+
+			/* Store the result vectors */
+			uint8_t* const dest_for_ith_element = dest + j;
+			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 0))), xmm0[0]);
+			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 1))), xmm0[1]);
+			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 2))), xmm0[2]);
+			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 3))), xmm0[3]);
+			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 4))), xmm0[4]);
+			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 5))), xmm0[5]);
+			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 6))), xmm0[6]);
+			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 7))), xmm0[7]);
+			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 8))), xmm0[8]);
+			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 9))), xmm0[9]);
+			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 10))), xmm0[10]);
+			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 11))), xmm0[11]);
+			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 12))), xmm0[12]);
+			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 13))), xmm0[13]);
+			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 14))), xmm0[14]);
+			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 15))), xmm0[15]);
+		}
 	}
 }
 
@@ -433,8 +595,8 @@ shuffle16(uint8_t* dest, const uint8_t* src, size_t size)
 /* Shuffle a block.  This can never fail. */
 void shuffle(size_t bytesoftype, size_t blocksize,
 	const uint8_t* _src, uint8_t* _dest) {
-	int unaligned_dest = (int)((uintptr_t)_dest % 16);
-	int multiple_of_block = (blocksize % (16 * bytesoftype)) == 0;
+	int unaligned_dest = (int)((uintptr_t)_dest % sizeof(__m128i));
+	int multiple_of_block = (blocksize % (sizeof(__m128i) * bytesoftype)) == 0;
 	int too_small = (blocksize < 256);
 
 	if (unaligned_dest || !multiple_of_block || too_small) {
@@ -447,21 +609,30 @@ void shuffle(size_t bytesoftype, size_t blocksize,
 	/* Optimized shuffle */
 	/* The buffer must be aligned on a 16 bytes boundary, have a power */
 	/* of 2 size and be larger or equal than 256 bytes. */
-	if (bytesoftype == 4) {
-		shuffle4(_dest, _src, blocksize);
-	}
-	else if (bytesoftype == 8) {
-		shuffle8(_dest, _src, blocksize);
-	}
-	else if (bytesoftype == 16) {
-		shuffle16(_dest, _src, blocksize);
-	}
-	else if (bytesoftype == 2) {
+	switch (bytesoftype)
+	{
+	case 2:
 		shuffle2(_dest, _src, blocksize);
-	}
-	else {
-		/* Non-optimized shuffle */
-		_shuffle(bytesoftype, blocksize, _src, _dest);
+		break;
+	case 4:
+		shuffle4(_dest, _src, blocksize);
+		break;
+	case 8:
+		shuffle8(_dest, _src, blocksize);
+		break;
+	case 16:
+		shuffle16(_dest, _src, blocksize);
+		break;
+	default:
+		if (bytesoftype > sizeof(__m128i)) {
+			//_shuffle(bytesoftype, blocksize, _src, _dest);
+			shuffle_multipart(_dest, _src, blocksize, bytesoftype);
+		}
+		else {
+			/* Non-optimized shuffle */
+			_shuffle(bytesoftype, blocksize, _src, _dest);
+		}
+		break;
 	}
 }
 
@@ -471,10 +642,11 @@ static void
 unshuffle2(uint8_t* dest, const uint8_t* orig, size_t size)
 {
 	size_t i, j;
-	const size_t numof16belem = size / (2 * VECTOR_SIZE);
-	__m128i xmm1[2], xmm2[2];
+	const size_t numof16belem = size / (2 * sizeof(__m128i));
 
 	for (i = 0, j = 0; i < numof16belem; i++, j += 2) {
+		__m128i xmm1[2], xmm2[2];
+
 		/* Load the first 32 bytes in 2 XMM registers */
 		xmm1[0] = ((__m128i *)orig)[0 * numof16belem + i];
 		xmm1[1] = ((__m128i *)orig)[1 * numof16belem + i];
@@ -495,10 +667,11 @@ static void
 unshuffle4(uint8_t* dest, const uint8_t* orig, size_t size)
 {
 	size_t i, j;
-	const size_t numof16belem = size / (4 * VECTOR_SIZE);
-	__m128i xmm0[4], xmm1[4];
+	const size_t numof16belem = size / (4 * sizeof(__m128i));
 
 	for (i = 0, j = 0; i < numof16belem; i++, j += 4) {
+		__m128i xmm0[4], xmm1[4];
+
 		/* Load the first 64 bytes in 4 XMM registers */
 		xmm0[0] = ((__m128i *)orig)[0*numof16belem + i];
 		xmm0[1] = ((__m128i *)orig)[1*numof16belem + i];
@@ -533,10 +706,11 @@ static void
 unshuffle8(uint8_t* dest, const uint8_t* orig, size_t size)
 {
 	size_t i, j;
-	const size_t numof16belem = size / (8 * VECTOR_SIZE);
-	__m128i xmm0[8], xmm1[8];
+	const size_t numof16belem = size / (8 * sizeof(__m128i));
 
 	for (i = 0, j = 0; i < numof16belem; i++, j += 8) {
+		__m128i xmm0[8], xmm1[8];
+
 		/* Load the first 64 bytes in 8 XMM registers */
 		xmm0[0] = ((__m128i *)orig)[0*numof16belem + i];
 		xmm0[1] = ((__m128i *)orig)[1*numof16belem + i];
@@ -604,10 +778,11 @@ static void
 unshuffle16(uint8_t* dest, const uint8_t* orig, size_t size)
 {
 	size_t i, j;
-	const size_t numof16belem = size / (16 * VECTOR_SIZE);
-	__m128i xmm1[16], xmm2[16];
+	const size_t numof16belem = size / (16 * sizeof(__m128i));
 
 	for (i = 0, j = 0; i < numof16belem; i++, j += 16) {
+		__m128i xmm1[16], xmm2[16];
+
 		/* Load the first 128 bytes in 16 XMM registers */
 		xmm1[0] = ((__m128i *)orig)[0*numof16belem + i];
 		xmm1[1] = ((__m128i *)orig)[1*numof16belem + i];

--- a/blosc/shuffle.c
+++ b/blosc/shuffle.c
@@ -86,7 +86,7 @@ shuffle2(uint8_t* dest, const uint8_t* src, size_t size)
 {
 	size_t i, j;
 	const size_t numof16belem = size / (2 * sizeof(__m128i));
-	
+
 
 	for (i = 0, j = 0; i < numof16belem; i++, j += 2) {
 		__m128i xmm0[2], xmm1[2];
@@ -132,7 +132,7 @@ shuffle4(uint8_t* dest, const uint8_t* src, size_t size)
 {
 	size_t i, j;
 	const size_t numof16belem = size / (4 * sizeof(__m128i));
-	
+
 	for (i = 0, j = 0; i < numof16belem; i++, j += 4) {
 		__m128i xmm0[4], xmm1[4];
 
@@ -442,9 +442,9 @@ shuffle_multipart(uint8_t* dest, const uint8_t* src, size_t size, size_t bytesof
 
 	for (j = 0; j < num_elements; j += sizeof(__m128i)) {
 		/* Advance the offset into the type by the vector size (in bytes), unless this is
-		   the initial iteration and the type size is not a multiple of the vector size.
-			 In that case, only advance by the number of bytes necessary so that the number
-			 of remaining bytes in the type will be a multiple of the vector size. */
+		the initial iteration and the type size is not a multiple of the vector size.
+		In that case, only advance by the number of bytes necessary so that the number
+		of remaining bytes in the type will be a multiple of the vector size. */
 		size_t offset_into_type;
 		for (offset_into_type = 0; offset_into_type < bytesoftype;
 			offset_into_type += (offset_into_type == 0 && vecs_per_el.rem > 0 ? vecs_per_el.rem : sizeof(__m128i))) {
@@ -570,23 +570,23 @@ shuffle_multipart(uint8_t* dest, const uint8_t* src, size_t size, size_t bytesof
 			xmm0[15] = _mm_unpackhi_epi64(xmm1[7], xmm1[15]);
 
 			/* Store the result vectors */
-			uint8_t* const dest_for_ith_element = dest + j;
-			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 0))), xmm0[0]);
-			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 1))), xmm0[1]);
-			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 2))), xmm0[2]);
-			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 3))), xmm0[3]);
-			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 4))), xmm0[4]);
-			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 5))), xmm0[5]);
-			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 6))), xmm0[6]);
-			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 7))), xmm0[7]);
-			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 8))), xmm0[8]);
-			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 9))), xmm0[9]);
-			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 10))), xmm0[10]);
-			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 11))), xmm0[11]);
-			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 12))), xmm0[12]);
-			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 13))), xmm0[13]);
-			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 14))), xmm0[14]);
-			_mm_storeu_si128((__m128i*)(dest_for_ith_element + (num_elements * (offset_into_type + 15))), xmm0[15]);
+			uint8_t* const dest_for_jth_element = dest + j;
+			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 0))), xmm0[0]);
+			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 1))), xmm0[1]);
+			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 2))), xmm0[2]);
+			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 3))), xmm0[3]);
+			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 4))), xmm0[4]);
+			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 5))), xmm0[5]);
+			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 6))), xmm0[6]);
+			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 7))), xmm0[7]);
+			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 8))), xmm0[8]);
+			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 9))), xmm0[9]);
+			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 10))), xmm0[10]);
+			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 11))), xmm0[11]);
+			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 12))), xmm0[12]);
+			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 13))), xmm0[13]);
+			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 14))), xmm0[14]);
+			_mm_storeu_si128((__m128i*)(dest_for_jth_element + (num_elements * (offset_into_type + 15))), xmm0[15]);
 		}
 	}
 }
@@ -625,7 +625,6 @@ void shuffle(size_t bytesoftype, size_t blocksize,
 		break;
 	default:
 		if (bytesoftype > sizeof(__m128i)) {
-			//_shuffle(bytesoftype, blocksize, _src, _dest);
 			shuffle_multipart(_dest, _src, blocksize, bytesoftype);
 		}
 		else {
@@ -673,10 +672,10 @@ unshuffle4(uint8_t* dest, const uint8_t* orig, size_t size)
 		__m128i xmm0[4], xmm1[4];
 
 		/* Load the first 64 bytes in 4 XMM registers */
-		xmm0[0] = ((__m128i *)orig)[0*numof16belem + i];
-		xmm0[1] = ((__m128i *)orig)[1*numof16belem + i];
-		xmm0[2] = ((__m128i *)orig)[2*numof16belem + i];
-		xmm0[3] = ((__m128i *)orig)[3*numof16belem + i];
+		xmm0[0] = ((__m128i *)orig)[0 * numof16belem + i];
+		xmm0[1] = ((__m128i *)orig)[1 * numof16belem + i];
+		xmm0[2] = ((__m128i *)orig)[2 * numof16belem + i];
+		xmm0[3] = ((__m128i *)orig)[3 * numof16belem + i];
 
 		/* Unshuffle bytes */
 		xmm1[0] = _mm_unpacklo_epi8(xmm0[0], xmm0[1]);
@@ -712,14 +711,14 @@ unshuffle8(uint8_t* dest, const uint8_t* orig, size_t size)
 		__m128i xmm0[8], xmm1[8];
 
 		/* Load the first 64 bytes in 8 XMM registers */
-		xmm0[0] = ((__m128i *)orig)[0*numof16belem + i];
-		xmm0[1] = ((__m128i *)orig)[1*numof16belem + i];
-		xmm0[2] = ((__m128i *)orig)[2*numof16belem + i];
-		xmm0[3] = ((__m128i *)orig)[3*numof16belem + i];
-		xmm0[4] = ((__m128i *)orig)[4*numof16belem + i];
-		xmm0[5] = ((__m128i *)orig)[5*numof16belem + i];
-		xmm0[6] = ((__m128i *)orig)[6*numof16belem + i];
-		xmm0[7] = ((__m128i *)orig)[7*numof16belem + i];
+		xmm0[0] = ((__m128i *)orig)[0 * numof16belem + i];
+		xmm0[1] = ((__m128i *)orig)[1 * numof16belem + i];
+		xmm0[2] = ((__m128i *)orig)[2 * numof16belem + i];
+		xmm0[3] = ((__m128i *)orig)[3 * numof16belem + i];
+		xmm0[4] = ((__m128i *)orig)[4 * numof16belem + i];
+		xmm0[5] = ((__m128i *)orig)[5 * numof16belem + i];
+		xmm0[6] = ((__m128i *)orig)[6 * numof16belem + i];
+		xmm0[7] = ((__m128i *)orig)[7 * numof16belem + i];
 
 		/* Unshuffle bytes */
 		xmm1[0] = _mm_unpacklo_epi8(xmm0[0], xmm0[1]);
@@ -784,22 +783,22 @@ unshuffle16(uint8_t* dest, const uint8_t* orig, size_t size)
 		__m128i xmm1[16], xmm2[16];
 
 		/* Load the first 128 bytes in 16 XMM registers */
-		xmm1[0] = ((__m128i *)orig)[0*numof16belem + i];
-		xmm1[1] = ((__m128i *)orig)[1*numof16belem + i];
-		xmm1[2] = ((__m128i *)orig)[2*numof16belem + i];
-		xmm1[3] = ((__m128i *)orig)[3*numof16belem + i];
-		xmm1[4] = ((__m128i *)orig)[4*numof16belem + i];
-		xmm1[5] = ((__m128i *)orig)[5*numof16belem + i];
-		xmm1[6] = ((__m128i *)orig)[6*numof16belem + i];
-		xmm1[7] = ((__m128i *)orig)[7*numof16belem + i];
-		xmm1[8] = ((__m128i *)orig)[8*numof16belem + i];
-		xmm1[9] = ((__m128i *)orig)[9*numof16belem + i];
-		xmm1[10] = ((__m128i *)orig)[10*numof16belem + i];
-		xmm1[11] = ((__m128i *)orig)[11*numof16belem + i];
-		xmm1[12] = ((__m128i *)orig)[12*numof16belem + i];
-		xmm1[13] = ((__m128i *)orig)[13*numof16belem + i];
-		xmm1[14] = ((__m128i *)orig)[14*numof16belem + i];
-		xmm1[15] = ((__m128i *)orig)[15*numof16belem + i];
+		xmm1[0] = ((__m128i *)orig)[0 * numof16belem + i];
+		xmm1[1] = ((__m128i *)orig)[1 * numof16belem + i];
+		xmm1[2] = ((__m128i *)orig)[2 * numof16belem + i];
+		xmm1[3] = ((__m128i *)orig)[3 * numof16belem + i];
+		xmm1[4] = ((__m128i *)orig)[4 * numof16belem + i];
+		xmm1[5] = ((__m128i *)orig)[5 * numof16belem + i];
+		xmm1[6] = ((__m128i *)orig)[6 * numof16belem + i];
+		xmm1[7] = ((__m128i *)orig)[7 * numof16belem + i];
+		xmm1[8] = ((__m128i *)orig)[8 * numof16belem + i];
+		xmm1[9] = ((__m128i *)orig)[9 * numof16belem + i];
+		xmm1[10] = ((__m128i *)orig)[10 * numof16belem + i];
+		xmm1[11] = ((__m128i *)orig)[11 * numof16belem + i];
+		xmm1[12] = ((__m128i *)orig)[12 * numof16belem + i];
+		xmm1[13] = ((__m128i *)orig)[13 * numof16belem + i];
+		xmm1[14] = ((__m128i *)orig)[14 * numof16belem + i];
+		xmm1[15] = ((__m128i *)orig)[15 * numof16belem + i];
 
 		/* Unshuffle bytes */
 		xmm2[0] = _mm_unpacklo_epi8(xmm1[0], xmm1[1]);
@@ -922,12 +921,169 @@ unshuffle16(uint8_t* dest, const uint8_t* orig, size_t size)
 }
 
 
+/* Routine optimized for unshuffling a buffer for a type size larger than 16 bytes. */
+static void
+unshuffle_multipart(uint8_t* dest, const uint8_t* orig, size_t size, size_t bytesoftype)
+{
+	const size_t num_elements = size / bytesoftype;
+	const lldiv_t vecs_per_el = lldiv(bytesoftype, sizeof(__m128i));
+
+	/* The unshuffle loops are inverted (compared to shuffle_multipart)
+		 to optimize cache utilization. */
+	size_t offset_into_type;
+	for (offset_into_type = 0; offset_into_type < bytesoftype;
+		offset_into_type += (offset_into_type == 0 && vecs_per_el.rem > 0 ? vecs_per_el.rem : sizeof(__m128i))) {
+		size_t j;
+		for (j = 0; j < num_elements; j += sizeof(__m128i)) {
+			__m128i xmm1[16], xmm2[16];
+
+			/* Load the first 128 bytes in 16 XMM registers */
+			uint8_t* const src_for_jth_element = orig + j;
+			xmm1[0] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 0))));
+			xmm1[1] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 1))));
+			xmm1[2] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 2))));
+			xmm1[3] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 3))));
+			xmm1[4] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 4))));
+			xmm1[5] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 5))));
+			xmm1[6] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 6))));
+			xmm1[7] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 7))));
+			xmm1[8] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 8))));
+			xmm1[9] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 9))));
+			xmm1[10] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 10))));
+			xmm1[11] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 11))));
+			xmm1[12] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 12))));
+			xmm1[13] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 13))));
+			xmm1[14] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 14))));
+			xmm1[15] = _mm_loadu_si128((__m128i*)(src_for_jth_element + (num_elements * (offset_into_type + 15))));
+
+			/* Unshuffle bytes */
+			xmm2[0] = _mm_unpacklo_epi8(xmm1[0], xmm1[1]);
+			xmm2[8] = _mm_unpackhi_epi8(xmm1[0], xmm1[1]);
+
+			xmm2[1] = _mm_unpacklo_epi8(xmm1[2], xmm1[3]);
+			xmm2[9] = _mm_unpackhi_epi8(xmm1[2], xmm1[3]);
+
+			xmm2[2] = _mm_unpacklo_epi8(xmm1[4], xmm1[5]);
+			xmm2[10] = _mm_unpackhi_epi8(xmm1[4], xmm1[5]);
+
+			xmm2[3] = _mm_unpacklo_epi8(xmm1[6], xmm1[7]);
+			xmm2[11] = _mm_unpackhi_epi8(xmm1[6], xmm1[7]);
+
+			xmm2[4] = _mm_unpacklo_epi8(xmm1[8], xmm1[9]);
+			xmm2[12] = _mm_unpackhi_epi8(xmm1[8], xmm1[9]);
+
+			xmm2[5] = _mm_unpacklo_epi8(xmm1[10], xmm1[11]);
+			xmm2[13] = _mm_unpackhi_epi8(xmm1[10], xmm1[11]);
+
+			xmm2[6] = _mm_unpacklo_epi8(xmm1[12], xmm1[13]);
+			xmm2[14] = _mm_unpackhi_epi8(xmm1[12], xmm1[13]);
+
+			xmm2[7] = _mm_unpacklo_epi8(xmm1[14], xmm1[15]);
+			xmm2[15] = _mm_unpackhi_epi8(xmm1[14], xmm1[15]);
+
+			/* Unshuffle 2-byte words */
+			xmm1[0] = _mm_unpacklo_epi16(xmm2[0], xmm2[1]);
+			xmm1[8] = _mm_unpackhi_epi16(xmm2[0], xmm2[1]);
+
+			xmm1[1] = _mm_unpacklo_epi16(xmm2[2], xmm2[3]);
+			xmm1[9] = _mm_unpackhi_epi16(xmm2[2], xmm2[3]);
+
+			xmm1[2] = _mm_unpacklo_epi16(xmm2[4], xmm2[5]);
+			xmm1[10] = _mm_unpackhi_epi16(xmm2[4], xmm2[5]);
+
+			xmm1[3] = _mm_unpacklo_epi16(xmm2[6], xmm2[7]);
+			xmm1[11] = _mm_unpackhi_epi16(xmm2[6], xmm2[7]);
+
+			xmm1[4] = _mm_unpacklo_epi16(xmm2[8], xmm2[9]);
+			xmm1[12] = _mm_unpackhi_epi16(xmm2[8], xmm2[9]);
+
+			xmm1[5] = _mm_unpacklo_epi16(xmm2[10], xmm2[11]);
+			xmm1[13] = _mm_unpackhi_epi16(xmm2[10], xmm2[11]);
+
+			xmm1[6] = _mm_unpacklo_epi16(xmm2[12], xmm2[13]);
+			xmm1[14] = _mm_unpackhi_epi16(xmm2[12], xmm2[13]);
+
+			xmm1[7] = _mm_unpacklo_epi16(xmm2[14], xmm2[15]);
+			xmm1[15] = _mm_unpackhi_epi16(xmm2[14], xmm2[15]);
+
+			/* Unshuffle 4-byte dwords */
+			xmm2[0] = _mm_unpacklo_epi32(xmm1[0], xmm1[1]);
+			xmm2[8] = _mm_unpackhi_epi32(xmm1[0], xmm1[1]);
+
+			xmm2[1] = _mm_unpacklo_epi32(xmm1[2], xmm1[3]);
+			xmm2[9] = _mm_unpackhi_epi32(xmm1[2], xmm1[3]);
+
+			xmm2[2] = _mm_unpacklo_epi32(xmm1[4], xmm1[5]);
+			xmm2[10] = _mm_unpackhi_epi32(xmm1[4], xmm1[5]);
+
+			xmm2[3] = _mm_unpacklo_epi32(xmm1[6], xmm1[7]);
+			xmm2[11] = _mm_unpackhi_epi32(xmm1[6], xmm1[7]);
+
+			xmm2[4] = _mm_unpacklo_epi32(xmm1[8], xmm1[9]);
+			xmm2[12] = _mm_unpackhi_epi32(xmm1[8], xmm1[9]);
+
+			xmm2[5] = _mm_unpacklo_epi32(xmm1[10], xmm1[11]);
+			xmm2[13] = _mm_unpackhi_epi32(xmm1[10], xmm1[11]);
+
+			xmm2[6] = _mm_unpacklo_epi32(xmm1[12], xmm1[13]);
+			xmm2[14] = _mm_unpackhi_epi32(xmm1[12], xmm1[13]);
+
+			xmm2[7] = _mm_unpacklo_epi32(xmm1[14], xmm1[15]);
+			xmm2[15] = _mm_unpackhi_epi32(xmm1[14], xmm1[15]);
+
+			/* Unshuffle 8-byte qwords */
+			xmm1[0] = _mm_unpacklo_epi64(xmm2[0], xmm2[1]);
+			xmm1[8] = _mm_unpackhi_epi64(xmm2[0], xmm2[1]);
+
+			xmm1[1] = _mm_unpacklo_epi64(xmm2[2], xmm2[3]);
+			xmm1[9] = _mm_unpackhi_epi64(xmm2[2], xmm2[3]);
+
+			xmm1[2] = _mm_unpacklo_epi64(xmm2[4], xmm2[5]);
+			xmm1[10] = _mm_unpackhi_epi64(xmm2[4], xmm2[5]);
+
+			xmm1[3] = _mm_unpacklo_epi64(xmm2[6], xmm2[7]);
+			xmm1[11] = _mm_unpackhi_epi64(xmm2[6], xmm2[7]);
+
+			xmm1[4] = _mm_unpacklo_epi64(xmm2[8], xmm2[9]);
+			xmm1[12] = _mm_unpackhi_epi64(xmm2[8], xmm2[9]);
+
+			xmm1[5] = _mm_unpacklo_epi64(xmm2[10], xmm2[11]);
+			xmm1[13] = _mm_unpackhi_epi64(xmm2[10], xmm2[11]);
+
+			xmm1[6] = _mm_unpacklo_epi64(xmm2[12], xmm2[13]);
+			xmm1[14] = _mm_unpackhi_epi64(xmm2[12], xmm2[13]);
+
+			xmm1[7] = _mm_unpacklo_epi64(xmm2[14], xmm2[15]);
+			xmm1[15] = _mm_unpackhi_epi64(xmm2[14], xmm2[15]);
+
+			/* Store the result vectors in proper order */
+			const uint8_t* const dest_with_offset = dest + offset_into_type;
+			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 0) * bytesoftype), xmm1[0]);
+			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 1) * bytesoftype), xmm1[8]);
+			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 2) * bytesoftype), xmm1[4]);
+			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 3) * bytesoftype), xmm1[12]);
+			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 4) * bytesoftype), xmm1[2]);
+			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 5) * bytesoftype), xmm1[10]);
+			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 6) * bytesoftype), xmm1[6]);
+			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 7) * bytesoftype), xmm1[14]);
+			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 8) * bytesoftype), xmm1[1]);
+			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 9) * bytesoftype), xmm1[9]);
+			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 10) * bytesoftype), xmm1[5]);
+			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 11) * bytesoftype), xmm1[13]);
+			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 12) * bytesoftype), xmm1[3]);
+			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 13) * bytesoftype), xmm1[11]);
+			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 14) * bytesoftype), xmm1[7]);
+			_mm_storeu_si128((__m128i*)(dest_with_offset + (j + 15) * bytesoftype), xmm1[15]);
+		}
+	}
+}
+
 /* Unshuffle a block.  This can never fail. */
 void unshuffle(size_t bytesoftype, size_t blocksize,
 	const uint8_t* _src, uint8_t* _dest) {
-	int unaligned_src = (int)((uintptr_t)_src % 16);
-	int unaligned_dest = (int)((uintptr_t)_dest % 16);
-	int multiple_of_block = (blocksize % (16 * bytesoftype)) == 0;
+	int unaligned_src = (int)((uintptr_t)_src % sizeof(__m128i));
+	int unaligned_dest = (int)((uintptr_t)_dest % sizeof(__m128i));
+	int multiple_of_block = (blocksize % (sizeof(__m128i) * bytesoftype)) == 0;
 	int too_small = (blocksize < 256);
 
 	if (unaligned_src || unaligned_dest || !multiple_of_block || too_small) {
@@ -940,21 +1096,29 @@ void unshuffle(size_t bytesoftype, size_t blocksize,
 	/* Optimized unshuffle */
 	/* The buffers must be aligned on a 16 bytes boundary, have a power */
 	/* of 2 size and be larger or equal than 256 bytes. */
-	if (bytesoftype == 4) {
-		unshuffle4(_dest, _src, blocksize);
-	}
-	else if (bytesoftype == 8) {
-		unshuffle8(_dest, _src, blocksize);
-	}
-	else if (bytesoftype == 16) {
-		unshuffle16(_dest, _src, blocksize);
-	}
-	else if (bytesoftype == 2) {
+	switch (bytesoftype)
+	{
+	case 2:
 		unshuffle2(_dest, _src, blocksize);
-	}
-	else {
-		/* Non-optimized unshuffle */
-		_unshuffle(bytesoftype, blocksize, _src, _dest);
+		break;
+	case 4:
+		unshuffle4(_dest, _src, blocksize);
+		break;
+	case 8:
+		unshuffle8(_dest, _src, blocksize);
+		break;
+	case 16:
+		unshuffle16(_dest, _src, blocksize);
+		break;
+	default:
+		if (bytesoftype > sizeof(__m128i)) {
+			unshuffle_multipart(_dest, _src, blocksize, bytesoftype);
+		}
+		else {
+			/* Non-optimized unshuffle */
+			_unshuffle(bytesoftype, blocksize, _src, _dest);
+		}
+		break;
 	}
 }
 


### PR DESCRIPTION
I've implemented SSE2-accelerated shuffle/unshuffle functions which can be used when the type size is larger than the SSE2 vector type (i.e., >16 bytes).

I've also hand-unrolled all of the small inner loops within the existing shuffle/unshuffle routines (for 2/4/8/16-byte types). This could have been done by some compilers already (in theory, at least), but I ran a baseline benchmark, then benched again with the change and the performance improved noticeably. I've included the results below for comparison.

Baseline:

```
Blosc version: 1.5.3.dev ($Date:: 2014-12-30 #$)
List of supported compressors in this build: blosclz,lz4,lz4hc,zlib
Supported compression libraries:
  BloscLZ: 1.0.3
  LZ4: 1.5.0
  Snappy: unknown
  Zlib: 1.2.8
Using compressor: blosclz
Running suite: suite


--> 1, 536870912, 16, 19, blosclz, 1
********************** Run info ******************************
Blosc version: 1.5.3.dev ($Date:: 2014-12-30 #$)
Number of threads: 1
Using synthetic data with 19 significant bits (out of 32)
Working set: 512.0 MB
Dataset size: 536870912 bytes
Type size: 16 bytes
Element Count: 33554432
********************** Running benchmarks *********************
memcpy(write):		 47219.8 us, 10842.9 MB/s
memcpy(read):		 88055.2 us, 5814.5 MB/s
Compression level: 0
comp(write):	 58532.1 us, 8747.3 MB/s	  Final bytes: 536870928  Ratio: 1.00
decomp(read):	 50988.6 us, 10041.5 MB/s	  OK
Compression level: 1
comp(write):	 214390.2 us, 2388.2 MB/s	  Final bytes: 77791248  Ratio: 6.90
decomp(read):	 108376.0 us, 4724.3 MB/s	  OK
Compression level: 2
comp(write):	 230685.9 us, 2219.5 MB/s	  Final bytes: 45645840  Ratio: 11.76
decomp(read):	 118848.3 us, 4308.0 MB/s	  OK
Compression level: 3
comp(write):	 236344.4 us, 2166.3 MB/s	  Final bytes: 45645840  Ratio: 11.76
decomp(read):	 118475.5 us, 4321.6 MB/s	  OK
Compression level: 4
comp(write):	 270834.0 us, 1890.5 MB/s	  Final bytes: 40583184  Ratio: 13.23
decomp(read):	 119848.0 us, 4272.1 MB/s	  OK
Compression level: 5
comp(write):	 297610.6 us, 1720.4 MB/s	  Final bytes: 40583184  Ratio: 13.23
decomp(read):	 119642.9 us, 4279.4 MB/s	  OK
Compression level: 6
comp(write):	 308840.5 us, 1657.8 MB/s	  Final bytes: 23207952  Ratio: 23.13
decomp(read):	 142526.7 us, 3592.3 MB/s	  OK
Compression level: 7
comp(write):	 282981.9 us, 1809.3 MB/s	  Final bytes: 19865616  Ratio: 27.03
decomp(read):	 148218.5 us, 3454.4 MB/s	  OK
Compression level: 8
comp(write):	 281059.1 us, 1821.7 MB/s	  Final bytes: 19865616  Ratio: 27.03
decomp(read):	 148182.3 us, 3455.2 MB/s	  OK
Compression level: 9
comp(write):	 282498.8 us, 1812.4 MB/s	  Final bytes: 16814096  Ratio: 31.93
decomp(read):	 151238.2 us, 3385.4 MB/s	  OK

Round-trip compr/decompr on 15.0 GB
Elapsed time:	   12.6 s, 2678.3 MB/s
```

After applying this PR:

```
Blosc version: 1.5.3.dev ($Date:: 2014-12-30 #$)
List of supported compressors in this build: blosclz,lz4,lz4hc,zlib
Supported compression libraries:
  BloscLZ: 1.0.3
  LZ4: 1.5.0
  Snappy: unknown
  Zlib: 1.2.8
Using compressor: blosclz
Running suite: suite


--> 1, 536870912, 16, 19, blosclz, 1
********************** Run info ******************************
Blosc version: 1.5.3.dev ($Date:: 2014-12-30 #$)
Number of threads: 1
Using synthetic data with 19 significant bits (out of 32)
Working set: 512.0 MB
Dataset size: 536870912 bytes
Type size: 16 bytes
Element Count: 33554432
********************** Running benchmarks *********************
memcpy(write):		 47802.6 us, 10710.7 MB/s
memcpy(read):		 79542.9 us, 6436.8 MB/s
Compression level: 0
comp(write):	 58640.4 us, 8731.2 MB/s	  Final bytes: 536870928  Ratio: 1.00
decomp(read):	 50753.0 us, 10088.1 MB/s	  OK
Compression level: 1
comp(write):	 164283.9 us, 3116.6 MB/s	  Final bytes: 77791248  Ratio: 6.90
decomp(read):	 97233.7 us, 5265.7 MB/s	  OK
Compression level: 2
comp(write):	 178714.5 us, 2864.9 MB/s	  Final bytes: 45645840  Ratio: 11.76
decomp(read):	 107850.6 us, 4747.3 MB/s	  OK
Compression level: 3
comp(write):	 184140.8 us, 2780.5 MB/s	  Final bytes: 45645840  Ratio: 11.76
decomp(read):	 107683.2 us, 4754.7 MB/s	  OK
Compression level: 4
comp(write):	 226673.0 us, 2258.8 MB/s	  Final bytes: 40583184  Ratio: 13.23
decomp(read):	 107106.9 us, 4780.3 MB/s	  OK
Compression level: 5
comp(write):	 255675.8 us, 2002.5 MB/s	  Final bytes: 40583184  Ratio: 13.23
decomp(read):	 107019.9 us, 4784.2 MB/s	  OK
Compression level: 6
comp(write):	 281721.3 us, 1817.4 MB/s	  Final bytes: 23207952  Ratio: 23.13
decomp(read):	 127463.4 us, 4016.8 MB/s	  OK
Compression level: 7
comp(write):	 253457.5 us, 2020.1 MB/s	  Final bytes: 19865616  Ratio: 27.03
decomp(read):	 131386.4 us, 3896.9 MB/s	  OK
Compression level: 8
comp(write):	 254045.5 us, 2015.4 MB/s	  Final bytes: 19865616  Ratio: 27.03
decomp(read):	 132194.2 us, 3873.1 MB/s	  OK
Compression level: 9
comp(write):	 257042.1 us, 1991.9 MB/s	  Final bytes: 16814096  Ratio: 31.93
decomp(read):	 136268.1 us, 3757.3 MB/s	  OK

Round-trip compr/decompr on 15.0 GB
Elapsed time:	   11.1 s, 3031.7 MB/s
```