### PR TITLE
Add build folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bench/bench
+build/


### PR DESCRIPTION
This PR simply adds the ``build`` folder to the ``.gitignore`` so generated files don't show up in ``git status``.