### PR TITLE
Fix resource leak in t_blosc

### DIFF
--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -1391,7 +1391,7 @@ static void *t_blosc(void *ctxt)
 
     if(context->parent_context->end_threads)
     {
-      return(NULL);
+      break;
     }
 
     /* Get parameters for this thread before entering the main loop */


### PR DESCRIPTION
This PR fixes a resource leak in the ``t_blosc`` function. On line 1394, the current code returns immediately once it detects the worker loop should be terminated. However, this means that it doesn't execute the cleanup code to release allocated resources after the while loop.

The modification in this PR causes execution to ``break`` out of the loop instead of returning, so the cleanup code is executed as expected.