### PR TITLE
AppVeyor CI configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,13 @@
 # AppVeyor CI build configuration for c-blosc
 
+# Before cloning the repo, configure git to handle line endings correctly.
+init:
+  - git config --global core.autocrlf input
+
+# This is the build version displayed on AppVeyor's UI.
+# It's incrementally automatically like travis-ci but allows custom formatting.
+version: '{build}'
+
 build_script:
   - cmd: mkdir build
   - cmd: cd build
@@ -7,4 +15,4 @@ build_script:
   - cmd: cmake --build . --config Release
 
 test_script:
-  - cmd: cmake --build . --config Release --target test
+  - cmd: ctest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ build_script:
   - cmd: cd build
   - cmd: cmake -G "Visual Studio 12 Win64" ..
   - cmd: cmake --build . --config Release
+  - cmd: cpack
 
 test_script:
   - cmd: ctest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,10 @@
+# AppVeyor CI build configuration for c-blosc
+
+build_script:
+  - cmd: mkdir build
+  - cmd: cd build
+  - cmd: cmake -G "Visual Studio 12 Win64" ..
+  - cmd: cmake --build . --config Release
+
+test_script:
+  - cmd: cmake --build . --config Release --target test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,9 @@ build_script:
   - cmd: cd build
   - cmd: cmake -G "Visual Studio 12 Win64" ..
   - cmd: cmake --build . --config Release
-  - cmd: cpack
+  # Disable CPack for now as it conflicts with the Chocolatey 'cpack' alias
+  # for 'choco pack' and causes the build to fail.
+  #- cmd: cpack
 
 test_script:
   - cmd: ctest


### PR DESCRIPTION
I've added a configuration for AppVeyor CI. It's similar to travis-ci but geared towards Windows. It's free and runs alongside travis-ci, so now we'll be able to see whether commits/PRs will break Windows builds.

@FrancescAlted Like travis-ci, you'll need to sign in to AppVeyor via Github and add the c-blosc project to your account (again, it's free) so AppVeyor can set up the necessary integration with Github.