### PR TITLE
Implemented high-precision timing for the blosc benchmark tool

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -4,6 +4,9 @@ set(SOURCES bench.c)
 
 # targets
 add_executable(bench ${SOURCES})
+if(UNIX)
+  target_link_libraries(bench LINK_PRIVATE rt)
+endif(UNIX)
 target_link_libraries(bench blosc_shared)
 
 # have to copy blosc dlls for Visual Studio

--- a/bench/bench.c
+++ b/bench/bench.c
@@ -24,12 +24,18 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #if defined(_WIN32) && !defined(__MINGW32__)
-  #include <time.h>
-#else
+  /* For QueryPerformanceCounter(), etc. */
+  #include <windows.h>
+#elif defined(__unix__)
   #include <unistd.h>
-  #include <sys/time.h>
+  #if defined(__linux__)
+    #include <time.h>
+  #else
+    #include <sys/time.h>
+  #endif
+#else
+  #error Unable to detect platform.
 #endif
-#include <math.h>
 
 
 struct bench_wrap_args
@@ -58,78 +64,66 @@ int nchunks = NCHUNKS;
 int niter = 3;                  /* default number of iterations */
 double totalsize = 0.;          /* total compressed/decompressed size */
 
+/* System-specific high-precision timing functions. */
 #if defined(_WIN32) && !defined(__MINGW32__)
-#include <windows.h>
-#include <malloc.h>
-#if defined(_MSC_VER) || defined(_MSC_EXTENSIONS)
-  #define DELTA_EPOCH_IN_MICROSECS  11644473600000000Ui64
+
+/* The type of timestamp used on this system. */
+#define blosc_timestamp_t LARGE_INTEGER
+
+/* Set a timestamp value to the current time. */
+void blosc_set_timestamp(blosc_timestamp_t* timestamp) {
+  /* Ignore the return value, assume the call always succeeds. */
+  QueryPerformanceCounter(timestamp);
+}
+
+/* Given two timestamp values, return the difference in microseconds. */
+double blosc_elapsed_usecs(blosc_timestamp_t start_time, blosc_timestamp_t end_time) {
+  LARGE_INTEGER CounterFreq;
+  QueryPerformanceFrequency(&CounterFreq);
+
+  return (double)(end_time.QuadPart - start_time.QuadPart) / ((double)CounterFreq.QuadPart / 1e6);
+}
+
 #else
-  #define DELTA_EPOCH_IN_MICROSECS  11644473600000000ULL
+
+/* The type of timestamp used on this system. */
+#define blosc_timestamp_t struct timespec
+
+/* Set a timestamp value to the current time. */
+void blosc_set_timestamp(blosc_timestamp_t* timestamp) {
+  clock_gettime(CLOCK_MONOTONIC, timestamp);
+}
+
+/* Given two timestamp values, return the difference in microseconds. */
+double blosc_elapsed_usecs(blosc_timestamp_t start_time, blosc_timestamp_t end_time) {
+	return (1e6 * (end_time.tv_sec - start_time.tv_sec))
+		+ (1e-3 * (end_time.tv_nsec - start_time.tv_nsec));
+}
+
 #endif
 
-struct timezone
-{
-  int  tz_minuteswest; /* minutes W of Greenwich */
-  int  tz_dsttime;     /* type of dst correction */
-};
-
-int gettimeofday(struct timeval *tv, struct timezone *tz)
-{
-  FILETIME ft;
-  unsigned __int64 tmpres = 0;
-  static int tzflag;
-
-  if (NULL != tv)
-  {
-    GetSystemTimeAsFileTime(&ft);
-
-    tmpres |= ft.dwHighDateTime;
-    tmpres <<= 32;
-    tmpres |= ft.dwLowDateTime;
-
-    /*converting file time to unix epoch*/
-    tmpres -= DELTA_EPOCH_IN_MICROSECS;
-    tmpres /= 10;  /*convert into microseconds*/
-    tv->tv_sec = (long)(tmpres / 1000000UL);
-    tv->tv_usec = (long)(tmpres % 1000000UL);
-  }
-
-  if (NULL != tz)
-  {
-    if (!tzflag)
-    {
-      _tzset();
-      tzflag++;
-    }
-    tz->tz_minuteswest = _timezone / 60;
-    tz->tz_dsttime = _daylight;
-  }
-
-  return 0;
+/* Given two timeval stamps, return the difference in seconds */
+double getseconds(blosc_timestamp_t last, blosc_timestamp_t current) {
+  return 1e-6 * blosc_elapsed_usecs(last, current);
 }
+
+/* Given two timeval stamps, return the time per chunk in usec */
+double get_usec_chunk(blosc_timestamp_t last, blosc_timestamp_t current, int niter, size_t nchunks) {
+  double elapsed_usecs = (double)blosc_elapsed_usecs(last, current);
+  return elapsed_usecs / (double)(niter * nchunks);
+}
+
+/* Define posix_memalign for Windows */
+#if defined(_WIN32) && !defined(__MINGW32__)
+#include <malloc.h>
 
 int posix_memalign(void **memptr, size_t alignment, size_t size)
 {
 	*memptr = _aligned_malloc(size, alignment);
 	return 0;
 }
-#endif   /* _WIN32 */
 
-
-/* Given two timeval stamps, return the difference in seconds */
-float getseconds(struct timeval last, struct timeval current) {
-  int sec, usec;
-
-  sec = current.tv_sec - last.tv_sec;
-  usec = current.tv_usec - last.tv_usec;
-  return (float)(((double)sec + usec*1e-6));
-}
-
-/* Given two timeval stamps, return the time per chunk in usec */
-float get_usec_chunk(struct timeval last, struct timeval current) {
-  return (float)(getseconds(last, current)/(niter*nchunks)*1e6);
-}
-
+#endif
 
 int get_value(int i, int rshift) {
   int v;
@@ -169,10 +163,10 @@ void do_bench(char *compressor, int nthreads, int size, int elsize,
   void *dest[NCHUNKS], *dest2;
   int nbytes = 0, cbytes = 0;
   int i, j, retcode;
-  struct timeval last, current;
-  float tmemcpy, tshuf, tunshuf;
-  int clevel, doshuffle=1;
   unsigned char *orig, *round;
+  blosc_timestamp_t last, current;
+  double tmemcpy, tshuf, tunshuf;
+  int clevel, doshuffle=1;
 
   blosc_set_nthreads(nthreads);
   if(blosc_set_compressor(compressor) < 0){
@@ -203,43 +197,43 @@ void do_bench(char *compressor, int nthreads, int size, int elsize,
   fprintf(ofile, "Number of threads: %d\n", nthreads);
   fprintf(ofile, "********************** Running benchmarks *********************\n");
 
-  gettimeofday(&last, NULL);
+  blosc_set_timestamp(&last);
   for (i = 0; i < niter; i++) {
     for (j = 0; j < nchunks; j++) {
       memcpy(dest[j], src, size);
     }
   }
-  gettimeofday(&current, NULL);
-  tmemcpy = get_usec_chunk(last, current);
+  blosc_set_timestamp(&current);
+  tmemcpy = get_usec_chunk(last, current, niter, nchunks);
   fprintf(ofile, "memcpy(write):\t\t %6.1f us, %.1f MB/s\n",
-         tmemcpy, size/(tmemcpy*MB/1e6));
+         tmemcpy, (size * 1e6) / (tmemcpy*MB));
 
-  gettimeofday(&last, NULL);
+  blosc_set_timestamp(&last);
   for (i = 0; i < niter; i++) {
     for (j = 0; j < nchunks; j++) {
       memcpy(dest2, dest[j], size);
     }
   }
-  gettimeofday(&current, NULL);
-  tmemcpy = get_usec_chunk(last, current);
+  blosc_set_timestamp(&current);
+  tmemcpy = get_usec_chunk(last, current, niter, nchunks);
   fprintf(ofile, "memcpy(read):\t\t %6.1f us, %.1f MB/s\n",
-         tmemcpy, size/(tmemcpy*MB/1e6));
+         tmemcpy, (size * 1e6) / (tmemcpy*MB));
 
   for (clevel=0; clevel<10; clevel++) {
 
     fprintf(ofile, "Compression level: %d\n", clevel);
 
-    gettimeofday(&last, NULL);
+    blosc_set_timestamp(&last);
     for (i = 0; i < niter; i++) {
       for (j = 0; j < nchunks; j++) {
         cbytes = blosc_compress(clevel, doshuffle, elsize, size, src,
                                 dest[j], size+BLOSC_MAX_OVERHEAD);
       }
     }
-    gettimeofday(&current, NULL);
-    tshuf = get_usec_chunk(last, current);
+    blosc_set_timestamp(&current);
+    tshuf = get_usec_chunk(last, current, niter, nchunks);
     fprintf(ofile, "comp(write):\t %6.1f us, %.1f MB/s\t  ",
-           tshuf, size/(tshuf*MB/1e6));
+           tshuf, (size * 1e6) / (tshuf*MB));
     fprintf(ofile, "Final bytes: %d  ", cbytes);
     if (cbytes > 0) {
       fprintf(ofile, "Ratio: %3.2f", size/(float)cbytes);
@@ -253,7 +247,7 @@ void do_bench(char *compressor, int nthreads, int size, int elsize,
       }
     }
 
-    gettimeofday(&last, NULL);
+    blosc_set_timestamp(&last);
     for (i = 0; i < niter; i++) {
       for (j = 0; j < nchunks; j++) {
         if (cbytes == 0) {
@@ -265,26 +259,33 @@ void do_bench(char *compressor, int nthreads, int size, int elsize,
         }
       }
     }
-    gettimeofday(&current, NULL);
-    tunshuf = get_usec_chunk(last, current);
+    blosc_set_timestamp(&current);
+    tunshuf = get_usec_chunk(last, current, niter, nchunks);
     fprintf(ofile, "decomp(read):\t %6.1f us, %.1f MB/s\t  ",
-           tunshuf, nbytes/(tunshuf*MB/1e6));
+           tunshuf, (nbytes * 1e6) / (tunshuf*MB));
     if (nbytes < 0) {
       fprintf(ofile, "FAILED.  Error code: %d\n", nbytes);
     }
     /* fprintf(ofile, "Orig bytes: %d\tFinal bytes: %d\n", cbytes, nbytes); */
 
-    /* Check if data has had a good roundtrip */
+    /* Check if data has had a good roundtrip.
+       Byte-by-byte comparison is slow, so use 'memcmp' to check whether the
+       roundtripped data is correct. If not, fall back to the slow path to
+       print diagnostic messages. */
     orig = (unsigned char *)srccpy;
     round = (unsigned char *)dest2;
-    for(i = 0; i<size; ++i){
-      if (orig[i] != round[i]) {
-        fprintf(ofile, "\nError: Original data and round-trip do not match in pos %d\n",
-               (int)i);
-        fprintf(ofile, "Orig--> %x, round-trip--> %x\n", orig[i], round[i]);
-        break;
+    if (memcmp(orig, round, size) != 0)
+    {
+      for(i = 0; i<size; ++i){
+        if (orig[i] != round[i]) {
+          fprintf(ofile, "\nError: Original data and round-trip do not match in pos %d\n",
+                 (int)i);
+          fprintf(ofile, "Orig--> %x, round-trip--> %x\n", orig[i], round[i]);
+          break;
+        }
       }
     }
+    else { i = size; }
 
     if (i == size) fprintf(ofile, "OK\n");
 
@@ -359,7 +360,7 @@ int main(int argc, char *argv[]) {
   int workingset = 256*MB;              /* The maximum allocated memory */
   int nthreads_, size_, elsize_, rshift_, i;
   FILE * output_file = stdout;
-  struct timeval last, current;
+  blosc_timestamp_t last, current;
   float totaltime;
   char usage[256];
 
@@ -453,7 +454,7 @@ int main(int argc, char *argv[]) {
   }
 
   nchunks = get_nchunks(size, workingset);
-  gettimeofday(&last, NULL);
+  blosc_set_timestamp(&last);
 
   blosc_init();
 
@@ -475,8 +476,8 @@ int main(int argc, char *argv[]) {
     	    niter = 1;
             for (nthreads_ = 1; nthreads_ <= nthreads; nthreads_++) {
               do_bench(compressor, nthreads_, size_+i, elsize_, rshift_, output_file);
-              gettimeofday(&current, NULL);
-              totaltime = getseconds(last, current);
+              blosc_set_timestamp(&current);
+              totaltime = (float)getseconds(last, current);
               printf("Elapsed time:\t %6.1f s.  Processed data: %.1f GB\n",
                      totaltime, totalsize / GB);
             }
@@ -494,8 +495,8 @@ int main(int argc, char *argv[]) {
             nchunks = get_nchunks(size_+i, workingset);
             for (nthreads_ = 1; nthreads_ <= nthreads; nthreads_++) {
               do_bench(compressor, nthreads_, size_+i, elsize_, rshift_, output_file);
-              gettimeofday(&current, NULL);
-              totaltime = getseconds(last, current);
+              blosc_set_timestamp(&current);
+              totaltime = (float)getseconds(last, current);
               printf("Elapsed time:\t %6.1f s.  Processed data: %.1f GB\n",
                      totaltime, totalsize / GB);
             }
@@ -513,8 +514,8 @@ int main(int argc, char *argv[]) {
             nchunks = get_nchunks(size_+i, workingset);
             for (nthreads_ = nthreads; nthreads_ <= 6; nthreads_++) {
               do_bench(compressor, nthreads_, size_+i, elsize_, rshift_, output_file);
-              gettimeofday(&current, NULL);
-              totaltime = getseconds(last, current);
+              blosc_set_timestamp(&current);
+              totaltime = (float)getseconds(last, current);
               printf("Elapsed time:\t %6.1f s.  Processed data: %.1f GB\n",
                      totaltime, totalsize / GB);
             }
@@ -529,8 +530,8 @@ int main(int argc, char *argv[]) {
   }
 
   /* Print out some statistics */
-  gettimeofday(&current, NULL);
-  totaltime = getseconds(last, current);
+  blosc_set_timestamp(&current);
+  totaltime = (float)getseconds(last, current);
   printf("\nRound-trip compr/decompr on %.1f GB\n", totalsize / GB);
   printf("Elapsed time:\t %6.1f s, %.1f MB/s\n",
          totaltime, totalsize*2*1.1/(MB*totaltime));


### PR DESCRIPTION
I've modified the blosc ``bench`` tool so it uses high-precision timing APIs for more fine-grained results. I've tested on both Windows 7 and Linux (Ubuntu 14.10) and the changes appear to work as expected. The POSIX API is used for non-Windows systems so should also work on OS X, *BSD, etc.

I also made a small modification where the ``memcmp`` function is used to perform a fast first-pass check on whether round-tripped data matches the input (original) data. This is much faster than the byte-by-byte check, so speeds up the benchmarking runs in usual (expected cases); upon detecting an error, it falls back to the byte-by-byte check to print out a diagnostic message.