### PR TITLE
fix build on non-intel architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,8 +139,11 @@ endif(NOT CMAKE_BUILD_TYPE)
 # by the compiler. Note we DO NOT check which hardware features are supported
 # by this (the host) system, because we want to be able to support compiling
 # for newer hardware on older machines as well as cross-compilation.
-set(SYSTEM_PROCESSOR_INTEL_X86 ((CMAKE_SYSTEM_PROCESSOR STREQUAL i686) OR (CMAKE_SYSTEM_PROCESSOR STREQUAL x86) OR (CMAKE_SYSTEM_PROCESSOR STREQUAL AMD64)))
-if(SYSTEM_PROCESSOR_INTEL_X86)
+message(STATUS "Building for system processor ${CMAKE_SYSTEM_PROCESSOR}.")
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL i386 OR
+   CMAKE_SYSTEM_PROCESSOR STREQUAL i686 OR
+   CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR
+   CMAKE_SYSTEM_PROCESSOR STREQUAL amd64)
     if(CMAKE_C_COMPILER_ID STREQUAL GNU)
         set(COMPILER_SUPPORT_SSE2 TRUE)
         if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 4.7 OR CMAKE_C_COMPILER_VERSION VERSION_EQUAL 4.7)
@@ -175,7 +178,7 @@ if(SYSTEM_PROCESSOR_INTEL_X86)
         # Unrecognized compiler. Emit a warning message to let the user know hardware-acceleration won't be available.
         message(WARNING "Unable to determine which ${CMAKE_SYSTEM_PROCESSOR} hardware features are supported by the C compiler (${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION}).")
     endif()
-else(SYSTEM_PROCESSOR_INTEL_X86)
+else()
     # If the target system processor isn't recognized, emit a warning message to alert the user
     # that hardware-acceleration support won't be available but allow configuration to proceed.
     message(WARNING "Unrecognized system processor ${CMAKE_SYSTEM_PROCESSOR}. Cannot determine which hardware features (${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION}) supports, so hardware-accelerated implementations will not be available.")

--- a/blosc/shuffle.c
+++ b/blosc/shuffle.c
@@ -217,6 +217,10 @@ static blosc_cpu_features blosc_get_cpu_features(void) {
   #warning Hardware-acceleration detection not implemented for the target architecture. Only the generic shuffle/unshuffle routines will be available.
   #endif
 
+static blosc_cpu_features blosc_get_cpu_features(void) {
+  return BLOSC_HAVE_NOTHING;
+}
+
 #endif
 
 static shuffle_implementation_t


### PR DESCRIPTION
Build on arm was failing. First, the test for sse2 was detecting it as an intel processor, passing -msse2 to the compiler which cannot work. Second, link was failing because of a missing function.

Build with those patches: https://kojipkgs.fedoraproject.org//work/tasks/9975/9679975/build.log