### PR TITLE
Added EditorConfig spec to help normalize code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+; Top-most EditorConfig file
+root = true
+
+; Global settings
+[*]
+end_of_line = LF
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+; C source files
+[*.{h,c}]
+indent_size = 2
+
+; CMake
+[CMakeLists.txt]
+indent_size = 4
+
+[*.cmake]
+indent_size = 4


### PR DESCRIPTION
I've added an [``.editorconfig``](http://editorconfig.org/) spec to the repository to help keep the formatting of the code (e.g., indentation) consistent. The presence of this file doesn't *force* the formatting of the code to be correct, but many tools now support EditorConfig and will automatically pick up formatting settings from it.