### PR TITLE
do not use win32/pthreads code with win32 gcc (v1.4 based)

### DIFF
--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -42,7 +42,7 @@
   #include <inttypes.h>
 #endif  /* _WIN32 */
 
-#if defined(_WIN32)
+#if (defined(_WIN32) && !defined(__GNUC__)) || defined(__MINGW32__)
   #include "win32/pthread.h"
   #include "win32/pthread.c"
 #else


### PR DESCRIPTION
Tested with win32 GCC & mingw32:

win32 GCC defines `__GNUC__` but does not need `pthread.c`
win32 mingw32 defines `__GNUC__` & `__MINGW32__` and does need `pthread.c`

Other compilers:
non-gcc compilers define `_WIN32` and probably need `pthread.c`

other gcc based win32 compilers untested