### PR TITLE
Pthreads for Windows support (v1.6.0 based)

### DIFF
--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -98,7 +98,7 @@ set_target_properties(blosc_shared PROPERTIES
         SOVERSION 1  # Change this when an ABI change happens
     )
 if (MSVC)
-	set_target_properties (blosc_shared PROPERTIES COMPILE_FLAGS -DDLL_EXPORT=TRUE)
+	set_target_properties (blosc_shared PROPERTIES COMPILE_FLAGS -DBLOSC_DLL_EXPORT=TRUE)
 endif(MSVC)
 
 if(COMPILER_SUPPORT_SSE2)

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -49,7 +49,7 @@
   #include <inttypes.h>
 #endif  /* _WIN32 */
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(__GNUC__)
   #include "win32/pthread.h"
   #include "win32/pthread.c"
 #else

--- a/blosc/blosc.h
+++ b/blosc/blosc.h
@@ -14,12 +14,12 @@
 extern "C" {
 #endif
 
-#ifdef DLL_EXPORT
-    #undef DLL_EXPORT
-	#define DLL_EXPORT __declspec(dllexport)
+#ifdef BLOSC_DLL_EXPORT
+    #undef BLOSC_DLL_EXPORT
+	#define BLOSC_DLL_EXPORT __declspec(dllexport)
 #else
-    #undef DLL_EXPORT
-	#define DLL_EXPORT
+    #undef BLOSC_DLL_EXPORT
+	#define BLOSC_DLL_EXPORT
 #endif
 
 /* Version numbers */
@@ -109,7 +109,7 @@ extern "C" {
   which case you should *exclusively* use the
   blosc_compress_ctx()/blosc_decompress_ctx() pair (see below).
   */
-DLL_EXPORT void blosc_init(void);
+BLOSC_DLL_EXPORT void blosc_init(void);
 
 
 /**
@@ -119,7 +119,7 @@ DLL_EXPORT void blosc_init(void);
   unless you have not used blosc_init() before (see blosc_init()
   above).
   */
-DLL_EXPORT void blosc_destroy(void);
+BLOSC_DLL_EXPORT void blosc_destroy(void);
 
 
 /**
@@ -156,9 +156,9 @@ DLL_EXPORT void blosc_destroy(void);
   should never happen.  If you see this, please report it back
   together with the buffer data causing this and compression settings.
   */
-DLL_EXPORT int blosc_compress(int clevel, int doshuffle, size_t typesize,
-                              size_t nbytes, const void *src, void *dest,
-                              size_t destsize);
+BLOSC_DLL_EXPORT int blosc_compress(int clevel, int doshuffle, size_t typesize,
+                                    size_t nbytes, const void *src, void *dest,
+                                    size_t destsize);
 
 
 /**
@@ -180,10 +180,10 @@ DLL_EXPORT int blosc_compress(int clevel, int doshuffle, size_t typesize,
   should never happen.  If you see this, please report it back
   together with the buffer data causing this and compression settings.
 */
-DLL_EXPORT int blosc_compress_ctx(int clevel, int doshuffle, size_t typesize,
-                                  size_t nbytes, const void* src, void* dest,
-                                  size_t destsize, const char* compressor,
-                                  size_t blocksize, int numinternalthreads);
+BLOSC_DLL_EXPORT int blosc_compress_ctx(int clevel, int doshuffle, size_t typesize,
+                                        size_t nbytes, const void* src, void* dest,
+                                        size_t destsize, const char* compressor,
+                                        size_t blocksize, int numinternalthreads);
 
 /**
   Decompress a block of compressed data in `src`, put the result in
@@ -198,7 +198,7 @@ DLL_EXPORT int blosc_compress_ctx(int clevel, int doshuffle, size_t typesize,
   output buffer is not large enough, then 0 (zero) or a negative value
   will be returned instead.
 */
-DLL_EXPORT int blosc_decompress(const void *src, void *dest, size_t destsize);
+BLOSC_DLL_EXPORT int blosc_decompress(const void *src, void *dest, size_t destsize);
 
 
 /**
@@ -218,7 +218,7 @@ DLL_EXPORT int blosc_decompress(const void *src, void *dest, size_t destsize);
   output buffer is not large enough, then 0 (zero) or a negative value
   will be returned instead.
 */
-DLL_EXPORT int blosc_decompress_ctx(const void *src, void *dest,
+BLOSC_DLL_EXPORT int blosc_decompress_ctx(const void *src, void *dest,
                                     size_t destsize, int numinternalthreads);
 
 /**
@@ -229,7 +229,7 @@ DLL_EXPORT int blosc_decompress_ctx(const void *src, void *dest,
   Returns the number of bytes copied to `dest` or a negative value if
   some error happens.
   */
-DLL_EXPORT int blosc_getitem(const void *src, int start, int nitems, void *dest);
+BLOSC_DLL_EXPORT int blosc_getitem(const void *src, int start, int nitems, void *dest);
 
 
 /**
@@ -240,7 +240,7 @@ DLL_EXPORT int blosc_getitem(const void *src, int start, int nitems, void *dest)
 
   Returns the previous number of threads.
   */
-DLL_EXPORT int blosc_set_nthreads(int nthreads);
+BLOSC_DLL_EXPORT int blosc_set_nthreads(int nthreads);
 
 
 /**
@@ -252,7 +252,7 @@ DLL_EXPORT int blosc_set_nthreads(int nthreads);
   for it in this build, it returns a -1.  Else it returns the code for
   the compressor (>=0).
   */
-DLL_EXPORT int blosc_set_compressor(const char* compname);
+BLOSC_DLL_EXPORT int blosc_set_compressor(const char* compname);
 
 
 /**
@@ -262,7 +262,7 @@ DLL_EXPORT int blosc_set_compressor(const char* compname);
   for it in this build, -1 is returned.  Else, the compressor code is
   returned.
  */
-DLL_EXPORT int blosc_compcode_to_compname(int compcode, char **compname);
+BLOSC_DLL_EXPORT int blosc_compcode_to_compname(int compcode, char **compname);
 
 
 /**
@@ -271,7 +271,7 @@ DLL_EXPORT int blosc_compcode_to_compname(int compcode, char **compname);
   If the compressor name is not recognized, or there is not support
   for it in this build, -1 is returned instead.
  */
-DLL_EXPORT int blosc_compname_to_compcode(const char *compname);
+BLOSC_DLL_EXPORT int blosc_compname_to_compcode(const char *compname);
 
 
 /**
@@ -285,7 +285,7 @@ DLL_EXPORT int blosc_compname_to_compcode(const char *compname);
 
   This function should always succeed.
   */
-DLL_EXPORT char* blosc_list_compressors(void);
+BLOSC_DLL_EXPORT char* blosc_list_compressors(void);
 
 
 /**
@@ -302,7 +302,7 @@ DLL_EXPORT char* blosc_list_compressors(void);
   If the compressor is supported, it returns the code for the library
   (>=0).  If it is not supported, this function returns -1.
   */
-DLL_EXPORT int blosc_get_complib_info(char *compname, char **complib, char **version);
+BLOSC_DLL_EXPORT int blosc_get_complib_info(char *compname, char **complib, char **version);
 
 
 /**
@@ -311,7 +311,7 @@ DLL_EXPORT int blosc_get_complib_info(char *compname, char **complib, char **ver
   problems releasing the resources, it returns a negative number, else
   it returns 0.
   */
-DLL_EXPORT int blosc_free_resources(void);
+BLOSC_DLL_EXPORT int blosc_free_resources(void);
 
 
 /**
@@ -325,8 +325,8 @@ DLL_EXPORT int blosc_free_resources(void);
 
   This function should always succeed.
   */
-DLL_EXPORT void blosc_cbuffer_sizes(const void *cbuffer, size_t *nbytes,
-                         size_t *cbytes, size_t *blocksize);
+BLOSC_DLL_EXPORT void blosc_cbuffer_sizes(const void *cbuffer, size_t *nbytes,
+                                          size_t *cbytes, size_t *blocksize);
 
 
 /**
@@ -343,8 +343,8 @@ DLL_EXPORT void blosc_cbuffer_sizes(const void *cbuffer, size_t *nbytes,
 
   This function should always succeed.
   */
-DLL_EXPORT void blosc_cbuffer_metainfo(const void *cbuffer, size_t *typesize,
-                            int *flags);
+BLOSC_DLL_EXPORT void blosc_cbuffer_metainfo(const void *cbuffer, size_t *typesize,
+                                             int *flags);
 
 
 /**
@@ -354,8 +354,8 @@ DLL_EXPORT void blosc_cbuffer_metainfo(const void *cbuffer, size_t *typesize,
 
   This function should always succeed.
   */
-DLL_EXPORT void blosc_cbuffer_versions(const void *cbuffer, int *version,
-                            int *versionlz);
+BLOSC_DLL_EXPORT void blosc_cbuffer_versions(const void *cbuffer, int *version,
+                                             int *versionlz);
 
 
 /**
@@ -363,7 +363,7 @@ DLL_EXPORT void blosc_cbuffer_versions(const void *cbuffer, int *version,
 
   This function should always succeed.
   */
-DLL_EXPORT char *blosc_cbuffer_complib(const void *cbuffer);
+BLOSC_DLL_EXPORT char *blosc_cbuffer_complib(const void *cbuffer);
 
 
 
@@ -378,7 +378,7 @@ DLL_EXPORT char *blosc_cbuffer_complib(const void *cbuffer);
   Force the use of a specific blocksize.  If 0, an automatic
   blocksize will be used (the default).
   */
-DLL_EXPORT void blosc_set_blocksize(size_t blocksize);
+BLOSC_DLL_EXPORT void blosc_set_blocksize(size_t blocksize);
 
 #ifdef __cplusplus
 }

--- a/blosc/config.h.in
+++ b/blosc/config.h.in
@@ -4,7 +4,7 @@
 #cmakedefine HAVE_LZ4 @HAVE_LZ4@
 #cmakedefine HAVE_SNAPPY @HAVE_SNAPPY@
 #cmakedefine HAVE_ZLIB @HAVE_ZLIB@
-#cmakedefine DLL_EXPORT @DLL_EXPORT@
+#cmakedefine BLOSC_DLL_EXPORT @DLL_EXPORT@
 
 
 #endif

--- a/blosc/shuffle-avx2.h
+++ b/blosc/shuffle-avx2.h
@@ -20,14 +20,14 @@ extern "C" {
 /**
   AVX2-accelerated shuffle routine.
 */
-DLL_EXPORT void shuffle_avx2(const size_t bytesoftype, const size_t blocksize,
-             const uint8_t* const _src, uint8_t* const _dest);
+BLOSC_DLL_EXPORT void shuffle_avx2(const size_t bytesoftype, const size_t blocksize,
+                                   const uint8_t* const _src, uint8_t* const _dest);
 
 /**
   AVX2-accelerated unshuffle routine.
 */
-DLL_EXPORT void unshuffle_avx2(const size_t bytesoftype, const size_t blocksize,
-               const uint8_t* const _src, uint8_t* const _dest);
+BLOSC_DLL_EXPORT void unshuffle_avx2(const size_t bytesoftype, const size_t blocksize,
+                                     const uint8_t* const _src, uint8_t* const _dest);
 
 #ifdef __cplusplus
 }

--- a/blosc/shuffle-common.h
+++ b/blosc/shuffle-common.h
@@ -10,12 +10,12 @@
 #define SHUFFLE_COMMON_H
 
 /* Macro for specifying an exported function. */
-#if defined(_WIN32) && defined(DLL_EXPORT)
-  #undef DLL_EXPORT
-  #define DLL_EXPORT __declspec(dllexport)
+#if defined(_WIN32) && defined(BLOSC_DLL_EXPORT)
+  #undef BLOSC_DLL_EXPORT
+  #define BLOSC_DLL_EXPORT __declspec(dllexport)
 #else
-  #undef DLL_EXPORT
-  #define DLL_EXPORT
+  #undef BLOSC_DLL_EXPORT
+  #define BLOSC_DLL_EXPORT
 #endif
 
 /* Define the __SSE2__ symbol if compiling with Visual C++ and

--- a/blosc/shuffle-generic.h
+++ b/blosc/shuffle-generic.h
@@ -24,14 +24,14 @@ extern "C" {
 /**
   Generic (non-hardware-accelerated) shuffle routine.
 */
-DLL_EXPORT void shuffle_generic(const size_t bytesoftype, const size_t blocksize,
-             const uint8_t* const _src, uint8_t* const _dest);
+BLOSC_DLL_EXPORT void shuffle_generic(const size_t bytesoftype, const size_t blocksize,
+                                      const uint8_t* const _src, uint8_t* const _dest);
 
 /**
   Generic (non-hardware-accelerated) unshuffle routine.
 */
-DLL_EXPORT void unshuffle_generic(const size_t bytesoftype, const size_t blocksize,
-               const uint8_t* const _src, uint8_t* const _dest);
+BLOSC_DLL_EXPORT void unshuffle_generic(const size_t bytesoftype, const size_t blocksize,
+                                        const uint8_t* const _src, uint8_t* const _dest);
 
 #ifdef __cplusplus
 }

--- a/blosc/shuffle-sse2.h
+++ b/blosc/shuffle-sse2.h
@@ -20,14 +20,14 @@ extern "C" {
 /**
   SSE2-accelerated shuffle routine.
 */
-DLL_EXPORT void shuffle_sse2(const size_t bytesoftype, const size_t blocksize,
-             const uint8_t* const _src, uint8_t* const _dest);
+BLOSC_DLL_EXPORT void shuffle_sse2(const size_t bytesoftype, const size_t blocksize,
+                                   const uint8_t* const _src, uint8_t* const _dest);
 
 /**
   SSE2-accelerated unshuffle routine.
 */
-DLL_EXPORT void unshuffle_sse2(const size_t bytesoftype, const size_t blocksize,
-               const uint8_t* const _src, uint8_t* const _dest);
+BLOSC_DLL_EXPORT void unshuffle_sse2(const size_t bytesoftype, const size_t blocksize,
+                                     const uint8_t* const _src, uint8_t* const _dest);
 
 #ifdef __cplusplus
 }

--- a/blosc/shuffle.h
+++ b/blosc/shuffle.h
@@ -31,8 +31,8 @@ extern "C" {
   calling the hardware-accelerated routines because this method is both cross-
   platform and future-proof.
 */
-DLL_EXPORT void shuffle(const size_t bytesoftype, const size_t blocksize,
-             const uint8_t* const _src, uint8_t* const _dest);
+BLOSC_DLL_EXPORT void shuffle(const size_t bytesoftype, const size_t blocksize,
+                              const uint8_t* const _src, uint8_t* const _dest);
 
 /**
   Primary unshuffle routine.
@@ -44,8 +44,8 @@ DLL_EXPORT void shuffle(const size_t bytesoftype, const size_t blocksize,
   calling the hardware-accelerated routines because this method is both cross-
   platform and future-proof.
 */
-DLL_EXPORT void unshuffle(const size_t bytesoftype, const size_t blocksize,
-               const uint8_t* const _src, uint8_t* const _dest);
+BLOSC_DLL_EXPORT void unshuffle(const size_t bytesoftype, const size_t blocksize,
+                                const uint8_t* const _src, uint8_t* const _dest);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fix #92.
Tested with `MinGW` and `TDM-GCC `.

`TDM-GCC`
```
>gcc --version
gcc (tdm64-1) 4.9.2
```
`MinGW`
```
>gcc --version
gcc (i686-posix-dwarf-rev2, Built by MinGW-W64 project) 4.9.1
```