### PR TITLE
Fix preprocessor macros in shuffle.c that broke MSVC compilation

### DIFF
--- a/blosc/shuffle.c
+++ b/blosc/shuffle.c
@@ -19,7 +19,8 @@
      targeting the minimum architecture level supporting SSE2.
      Other compilers define this as expected and emit warnings
      when it is re-defined. */
-  #if defined(_MSC_VER) && (defined(_M_X64) || (defined(_M_IX86) && _M_IX86_FP >= 2))
+  #if !defined(__SSE2__) && defined(_MSC_VER) && \
+      (defined(_M_X64) || (defined(_M_IX86) && _M_IX86_FP >= 2))
     #define __SSE2__
   #endif
 #else
@@ -65,7 +66,7 @@ static void _unshuffle(size_t bytesoftype, size_t blocksize,
 }
 
 
-#ifdef __AVX2__
+#if defined(__AVX2__)
 //#pragma message "Using AVX2 version shuffle/unshuffle"
 
 #include <immintrin.h>
@@ -527,7 +528,7 @@ void unshuffle(size_t bytesoftype, size_t blocksize,
 }
 
 
-#elif __SSE2__
+#elif defined(__SSE2__)
 
 /* The SSE2 versions of shuffle and unshuffle */
 


### PR DESCRIPTION
The recent addition of AVX2 support in shuffle.c broke compilation with MSVC due to an "invalid integer expression" on line 530 (``#elif __SSE2__``). I've fixed this so the preprocessor checks for the definition of the symbol rather than the value, and I've modified the ``__AVX2__`` check to be consistent (so it also checks whether the symbol is defined).

I've also made a small modification to the preprocessor checks which define the ``__SSE2__`` symbol for MSVC; now it only defines the symbol if it's not already defined. This avoids symbol redefinition warnings when using other compilers (e.g., clang) in Visual Studio.