### PR TITLE
use runtime detection of AVX2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,11 +170,6 @@ endif (CMAKE_C_COMPILER_ID STREQUAL GNU)
 # Set the "-msse2" build flag only if the CMAKE_C_FLAGS is not already set.
 # Probably "-msse2" should be appended to CMAKE_C_FLAGS_RELEASE.
 if(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
-     if(NOT CMAKE_C_FLAGS AND AVX2_TRUE AND COMPILER_SUPPORT_AVX2)
-         message(STATUS "AVX2 is here.  Adding support for it.")
-         set(CMAKE_C_FLAGS -march=core-avx2 CACHE STRING "C flags." FORCE)
-         set(RES_SUPPORT_AVX2 true)
-     endif(NOT CMAKE_C_FLAGS AND AVX2_TRUE AND COMPILER_SUPPORT_AVX2)
      if(NOT CMAKE_C_FLAGS AND SSE2_TRUE)
          message(STATUS "SSE2 is here.  Adding support for it.")
          set(CMAKE_C_FLAGS -msse2 CACHE STRING "C flags." FORCE)

--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -33,6 +33,10 @@ endif(NOT DEACTIVATE_ZLIB)
 
 # library sources
 set(SOURCES blosc.c blosclz.c shuffle.c)
+if(COMPILER_SUPPORT_AVX2)
+    set(SOURCES ${SOURCES} avx2.c)
+endif(COMPILER_SUPPORT_AVX2)
+
 # library install directory
 set(lib_dir lib${LIB_SUFFIX})
 set(version_string ${BLOSC_VERSION_MAJOR}.${BLOSC_VERSION_MINOR}.${BLOSC_VERSION_PATCH})
@@ -90,6 +94,10 @@ set_target_properties(blosc_shared PROPERTIES
 if (MSVC)
 	set_target_properties (blosc_shared PROPERTIES COMPILE_FLAGS -DDLL_EXPORT=TRUE)
 endif(MSVC)
+if(COMPILER_SUPPORT_AVX2)
+    set_source_files_properties(shuffle.c PROPERTIES COMPILE_DEFINITIONS HAVE_AVX2=1)
+    set_source_files_properties(avx2.c PROPERTIES COMPILE_FLAGS -mavx2)
+endif(COMPILER_SUPPORT_AVX2)
 target_link_libraries(blosc_shared ${LIBS})
 
 if(BUILD_STATIC)

--- a/blosc/avx2.c
+++ b/blosc/avx2.c
@@ -1,0 +1,388 @@
+#include <stdint.h>
+/* #pragma message "Using AVX2 version shuffle/unshuffle" */
+
+#include <immintrin.h>
+
+/* Routine optimized for shuffling a buffer for a type size of 2 bytes. */
+void
+shuffle2_AVX2(uint8_t* dest, const uint8_t* src, size_t size)
+{
+  size_t i, j, k;
+  size_t nitem;
+  __m256i a[2], b[2], c[2], d[2], shmask;
+  static uint8_t b_mask[] = {0x00, 0x02, 0x04, 0x06, 0x08, 0x0A, 0x0C, 0x0E,
+          0x01, 0x03, 0x05, 0x07, 0x09, 0x0B, 0x0D, 0x0F,
+          0x00, 0x02, 0x04, 0x06, 0x08, 0x0A, 0x0C, 0x0E,
+          0x01, 0x03, 0x05, 0x07, 0x09, 0x0B, 0x0D, 0x0F };
+
+  nitem = size/256;
+  shmask = _mm256_loadu_si256( (__m256i*)(b_mask));
+  for( i=0;i<nitem;i++ ) {
+    for( j=0;j<4;j++ )  {
+      for(k=0;k<2;k++) {
+        a[k] = _mm256_loadu_si256( (__m256i*)(src + i*256 +j*64+k*32));
+        b[k] = _mm256_shuffle_epi8( a[k], shmask );
+      }
+      c[0] = _mm256_permute4x64_epi64( b[0], 0xD8);
+      c[1] = _mm256_permute4x64_epi64( b[1], 0x8D);
+
+      d[0] = _mm256_blend_epi32(c[0], c[1], 0xF0);
+      _mm256_store_si256((__m256i*)(dest+j*32), d[0]);
+      c[0] = _mm256_blend_epi32(c[0], c[1], 0x0F);
+      d[1] = _mm256_permute4x64_epi64( c[0], 0x4E);
+      _mm256_store_si256((__m256i*)(dest+j*32+(size>>1)), d[1]);
+    }
+    dest += 128;
+  }
+}
+
+
+/* Routine optimized for shuffling a buffer for a type size of 4 bytes. */
+void
+shuffle4_AVX2(uint8_t* dest, const uint8_t* src, size_t size)
+{
+  size_t i, j, k;
+  size_t numof16belem;
+  __m256i ymm0[4], ymm1[4], mask;
+  static uint8_t b_mask[] = {
+    0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
+    0x01, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00,
+    0x02, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00,
+    0x03, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00
+  };
+
+  numof16belem = size / (32*4);
+  mask = _mm256_loadu_si256((__m256i*)(b_mask));
+  for (i = 0, j = 0; i < numof16belem; i++, j += 32*4) {
+    /* Fetch and transpose bytes and words in groups of 64 bytes */
+    for (k = 0; k < 4; k++) {
+      ymm0[k] = _mm256_loadu_si256((__m256i*)(src+j+k*32));
+      ymm1[k] = _mm256_shuffle_epi32(ymm0[k], 0xd8);
+      ymm0[k] = _mm256_shuffle_epi32(ymm0[k], 0x8d);
+      ymm0[k] = _mm256_unpacklo_epi8(ymm1[k], ymm0[k]);
+      ymm1[k] = _mm256_shuffle_epi32(ymm0[k], 0x04e);
+      ymm0[k] = _mm256_unpacklo_epi16(ymm0[k], ymm1[k]);
+    }
+    /* Transpose double words */
+    for (k = 0; k < 2; k++) {
+      ymm1[k*2] = _mm256_unpacklo_epi32(ymm0[k*2], ymm0[k*2+1]);
+      ymm1[k*2+1] = _mm256_unpackhi_epi32(ymm0[k*2], ymm0[k*2+1]);
+    }
+    /* Transpose quad words */
+    for (k = 0; k < 2; k++) {
+      ymm0[k*2] = _mm256_unpacklo_epi64(ymm1[k], ymm1[k+2]);
+      ymm0[k*2+1] = _mm256_unpackhi_epi64(ymm1[k], ymm1[k+2]);
+    }
+
+    for (k = 0; k < 4; k++) {
+      ymm0[k] = _mm256_permutevar8x32_epi32(ymm0[k], mask);
+    }
+
+    /* Store the result vectors */
+    for (k = 0; k < 4; k++) {
+      ((__m256i *)dest)[k*numof16belem+i] = ymm0[k];
+    }
+  }
+}
+
+
+/* Routine optimized for shuffling a buffer for a type size of 8 bytes. */
+void
+shuffle8_AVX2(uint8_t* dest, const uint8_t* src, size_t size)
+{
+  size_t i, j, k, l;
+  size_t numof16belem;
+  __m256i ymm0[8], ymm1[8];
+  numof16belem = size / (16*8*2);
+
+  for (i = 0, j = 0; i < numof16belem; i++, j += 16*8*2) {
+    /* Fetch and transpose bytes in groups of 128 bytes */
+    for (k = 0; k < 8; k++) {
+      ymm0[k] = _mm256_loadu_si256((__m256i*)(src+j+k*32));
+      ymm1[k] = _mm256_shuffle_epi32(ymm0[k], 0x4e);
+      ymm1[k] = _mm256_unpacklo_epi8(ymm0[k], ymm1[k]);
+    }
+
+    /* Transpose words */
+    for (k = 0, l = 0; k < 4; k++, l +=2) {
+      ymm0[k*2] = _mm256_unpacklo_epi16(ymm1[l], ymm1[l+1]);
+      ymm0[k*2+1] = _mm256_unpackhi_epi16(ymm1[l], ymm1[l+1]);
+    }
+    /* Transpose double words */
+    for (k = 0, l = 0; k < 4; k++, l++) {
+      if (k == 2) l += 2;
+      ymm1[k*2] = _mm256_unpacklo_epi32(ymm0[l], ymm0[l+2]);
+      ymm1[k*2+1] = _mm256_unpackhi_epi32(ymm0[l], ymm0[l+2]);
+    }
+    /* Transpose quad words */
+    for (k = 0; k < 4; k++) {
+      ymm0[k*2] = _mm256_unpacklo_epi64(ymm1[k], ymm1[k+4]);
+      ymm0[k*2+1] = _mm256_unpackhi_epi64(ymm1[k], ymm1[k+4]);
+    }
+    for( k=0;k<8;k++)
+    {
+      ymm1[k] = _mm256_permute4x64_epi64(ymm0[k], 0x72);
+      ymm0[k] = _mm256_permute4x64_epi64(ymm0[k], 0xD8);
+      ymm0[k] = _mm256_unpacklo_epi16(ymm0[k], ymm1[k]);
+    }
+    /* Store the result vectors */
+    for (k = 0; k < 8; k++) {
+        ((__m256i *)dest)[k*numof16belem+i] = ymm0[k];
+    }
+  }
+}
+
+
+/* Routine optimized for shuffling a buffer for a type size of 16 bytes. */
+void
+shuffle16_AVX2(uint8_t* dest, const uint8_t* src, size_t size)
+{
+  size_t i, j, k, l;
+  size_t numof16belem;
+  __m256i ymm0[16], ymm1[16], shmask;
+  static uint8_t b_mask[] = { 0x00, 0x08, 0x01, 0x09, 0x02, 0x0A, 0x03, 0x0B,
+          0x04, 0x0C, 0x05, 0x0D, 0x06, 0x0E, 0x07, 0x0F,
+          0x00, 0x08, 0x01, 0x09, 0x02, 0x0A, 0x03, 0x0B,
+          0x04, 0x0C, 0x05, 0x0D, 0x06, 0x0E, 0x07, 0x0F
+  };
+
+  numof16belem = size / (16*32);
+  shmask = _mm256_loadu_si256((__m256i*)b_mask);
+  for (i = 0, j = 0; i < numof16belem; i++, j += 16*32) {
+    /* Fetch elements in groups of 256 bytes */
+    for (k = 0; k < 16; k++) {
+      ymm0[k] = _mm256_loadu_si256((__m256i*)(src+j+k*32));
+    }
+
+    /* Transpose bytes */
+    for (k = 0, l = 0; k < 8; k++, l +=2) {
+      ymm1[k*2] = _mm256_unpacklo_epi8(ymm0[l], ymm0[l+1]);
+      ymm1[k*2+1] = _mm256_unpackhi_epi8(ymm0[l], ymm0[l+1]);
+    }
+
+    /* Transpose words */
+    for (k = 0, l = -2; k < 8; k++, l++) {
+      if ((k%2) == 0) l += 2;
+      ymm0[k*2] = _mm256_unpacklo_epi16(ymm1[l], ymm1[l+2]);
+      ymm0[k*2+1] = _mm256_unpackhi_epi16(ymm1[l], ymm1[l+2]);
+    }
+
+    /* Transpose double words */
+    for (k = 0, l = -4; k < 8; k++, l++) {
+      if ((k%4) == 0) l += 4;
+      ymm1[k*2] = _mm256_unpacklo_epi32(ymm0[l], ymm0[l+4]);
+      ymm1[k*2+1] = _mm256_unpackhi_epi32(ymm0[l], ymm0[l+4]);
+    }
+
+    /* Transpose quad words */
+    for (k = 0; k < 8; k++) {
+      ymm0[k*2] = _mm256_unpacklo_epi64(ymm1[k], ymm1[k+8]);
+      ymm0[k*2+1] = _mm256_unpackhi_epi64(ymm1[k], ymm1[k+8]);
+    }
+
+    for (k = 0; k < 16; k++) {
+      ymm0[k] = _mm256_permute4x64_epi64( ymm0[k], 0xD8);
+      ymm0[k] = _mm256_shuffle_epi8( ymm0[k], shmask);
+    }
+
+    /* Store the result vectors */
+    for (k = 0; k < 16; k++) {
+      ((__m256i *)dest)[k*numof16belem+i] = ymm0[k];
+    }
+  }
+}
+
+
+/* Routine optimized for unshuffling a buffer for a type size of 2 bytes. */
+void
+unshuffle2_AVX2(uint8_t* dest, const uint8_t* src, size_t size)
+{
+  size_t i, j;
+  size_t nitem;
+  __m256i a[2], b[2], c[2];
+
+  nitem = size/64;
+  for( i=0, j=0;i<nitem;i++,j+=2 ) {
+    a[0] = ((__m256i *)src)[0*nitem+i];
+    a[1] = ((__m256i *)src)[1*nitem+i];
+    a[0] = _mm256_permute4x64_epi64(a[0], 0xD8);
+    a[1] = _mm256_permute4x64_epi64(a[1], 0xD8);
+    b[0] = _mm256_unpacklo_epi8(a[0], a[1]);
+    b[1] = _mm256_unpackhi_epi8(a[0], a[1]);
+    ((__m256i *)dest)[j+0] = b[0];
+    ((__m256i *)dest)[j+1] = b[1];
+  }
+}
+
+
+/* Routine optimized for unshuffling a buffer for a type size of 4 bytes. */
+void
+unshuffle4_AVX2(uint8_t* dest, const uint8_t* orig, size_t size)
+{
+  size_t i, j, k;
+  size_t neblock, numof16belem;
+  __m256i ymm0[4], ymm1[4];
+
+  neblock = size / 4;
+  numof16belem = neblock / 32;
+  for (i = 0, k = 0; i < numof16belem; i++, k += 4) {
+    /* Load the first 64 bytes in 4 XMM registrers */
+    for (j = 0; j < 4; j++) {
+      ymm0[j] = ((__m256i *)orig)[j*numof16belem+i];
+    }
+    /* Shuffle bytes */
+    for (j = 0; j < 2; j++) {
+      /* Compute the low 32 bytes */
+      ymm1[j] = _mm256_unpacklo_epi8(ymm0[j*2], ymm0[j*2+1]);
+      /* Compute the hi 32 bytes */
+      ymm1[2+j] = _mm256_unpackhi_epi8(ymm0[j*2], ymm0[j*2+1]);
+    }
+
+    /* Shuffle 2-byte words */
+    for (j = 0; j < 2; j++) {
+      /* Compute the low 32 bytes */
+      ymm0[j] = _mm256_unpacklo_epi16(ymm1[j*2], ymm1[j*2+1]);
+      /* Compute the hi 32 bytes */
+      ymm0[2+j] = _mm256_unpackhi_epi16(ymm1[j*2], ymm1[j*2+1]);
+    }
+
+	ymm1[0] = _mm256_permute2x128_si256(ymm0[0], ymm0[2], 0x20);
+	ymm1[1] = _mm256_permute2x128_si256(ymm0[1], ymm0[3], 0x20);
+	ymm1[2] = _mm256_permute2x128_si256(ymm0[0], ymm0[2], 0x31);
+	ymm1[3] = _mm256_permute2x128_si256(ymm0[1], ymm0[3], 0x31);
+
+    /* Store the result vectors in proper order */
+    ((__m256i *)dest)[k+0] = ymm1[0];
+    ((__m256i *)dest)[k+1] = ymm1[1];
+    ((__m256i *)dest)[k+2] = ymm1[2];
+    ((__m256i *)dest)[k+3] = ymm1[3];
+  }
+}
+
+
+/* Routine optimized for unshuffling a buffer for a type size of 8 bytes. */
+void
+unshuffle8_AVX2(uint8_t* dest, const uint8_t* orig, size_t size)
+{
+  size_t i, j, k;
+  size_t neblock, numof16belem;
+  __m256i ymm0[8], ymm1[8];
+
+  neblock = size / 8;
+  numof16belem = neblock/32;
+  for (i = 0, k = 0; i < numof16belem; i++, k += 8) {
+    /* Load the first 64 bytes in 8 XMM registrers */
+    for (j = 0; j < 8; j++) {
+      ymm0[j] = ((__m256i *)orig)[j*numof16belem+i];
+    }
+    /* Shuffle bytes */
+    for (j = 0; j < 4; j++) {
+      /* Compute the low 32 bytes */
+      ymm1[j] = _mm256_unpacklo_epi8(ymm0[j*2], ymm0[j*2+1]);
+      /* Compute the hi 32 bytes */
+      ymm1[4+j] = _mm256_unpackhi_epi8(ymm0[j*2], ymm0[j*2+1]);
+    }
+    /* Shuffle 2-byte words */
+    for (j = 0; j < 4; j++) {
+      /* Compute the low 32 bytes */
+      ymm0[j] = _mm256_unpacklo_epi16(ymm1[j*2], ymm1[j*2+1]);
+      /* Compute the hi 32 bytes */
+      ymm0[4+j] = _mm256_unpackhi_epi16(ymm1[j*2], ymm1[j*2+1]);
+    }
+
+     for( j=0;j<8;j++)
+      {
+        ymm0[j] = _mm256_permute4x64_epi64(ymm0[j], 0xD8);
+      }
+
+    /* Shuffle 4-byte dwords */
+    for (j = 0; j < 4; j++) {
+      /* Compute the low 32 bytes */
+      ymm1[j] = _mm256_unpacklo_epi32(ymm0[j*2], ymm0[j*2+1]);
+      /* Compute the hi 32 bytes */
+      ymm1[4+j] = _mm256_unpackhi_epi32(ymm0[j*2], ymm0[j*2+1]);
+    }
+
+    /* Store the result vectors in proper order */
+      ((__m256i *)dest)[k+0] = ymm1[0];
+      ((__m256i *)dest)[k+1] = ymm1[2];
+      ((__m256i *)dest)[k+2] = ymm1[1];
+      ((__m256i *)dest)[k+3] = ymm1[3];
+      ((__m256i *)dest)[k+4] = ymm1[4];
+      ((__m256i *)dest)[k+5] = ymm1[6];
+      ((__m256i *)dest)[k+6] = ymm1[5];
+      ((__m256i *)dest)[k+7] = ymm1[7];
+  }
+}
+
+
+/* Routine optimized for unshuffling a buffer for a type size of 16 bytes. */
+void
+unshuffle16_AVX2(uint8_t* dest, const uint8_t* orig, size_t size)
+{
+  size_t i, j, k;
+  size_t neblock, numof16belem;
+  __m256i ymm1[16], ymm2[16];
+
+  neblock = size / 16;
+  numof16belem = neblock / 32;
+  for (i = 0, k = 0; i < numof16belem; i++, k += 16) {
+    /* Load the first 128 bytes in 16 XMM registrers */
+    for (j = 0; j < 16; j++) {
+      ymm1[j] = ((__m256i *)orig)[j*numof16belem+i];
+    }
+    /* Shuffle bytes */
+    for (j = 0; j < 8; j++) {
+      /* Compute the low 32 bytes */
+      ymm2[j] = _mm256_unpacklo_epi8(ymm1[j*2], ymm1[j*2+1]);
+      /* Compute the hi 32 bytes */
+      ymm2[8+j] = _mm256_unpackhi_epi8(ymm1[j*2], ymm1[j*2+1]);
+    }
+    /* Shuffle 2-byte words */
+    for (j = 0; j < 8; j++) {
+      /* Compute the low 32 bytes */
+      ymm1[j] = _mm256_unpacklo_epi16(ymm2[j*2], ymm2[j*2+1]);
+      /* Compute the hi 32 bytes */
+      ymm1[8+j] = _mm256_unpackhi_epi16(ymm2[j*2], ymm2[j*2+1]);
+    }
+    /* Shuffle 4-byte dwords */
+    for (j = 0; j < 8; j++) {
+      /* Compute the low 32 bytes */
+      ymm2[j] = _mm256_unpacklo_epi32(ymm1[j*2], ymm1[j*2+1]);
+      /* Compute the hi 32 bytes */
+      ymm2[8+j] = _mm256_unpackhi_epi32(ymm1[j*2], ymm1[j*2+1]);
+    }
+
+    /* Shuffle 8-byte qwords */
+    for (j = 0; j < 8; j++) {
+      /* Compute the low 32 bytes */
+      ymm1[j] = _mm256_unpacklo_epi64(ymm2[j*2], ymm2[j*2+1]);
+      /* Compute the hi 32 bytes */
+      ymm1[8+j] = _mm256_unpackhi_epi64(ymm2[j*2], ymm2[j*2+1]);
+    }
+
+    for( j=0;j<8;j++) {
+      ymm2[j] = _mm256_permute2x128_si256(ymm1[j], ymm1[j+8], 0x20);
+      ymm2[j+8] = _mm256_permute2x128_si256(ymm1[j], ymm1[j+8], 0x31);
+    }
+
+    /* Store the result vectors in proper order */
+    ((__m256i *)dest)[k+0] = ymm2[0];
+    ((__m256i *)dest)[k+1] = ymm2[4];
+    ((__m256i *)dest)[k+2] = ymm2[2];
+    ((__m256i *)dest)[k+3] = ymm2[6];
+    ((__m256i *)dest)[k+4] = ymm2[1];
+    ((__m256i *)dest)[k+5] = ymm2[5];
+    ((__m256i *)dest)[k+6] = ymm2[3];
+    ((__m256i *)dest)[k+7] = ymm2[7];
+    ((__m256i *)dest)[k+8] = ymm2[8];
+    ((__m256i *)dest)[k+9] = ymm2[12];
+    ((__m256i *)dest)[k+10] = ymm2[10];
+    ((__m256i *)dest)[k+11] = ymm2[14];
+    ((__m256i *)dest)[k+12] = ymm2[9];
+    ((__m256i *)dest)[k+13] = ymm2[13];
+    ((__m256i *)dest)[k+14] = ymm2[11];
+    ((__m256i *)dest)[k+15] = ymm2[15];
+  }
+}
+

--- a/blosc/shuffle.c
+++ b/blosc/shuffle.c
@@ -28,12 +28,42 @@
   #include <inttypes.h>
 #endif  /* _WIN32 */
 
+#ifdef HAVE_AVX2
+void __attribute__((visibility ("hidden")))
+shuffle2_AVX2(uint8_t* dest, const uint8_t* src, size_t size);
+void __attribute__((visibility ("hidden")))
+shuffle4_AVX2(uint8_t* dest, const uint8_t* src, size_t size);
+void __attribute__((visibility ("hidden")))
+shuffle8_AVX2(uint8_t* dest, const uint8_t* src, size_t size);
+void __attribute__((visibility ("hidden")))
+shuffle16_AVX2(uint8_t* dest, const uint8_t* src, size_t size);
+void __attribute__((visibility ("hidden")))
+unshuffle2_AVX2(uint8_t* dest, const uint8_t* src, size_t size);
+void __attribute__((visibility ("hidden")))
+unshuffle4_AVX2(uint8_t* dest, const uint8_t* src, size_t size);
+void __attribute__((visibility ("hidden")))
+unshuffle8_AVX2(uint8_t* dest, const uint8_t* src, size_t size);
+void __attribute__((visibility ("hidden")))
+unshuffle16_AVX2(uint8_t* dest, const uint8_t* src, size_t size);
+#endif
+
+static int
+have_avx2(void)
+{
+#if !defined(__clang__) && defined(__GNUC__) && defined(__GNUC_MINOR__) && \
+    __GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+  return __builtin_cpu_supports("avx2");
+#else
+  return 0;
+#endif
+}
+
 
 /* The non-SIMD versions of shuffle and unshuffle */
 
 /* Shuffle a block.  This can never fail. */
-static void _shuffle(size_t bytesoftype, size_t blocksize,
-                     const uint8_t* _src, uint8_t* _dest)
+void _shuffle(size_t bytesoftype, size_t blocksize,
+              const uint8_t* _src, uint8_t* _dest)
 {
   size_t i, j, neblock, leftover;
 
@@ -49,7 +79,7 @@ static void _shuffle(size_t bytesoftype, size_t blocksize,
 }
 
 /* Unshuffle a block.  This can never fail. */
-static void _unshuffle(size_t bytesoftype, size_t blocksize,
+void _unshuffle(size_t bytesoftype, size_t blocksize,
                        const uint8_t* _src, uint8_t* _dest)
 {
   size_t i, j, neblock, leftover;
@@ -66,470 +96,7 @@ static void _unshuffle(size_t bytesoftype, size_t blocksize,
 }
 
 
-#if defined(__AVX2__)
-/* #pragma message "Using AVX2 version shuffle/unshuffle" */
-
-#include <immintrin.h>
-
-/* Routine optimized for shuffling a buffer for a type size of 2 bytes. */
-static void
-shuffle2_AVX2(uint8_t* dest, const uint8_t* src, size_t size)
-{
-  size_t i, j, k;
-  size_t nitem;
-  __m256i a[2], b[2], c[2], d[2], shmask;
-  static uint8_t b_mask[] = {0x00, 0x02, 0x04, 0x06, 0x08, 0x0A, 0x0C, 0x0E,
-          0x01, 0x03, 0x05, 0x07, 0x09, 0x0B, 0x0D, 0x0F,
-          0x00, 0x02, 0x04, 0x06, 0x08, 0x0A, 0x0C, 0x0E,
-          0x01, 0x03, 0x05, 0x07, 0x09, 0x0B, 0x0D, 0x0F };
-
-  nitem = size/256;
-  shmask = _mm256_loadu_si256( (__m256i*)(b_mask));
-  for( i=0;i<nitem;i++ ) {
-    for( j=0;j<4;j++ )  {
-      for(k=0;k<2;k++) {
-        a[k] = _mm256_loadu_si256( (__m256i*)(src + i*256 +j*64+k*32));
-        b[k] = _mm256_shuffle_epi8( a[k], shmask );
-      }
-      c[0] = _mm256_permute4x64_epi64( b[0], 0xD8);
-      c[1] = _mm256_permute4x64_epi64( b[1], 0x8D);
-
-      d[0] = _mm256_blend_epi32(c[0], c[1], 0xF0);
-      _mm256_store_si256((__m256i*)(dest+j*32), d[0]);
-      c[0] = _mm256_blend_epi32(c[0], c[1], 0x0F);
-      d[1] = _mm256_permute4x64_epi64( c[0], 0x4E);
-      _mm256_store_si256((__m256i*)(dest+j*32+(size>>1)), d[1]);
-    }
-    dest += 128;
-  }
-}
-
-
-/* Routine optimized for shuffling a buffer for a type size of 4 bytes. */
-static void
-shuffle4_AVX2(uint8_t* dest, const uint8_t* src, size_t size)
-{
-  size_t i, j, k;
-  size_t numof16belem;
-  __m256i ymm0[4], ymm1[4], mask;
-  static uint8_t b_mask[] = {
-    0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
-    0x01, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00,
-    0x02, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00,
-    0x03, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00
-  };
-
-  numof16belem = size / (32*4);
-  mask = _mm256_loadu_si256((__m256i*)(b_mask));
-  for (i = 0, j = 0; i < numof16belem; i++, j += 32*4) {
-    /* Fetch and transpose bytes and words in groups of 64 bytes */
-    for (k = 0; k < 4; k++) {
-      ymm0[k] = _mm256_loadu_si256((__m256i*)(src+j+k*32));
-      ymm1[k] = _mm256_shuffle_epi32(ymm0[k], 0xd8);
-      ymm0[k] = _mm256_shuffle_epi32(ymm0[k], 0x8d);
-      ymm0[k] = _mm256_unpacklo_epi8(ymm1[k], ymm0[k]);
-      ymm1[k] = _mm256_shuffle_epi32(ymm0[k], 0x04e);
-      ymm0[k] = _mm256_unpacklo_epi16(ymm0[k], ymm1[k]);
-    }
-    /* Transpose double words */
-    for (k = 0; k < 2; k++) {
-      ymm1[k*2] = _mm256_unpacklo_epi32(ymm0[k*2], ymm0[k*2+1]);
-      ymm1[k*2+1] = _mm256_unpackhi_epi32(ymm0[k*2], ymm0[k*2+1]);
-    }
-    /* Transpose quad words */
-    for (k = 0; k < 2; k++) {
-      ymm0[k*2] = _mm256_unpacklo_epi64(ymm1[k], ymm1[k+2]);
-      ymm0[k*2+1] = _mm256_unpackhi_epi64(ymm1[k], ymm1[k+2]);
-    }
-
-    for (k = 0; k < 4; k++) {
-      ymm0[k] = _mm256_permutevar8x32_epi32(ymm0[k], mask);
-    }
-
-    /* Store the result vectors */
-    for (k = 0; k < 4; k++) {
-      ((__m256i *)dest)[k*numof16belem+i] = ymm0[k];
-    }
-  }
-}
-
-
-/* Routine optimized for shuffling a buffer for a type size of 8 bytes. */
-static void
-shuffle8_AVX2(uint8_t* dest, const uint8_t* src, size_t size)
-{
-  size_t i, j, k, l;
-  size_t numof16belem;
-  __m256i ymm0[8], ymm1[8];
-  numof16belem = size / (16*8*2);
-
-  for (i = 0, j = 0; i < numof16belem; i++, j += 16*8*2) {
-    /* Fetch and transpose bytes in groups of 128 bytes */
-    for (k = 0; k < 8; k++) {
-      ymm0[k] = _mm256_loadu_si256((__m256i*)(src+j+k*32));
-      ymm1[k] = _mm256_shuffle_epi32(ymm0[k], 0x4e);
-      ymm1[k] = _mm256_unpacklo_epi8(ymm0[k], ymm1[k]);
-    }
-
-    /* Transpose words */
-    for (k = 0, l = 0; k < 4; k++, l +=2) {
-      ymm0[k*2] = _mm256_unpacklo_epi16(ymm1[l], ymm1[l+1]);
-      ymm0[k*2+1] = _mm256_unpackhi_epi16(ymm1[l], ymm1[l+1]);
-    }
-    /* Transpose double words */
-    for (k = 0, l = 0; k < 4; k++, l++) {
-      if (k == 2) l += 2;
-      ymm1[k*2] = _mm256_unpacklo_epi32(ymm0[l], ymm0[l+2]);
-      ymm1[k*2+1] = _mm256_unpackhi_epi32(ymm0[l], ymm0[l+2]);
-    }
-    /* Transpose quad words */
-    for (k = 0; k < 4; k++) {
-      ymm0[k*2] = _mm256_unpacklo_epi64(ymm1[k], ymm1[k+4]);
-      ymm0[k*2+1] = _mm256_unpackhi_epi64(ymm1[k], ymm1[k+4]);
-    }
-    for( k=0;k<8;k++)
-    {
-      ymm1[k] = _mm256_permute4x64_epi64(ymm0[k], 0x72);
-      ymm0[k] = _mm256_permute4x64_epi64(ymm0[k], 0xD8);
-      ymm0[k] = _mm256_unpacklo_epi16(ymm0[k], ymm1[k]);
-    }
-    /* Store the result vectors */
-    for (k = 0; k < 8; k++) {
-        ((__m256i *)dest)[k*numof16belem+i] = ymm0[k];
-    }
-  }
-}
-
-
-/* Routine optimized for shuffling a buffer for a type size of 16 bytes. */
-static void
-shuffle16_AVX2(uint8_t* dest, const uint8_t* src, size_t size)
-{
-  size_t i, j, k, l;
-  size_t numof16belem;
-  __m256i ymm0[16], ymm1[16], shmask;
-  static uint8_t b_mask[] = { 0x00, 0x08, 0x01, 0x09, 0x02, 0x0A, 0x03, 0x0B,
-          0x04, 0x0C, 0x05, 0x0D, 0x06, 0x0E, 0x07, 0x0F,
-          0x00, 0x08, 0x01, 0x09, 0x02, 0x0A, 0x03, 0x0B,
-          0x04, 0x0C, 0x05, 0x0D, 0x06, 0x0E, 0x07, 0x0F
-  };
-
-  numof16belem = size / (16*32);
-  shmask = _mm256_loadu_si256((__m256i*)b_mask);
-  for (i = 0, j = 0; i < numof16belem; i++, j += 16*32) {
-    /* Fetch elements in groups of 256 bytes */
-    for (k = 0; k < 16; k++) {
-      ymm0[k] = _mm256_loadu_si256((__m256i*)(src+j+k*32));
-    }
-
-    /* Transpose bytes */
-    for (k = 0, l = 0; k < 8; k++, l +=2) {
-      ymm1[k*2] = _mm256_unpacklo_epi8(ymm0[l], ymm0[l+1]);
-      ymm1[k*2+1] = _mm256_unpackhi_epi8(ymm0[l], ymm0[l+1]);
-    }
-
-    /* Transpose words */
-    for (k = 0, l = -2; k < 8; k++, l++) {
-      if ((k%2) == 0) l += 2;
-      ymm0[k*2] = _mm256_unpacklo_epi16(ymm1[l], ymm1[l+2]);
-      ymm0[k*2+1] = _mm256_unpackhi_epi16(ymm1[l], ymm1[l+2]);
-    }
-
-    /* Transpose double words */
-    for (k = 0, l = -4; k < 8; k++, l++) {
-      if ((k%4) == 0) l += 4;
-      ymm1[k*2] = _mm256_unpacklo_epi32(ymm0[l], ymm0[l+4]);
-      ymm1[k*2+1] = _mm256_unpackhi_epi32(ymm0[l], ymm0[l+4]);
-    }
-
-    /* Transpose quad words */
-    for (k = 0; k < 8; k++) {
-      ymm0[k*2] = _mm256_unpacklo_epi64(ymm1[k], ymm1[k+8]);
-      ymm0[k*2+1] = _mm256_unpackhi_epi64(ymm1[k], ymm1[k+8]);
-    }
-
-    for (k = 0; k < 16; k++) {
-      ymm0[k] = _mm256_permute4x64_epi64( ymm0[k], 0xD8);
-      ymm0[k] = _mm256_shuffle_epi8( ymm0[k], shmask);
-    }
-
-    /* Store the result vectors */
-    for (k = 0; k < 16; k++) {
-      ((__m256i *)dest)[k*numof16belem+i] = ymm0[k];
-    }
-  }
-}
-
-
-/* Shuffle a block.  This can never fail. */
-void shuffle(size_t bytesoftype, size_t blocksize,
-             const uint8_t* _src, uint8_t* _dest) {
-  int unaligned_src = (int)((uintptr_t)_src % 32);
-  int unaligned_dest = (int)((uintptr_t)_dest % 32);
-  int multiple_of_block = (blocksize % (32 * bytesoftype)) == 0;
-  int too_small = (blocksize < 256);
-
-  if (unaligned_src || unaligned_dest || !multiple_of_block || too_small) {
-    /* _dest buffer is not aligned, not multiple of the vectorization size
-     * or is too small.  Call the non-simd version. */
-    _shuffle(bytesoftype, blocksize, _src, _dest);
-    return;
-  }
-
-  /* Optimized shuffle */
-  /* The buffer must be aligned on a 16 bytes boundary, have a power */
-  /* of 2 size and be larger or equal than 256 bytes. */
-  if (bytesoftype == 4) {
-    shuffle4_AVX2(_dest, _src, blocksize);
-  }
-  else if (bytesoftype == 8) {
-    shuffle8_AVX2(_dest, _src, blocksize);
-  }
-  else if (bytesoftype == 16) {
-    shuffle16_AVX2(_dest, _src, blocksize);
-  }
-  else if (bytesoftype == 2) {
-    shuffle2_AVX2(_dest, _src, blocksize);
-  }
-  else {
-    /* Non-optimized shuffle */
-    _shuffle(bytesoftype, blocksize, _src, _dest);
-  }
-}
-
-
-/* Routine optimized for unshuffling a buffer for a type size of 2 bytes. */
-static void
-unshuffle2_AVX2(uint8_t* dest, const uint8_t* src, size_t size)
-{
-  size_t i, j;
-  size_t nitem;
-  __m256i a[2], b[2], c[2];
-
-  nitem = size/64;
-  for( i=0, j=0;i<nitem;i++,j+=2 ) {
-    a[0] = ((__m256i *)src)[0*nitem+i];
-    a[1] = ((__m256i *)src)[1*nitem+i];
-    a[0] = _mm256_permute4x64_epi64(a[0], 0xD8);
-    a[1] = _mm256_permute4x64_epi64(a[1], 0xD8);
-    b[0] = _mm256_unpacklo_epi8(a[0], a[1]);
-    b[1] = _mm256_unpackhi_epi8(a[0], a[1]);
-    ((__m256i *)dest)[j+0] = b[0];
-    ((__m256i *)dest)[j+1] = b[1];
-  }
-}
-
-
-/* Routine optimized for unshuffling a buffer for a type size of 4 bytes. */
-static void
-unshuffle4_AVX2(uint8_t* dest, const uint8_t* orig, size_t size)
-{
-  size_t i, j, k;
-  size_t neblock, numof16belem;
-  __m256i ymm0[4], ymm1[4];
-
-  neblock = size / 4;
-  numof16belem = neblock / 32;
-  for (i = 0, k = 0; i < numof16belem; i++, k += 4) {
-    /* Load the first 64 bytes in 4 XMM registrers */
-    for (j = 0; j < 4; j++) {
-      ymm0[j] = ((__m256i *)orig)[j*numof16belem+i];
-    }
-    /* Shuffle bytes */
-    for (j = 0; j < 2; j++) {
-      /* Compute the low 32 bytes */
-      ymm1[j] = _mm256_unpacklo_epi8(ymm0[j*2], ymm0[j*2+1]);
-      /* Compute the hi 32 bytes */
-      ymm1[2+j] = _mm256_unpackhi_epi8(ymm0[j*2], ymm0[j*2+1]);
-    }
-
-    /* Shuffle 2-byte words */
-    for (j = 0; j < 2; j++) {
-      /* Compute the low 32 bytes */
-      ymm0[j] = _mm256_unpacklo_epi16(ymm1[j*2], ymm1[j*2+1]);
-      /* Compute the hi 32 bytes */
-      ymm0[2+j] = _mm256_unpackhi_epi16(ymm1[j*2], ymm1[j*2+1]);
-    }
-
-	ymm1[0] = _mm256_permute2x128_si256(ymm0[0], ymm0[2], 0x20);
-	ymm1[1] = _mm256_permute2x128_si256(ymm0[1], ymm0[3], 0x20);
-	ymm1[2] = _mm256_permute2x128_si256(ymm0[0], ymm0[2], 0x31);
-	ymm1[3] = _mm256_permute2x128_si256(ymm0[1], ymm0[3], 0x31);
-
-    /* Store the result vectors in proper order */
-    ((__m256i *)dest)[k+0] = ymm1[0];
-    ((__m256i *)dest)[k+1] = ymm1[1];
-    ((__m256i *)dest)[k+2] = ymm1[2];
-    ((__m256i *)dest)[k+3] = ymm1[3];
-  }
-}
-
-
-/* Routine optimized for unshuffling a buffer for a type size of 8 bytes. */
-static void
-unshuffle8_AVX2(uint8_t* dest, const uint8_t* orig, size_t size)
-{
-  size_t i, j, k;
-  size_t neblock, numof16belem;
-  __m256i ymm0[8], ymm1[8];
-
-  neblock = size / 8;
-  numof16belem = neblock/32;
-  for (i = 0, k = 0; i < numof16belem; i++, k += 8) {
-    /* Load the first 64 bytes in 8 XMM registrers */
-    for (j = 0; j < 8; j++) {
-      ymm0[j] = ((__m256i *)orig)[j*numof16belem+i];
-    }
-    /* Shuffle bytes */
-    for (j = 0; j < 4; j++) {
-      /* Compute the low 32 bytes */
-      ymm1[j] = _mm256_unpacklo_epi8(ymm0[j*2], ymm0[j*2+1]);
-      /* Compute the hi 32 bytes */
-      ymm1[4+j] = _mm256_unpackhi_epi8(ymm0[j*2], ymm0[j*2+1]);
-    }
-    /* Shuffle 2-byte words */
-    for (j = 0; j < 4; j++) {
-      /* Compute the low 32 bytes */
-      ymm0[j] = _mm256_unpacklo_epi16(ymm1[j*2], ymm1[j*2+1]);
-      /* Compute the hi 32 bytes */
-      ymm0[4+j] = _mm256_unpackhi_epi16(ymm1[j*2], ymm1[j*2+1]);
-    }
-
-     for( j=0;j<8;j++)
-      {
-        ymm0[j] = _mm256_permute4x64_epi64(ymm0[j], 0xD8);
-      }
-
-    /* Shuffle 4-byte dwords */
-    for (j = 0; j < 4; j++) {
-      /* Compute the low 32 bytes */
-      ymm1[j] = _mm256_unpacklo_epi32(ymm0[j*2], ymm0[j*2+1]);
-      /* Compute the hi 32 bytes */
-      ymm1[4+j] = _mm256_unpackhi_epi32(ymm0[j*2], ymm0[j*2+1]);
-    }
-
-    /* Store the result vectors in proper order */
-      ((__m256i *)dest)[k+0] = ymm1[0];
-      ((__m256i *)dest)[k+1] = ymm1[2];
-      ((__m256i *)dest)[k+2] = ymm1[1];
-      ((__m256i *)dest)[k+3] = ymm1[3];
-      ((__m256i *)dest)[k+4] = ymm1[4];
-      ((__m256i *)dest)[k+5] = ymm1[6];
-      ((__m256i *)dest)[k+6] = ymm1[5];
-      ((__m256i *)dest)[k+7] = ymm1[7];
-  }
-}
-
-
-/* Routine optimized for unshuffling a buffer for a type size of 16 bytes. */
-static void
-unshuffle16_AVX2(uint8_t* dest, const uint8_t* orig, size_t size)
-{
-  size_t i, j, k;
-  size_t neblock, numof16belem;
-  __m256i ymm1[16], ymm2[16];
-
-  neblock = size / 16;
-  numof16belem = neblock / 32;
-  for (i = 0, k = 0; i < numof16belem; i++, k += 16) {
-    /* Load the first 128 bytes in 16 XMM registrers */
-    for (j = 0; j < 16; j++) {
-      ymm1[j] = ((__m256i *)orig)[j*numof16belem+i];
-    }
-    /* Shuffle bytes */
-    for (j = 0; j < 8; j++) {
-      /* Compute the low 32 bytes */
-      ymm2[j] = _mm256_unpacklo_epi8(ymm1[j*2], ymm1[j*2+1]);
-      /* Compute the hi 32 bytes */
-      ymm2[8+j] = _mm256_unpackhi_epi8(ymm1[j*2], ymm1[j*2+1]);
-    }
-    /* Shuffle 2-byte words */
-    for (j = 0; j < 8; j++) {
-      /* Compute the low 32 bytes */
-      ymm1[j] = _mm256_unpacklo_epi16(ymm2[j*2], ymm2[j*2+1]);
-      /* Compute the hi 32 bytes */
-      ymm1[8+j] = _mm256_unpackhi_epi16(ymm2[j*2], ymm2[j*2+1]);
-    }
-    /* Shuffle 4-byte dwords */
-    for (j = 0; j < 8; j++) {
-      /* Compute the low 32 bytes */
-      ymm2[j] = _mm256_unpacklo_epi32(ymm1[j*2], ymm1[j*2+1]);
-      /* Compute the hi 32 bytes */
-      ymm2[8+j] = _mm256_unpackhi_epi32(ymm1[j*2], ymm1[j*2+1]);
-    }
-
-    /* Shuffle 8-byte qwords */
-    for (j = 0; j < 8; j++) {
-      /* Compute the low 32 bytes */
-      ymm1[j] = _mm256_unpacklo_epi64(ymm2[j*2], ymm2[j*2+1]);
-      /* Compute the hi 32 bytes */
-      ymm1[8+j] = _mm256_unpackhi_epi64(ymm2[j*2], ymm2[j*2+1]);
-    }
-
-    for( j=0;j<8;j++) {
-      ymm2[j] = _mm256_permute2x128_si256(ymm1[j], ymm1[j+8], 0x20);
-      ymm2[j+8] = _mm256_permute2x128_si256(ymm1[j], ymm1[j+8], 0x31);
-    }
-
-    /* Store the result vectors in proper order */
-    ((__m256i *)dest)[k+0] = ymm2[0];
-    ((__m256i *)dest)[k+1] = ymm2[4];
-    ((__m256i *)dest)[k+2] = ymm2[2];
-    ((__m256i *)dest)[k+3] = ymm2[6];
-    ((__m256i *)dest)[k+4] = ymm2[1];
-    ((__m256i *)dest)[k+5] = ymm2[5];
-    ((__m256i *)dest)[k+6] = ymm2[3];
-    ((__m256i *)dest)[k+7] = ymm2[7];
-    ((__m256i *)dest)[k+8] = ymm2[8];
-    ((__m256i *)dest)[k+9] = ymm2[12];
-    ((__m256i *)dest)[k+10] = ymm2[10];
-    ((__m256i *)dest)[k+11] = ymm2[14];
-    ((__m256i *)dest)[k+12] = ymm2[9];
-    ((__m256i *)dest)[k+13] = ymm2[13];
-    ((__m256i *)dest)[k+14] = ymm2[11];
-    ((__m256i *)dest)[k+15] = ymm2[15];
-  }
-}
-
-
-/* Unshuffle a block.  This can never fail. */
-void unshuffle(size_t bytesoftype, size_t blocksize,
-               const uint8_t* _src, uint8_t* _dest) {
-  int unaligned_src = (int)((uintptr_t)_src % 32);
-  int unaligned_dest = (int)((uintptr_t)_dest % 32);
-  int multiple_of_block = (blocksize % (32 * bytesoftype)) == 0;
-  int too_small = (blocksize < 256);
-
-  if (unaligned_src || unaligned_dest || !multiple_of_block || too_small) {
-    /* _src or _dest buffer is not aligned, not multiple of the vectorization
-     * size or is not too small.  Call the non-simd version. */
-    _unshuffle(bytesoftype, blocksize, _src, _dest);
-    return;
-  }
-
-  /* Optimized unshuffle */
-  /* The buffers must be aligned on a 16 bytes boundary, have a power */
-  /* of 2 size and be larger or equal than 256 bytes. */
-  if (bytesoftype == 4) {
-    unshuffle4_AVX2(_dest, _src, blocksize);
-  }
-  else if (bytesoftype == 8) {
-    unshuffle8_AVX2(_dest, _src, blocksize);
-  }
-  else if (bytesoftype == 16) {
-    unshuffle16_AVX2(_dest, _src, blocksize);
-  }
-  else if (bytesoftype == 2) {
-    unshuffle2_AVX2(_dest, _src, blocksize);
-  }
-  else {
-    /* Non-optimized unshuffle */
-    _unshuffle(bytesoftype, blocksize, _src, _dest);
-  }
-}
-
-
-#elif defined(__SSE2__)
+#if defined(__SSE2__)
 /* #pragma message "Using SSE2 version shuffle/unshuffle" */
 
 /* The SSE2 versions of shuffle and unshuffle */
@@ -713,8 +280,8 @@ shuffle16_SSE2(uint8_t* dest, const uint8_t* src, size_t size)
 /* Shuffle a block.  This can never fail. */
 void shuffle(size_t bytesoftype, size_t blocksize,
              const uint8_t* _src, uint8_t* _dest) {
-  int unaligned_dest = (int)((uintptr_t)_dest % 16);
-  int multiple_of_block = (blocksize % (16 * bytesoftype)) == 0;
+  int unaligned_dest = (int)((uintptr_t)_dest % 32);
+  int multiple_of_block = (blocksize % (32 * bytesoftype)) == 0;
   int too_small = (blocksize < 256);
 
   if (unaligned_dest || !multiple_of_block || too_small) {
@@ -727,21 +294,44 @@ void shuffle(size_t bytesoftype, size_t blocksize,
   /* Optimized shuffle */
   /* The buffer must be aligned on a 16 bytes boundary, have a power */
   /* of 2 size and be larger or equal than 256 bytes. */
-  if (bytesoftype == 4) {
-    shuffle4_SSE2(_dest, _src, blocksize);
+#ifdef HAVE_AVX2
+  if (have_avx2()) {
+      if (bytesoftype == 4) {
+        shuffle4_AVX2(_dest, _src, blocksize);
+      }
+      else if (bytesoftype == 8) {
+        shuffle8_AVX2(_dest, _src, blocksize);
+      }
+      else if (bytesoftype == 16) {
+        shuffle16_AVX2(_dest, _src, blocksize);
+      }
+      else if (bytesoftype == 2) {
+        shuffle2_AVX2(_dest, _src, blocksize);
+      }
+      else {
+        /* Non-optimized shuffle */
+        _shuffle(bytesoftype, blocksize, _src, _dest);
+      }
   }
-  else if (bytesoftype == 8) {
-    shuffle8_SSE2(_dest, _src, blocksize);
-  }
-  else if (bytesoftype == 16) {
-    shuffle16_SSE2(_dest, _src, blocksize);
-  }
-  else if (bytesoftype == 2) {
-    shuffle2_SSE2(_dest, _src, blocksize);
-  }
-  else {
-    /* Non-optimized shuffle */
-    _shuffle(bytesoftype, blocksize, _src, _dest);
+  else
+#endif
+  {
+      if (bytesoftype == 4) {
+        shuffle4_SSE2(_dest, _src, blocksize);
+      }
+      else if (bytesoftype == 8) {
+        shuffle8_SSE2(_dest, _src, blocksize);
+      }
+      else if (bytesoftype == 16) {
+        shuffle16_SSE2(_dest, _src, blocksize);
+      }
+      else if (bytesoftype == 2) {
+        shuffle2_SSE2(_dest, _src, blocksize);
+      }
+      else {
+        /* Non-optimized shuffle */
+        _shuffle(bytesoftype, blocksize, _src, _dest);
+      }
   }
 }
 
@@ -922,43 +512,6 @@ unshuffle16_SSE2(uint8_t* dest, const uint8_t* orig, size_t size)
   }
 }
 
-
-/* Unshuffle a block.  This can never fail. */
-void unshuffle(size_t bytesoftype, size_t blocksize,
-               const uint8_t* _src, uint8_t* _dest) {
-  int unaligned_src = (int)((uintptr_t)_src % 16);
-  int unaligned_dest = (int)((uintptr_t)_dest % 16);
-  int multiple_of_block = (blocksize % (16 * bytesoftype)) == 0;
-  int too_small = (blocksize < 256);
-
-  if (unaligned_src || unaligned_dest || !multiple_of_block || too_small) {
-    /* _src or _dest buffer is not aligned, not multiple of the vectorization
-     * size or is not too small.  Call the non-sse2 version. */
-    _unshuffle(bytesoftype, blocksize, _src, _dest);
-    return;
-  }
-
-  /* Optimized unshuffle */
-  /* The buffers must be aligned on a 16 bytes boundary, have a power */
-  /* of 2 size and be larger or equal than 256 bytes. */
-  if (bytesoftype == 4) {
-    unshuffle4_SSE2(_dest, _src, blocksize);
-  }
-  else if (bytesoftype == 8) {
-    unshuffle8_SSE2(_dest, _src, blocksize);
-  }
-  else if (bytesoftype == 16) {
-    unshuffle16_SSE2(_dest, _src, blocksize);
-  }
-  else if (bytesoftype == 2) {
-    unshuffle2_SSE2(_dest, _src, blocksize);
-  }
-  else {
-    /* Non-optimized unshuffle */
-    _unshuffle(bytesoftype, blocksize, _src, _dest);
-  }
-}
-
 #else   /* no __SSE2__ available */
 
 void shuffle(size_t bytesoftype, size_t blocksize,
@@ -972,3 +525,63 @@ void unshuffle(size_t bytesoftype, size_t blocksize,
 }
 
 #endif  /* __SSE2__ */
+
+/* Unshuffle a block.  This can never fail. */
+void unshuffle(size_t bytesoftype, size_t blocksize,
+               const uint8_t* _src, uint8_t* _dest) {
+  int unaligned_src = (int)((uintptr_t)_src % 32);
+  int unaligned_dest = (int)((uintptr_t)_dest % 32);
+  int multiple_of_block = (blocksize % (32 * bytesoftype)) == 0;
+  int too_small = (blocksize < 256);
+
+  if (unaligned_src || unaligned_dest || !multiple_of_block || too_small) {
+    /* _src or _dest buffer is not aligned, not multiple of the vectorization
+     * size or is not too small.  Call the non-sse2 version. */
+    _unshuffle(bytesoftype, blocksize, _src, _dest);
+    return;
+  }
+
+  /* Optimized unshuffle */
+  /* The buffers must be aligned on a 16 bytes boundary, have a power */
+  /* of 2 size and be larger or equal than 256 bytes. */
+#ifdef HAVE_AVX2
+  if (have_avx2()) {
+    if (bytesoftype == 4) {
+      unshuffle4_AVX2(_dest, _src, blocksize);
+    }
+    else if (bytesoftype == 8) {
+      unshuffle8_AVX2(_dest, _src, blocksize);
+    }
+    else if (bytesoftype == 16) {
+      unshuffle16_AVX2(_dest, _src, blocksize);
+    }
+    else if (bytesoftype == 2) {
+      unshuffle2_AVX2(_dest, _src, blocksize);
+    }
+    else {
+      /* Non-optimized unshuffle */
+      _unshuffle(bytesoftype, blocksize, _src, _dest);
+    }
+  }
+  else
+#endif
+  {
+    if (bytesoftype == 4) {
+      unshuffle4_SSE2(_dest, _src, blocksize);
+    }
+    else if (bytesoftype == 8) {
+      unshuffle8_SSE2(_dest, _src, blocksize);
+    }
+    else if (bytesoftype == 16) {
+      unshuffle16_SSE2(_dest, _src, blocksize);
+    }
+    else if (bytesoftype == 2) {
+      unshuffle2_SSE2(_dest, _src, blocksize);
+    }
+    else {
+      /* Non-optimized unshuffle */
+      _unshuffle(bytesoftype, blocksize, _src, _dest);
+    }
+  }
+}
+


### PR DESCRIPTION
allows building portable binaries that still can use AVX2 on appropriate
hardware.
Currently only supported compiler is GCC >= 4.8 (avx2 support landed in 4.7)
and increases alignment requirement to 32 for all vectorized shuffles.
This could be relaxed with more code or even removed, to my knowledge
haswell, unlike sandy bridge, does not suffer any measurable penalty for
not 32 byte aligned memory.