### PR TITLE
Build with CMake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,6 @@ before_script:
   - cd build
   - cmake -DBUILD_HDF5_FILTER=TRUE ..
 
-script: make && make test
+script:
+  - cmake --build . --config Release
+  - cmake --build . --config Release --target test

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ before_script:
 
 script:
   - cmake --build . --config Release
-  - cmake --build . --config Release --target test
+  - ctest

--- a/README.rst
+++ b/README.rst
@@ -198,9 +198,9 @@ Build, test and install Blosc:
 
 .. code-block:: console
 
-  $ make
-  $ make test
-  $ make install
+  $ cmake --build .
+  $ cmake --build . --target test
+  $ cmake --build . --target install
 
 The static and dynamic version of the Blosc library, together with
 header files, will be installed into the specified

--- a/README.rst
+++ b/README.rst
@@ -199,7 +199,7 @@ Build, test and install Blosc:
 .. code-block:: console
 
   $ cmake --build .
-  $ cmake --build . --target test
+  $ ctest
   $ cmake --build . --target install
 
 The static and dynamic version of the Blosc library, together with

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -21,8 +21,8 @@ Testing
 Create a new build/ directory, change into it and issue::
 
   $ cmake -DBUILD_HDF5_FILTER=TRUE ..
-  $ make
-  $ make test
+  $ cmake --build .
+  $ cmake --build . --target test
 
 To actually test Blosc the hard way, look at the end of:
 

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -22,7 +22,7 @@ Create a new build/ directory, change into it and issue::
 
   $ cmake -DBUILD_HDF5_FILTER=TRUE ..
   $ cmake --build .
-  $ cmake --build . --target test
+  $ ctest
 
 To actually test Blosc the hard way, look at the end of:
 


### PR DESCRIPTION
CMake can also be used to run the build, via ``cmake --build``. Building this way has the advantage of being cross-platform (the command is the same across all platforms) and independent of the build system being used (e.g., ``make``, ``msbuild``, etc.).