### PR TITLE
Pthreads for Windows support

### DIFF
--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -48,7 +48,7 @@
   #include <inttypes.h>
 #endif  /* _WIN32 */
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(__GNUC__)
   #include "win32/pthread.h"
   #include "win32/pthread.c"
 #else

--- a/examples/multithread.c
+++ b/examples/multithread.c
@@ -39,9 +39,8 @@
 #include <stdio.h>
 #include <blosc.h>
 
-#define SIZE 100*100*100
-#define SHAPE {100,100,100}
-#define CHUNKSHAPE {1,100,100}
+#define SIZE 1000*1000
+
 
 int main(){
   static float data[SIZE];


### PR DESCRIPTION
Support for pthreads and GCC on Windows.  Fixes #92.  Still needs to be tested with MinGW and Clang.