### PR TITLE
Retry of shuffle tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,12 @@ foreach(source ${SOURCES})
     get_filename_component(target ${source} NAME_WE)
     add_executable(${target} ${source})
 
+    # Define the BLOSC_TESTING symbol so normally-hidden functions
+    # aren't hidden from the view of the test programs.
+    set_property(
+        TARGET ${target}
+        APPEND PROPERTY COMPILE_DEFINITIONS BLOSC_TESTING)
+
     # have to copy dlls for Visual Studio
     if(MSVC)
         add_custom_command(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,20 @@ link_directories(${PROJECT_BINARY_DIR}/blosc)
 
 # targets and tests
 foreach(source ${SOURCES})
+    # Enable support for testing accelerated shuffles
+    if(COMPILER_SUPPORT_SSE2)
+        # Define a symbol so tests for SSE2 shuffle/unshuffle will be compiled in.
+        set_property(
+            SOURCE ${source}
+            APPEND PROPERTY COMPILE_DEFINITIONS SHUFFLE_SSE2_ENABLED)
+    endif(COMPILER_SUPPORT_SSE2)
+#    if(COMPILER_SUPPORT_AVX2)
+#        # Define a symbol so tests for AVX2 shuffle/unshuffle will be compiled in.
+#        set_property(
+#            SOURCE ${source}
+#            APPEND PROPERTY COMPILE_DEFINITIONS SHUFFLE_AVX2_ENABLED)
+#    endif(COMPILER_SUPPORT_AVX2)
+
     get_filename_component(target ${source} NAME_WE)
     add_executable(${target} ${source})
 

--- a/tests/test_basics.c
+++ b/tests/test_basics.c
@@ -10,6 +10,31 @@
 **********************************************************************/
 
 #include "test_common.h"
+#include "../blosc/shuffle.h"
+#include "../blosc/shuffle-generic.h"
+
+/* Include accelerated shuffles if supported by this compiler.
+   TODO: Need to also do run-time CPU feature support here. */
+#if defined(SHUFFLE_SSE2_ENABLED)
+  #include "../blosc/shuffle-sse2.h"
+#else
+  #if defined(_MSC_VER)
+  #pragma message("SSE2 shuffle tests not enabled.")
+  #else
+  #warning SSE2 shuffle tests not enabled.
+  #endif
+#endif  /* defined(SHUFFLE_SSE2_ENABLED) */
+
+#if defined(SHUFFLE_AVX2_ENABLED)
+  #include "../blosc/shuffle-avx2.h"
+#else
+  #if defined(_MSC_VER)
+  #pragma message("AVX2 shuffle tests not enabled.")
+  #else
+  #warning AVX2 shuffle tests not enabled.
+  #endif
+#endif  /* defined(SHUFFLE_AVX2_ENABLED) */
+
 
 int tests_run = 0;
 
@@ -20,6 +45,14 @@ int clevel = 1;
 int doshuffle = 0;
 size_t typesize = 4;
 size_t size = 1000;             /* must be divisible by 4 */
+
+static char* malloc_cleaned(size_t size)
+{
+  const int clean_value = 0x99;
+  char* buf = malloc(size);
+  memset(buf, clean_value, size);
+  return buf;
+}
 
 
 /* Check maxout with maxout < size */
@@ -65,23 +98,25 @@ static char *test_maxout_great() {
 
 static char * test_shuffle()
 {
-  int sizes[] = {7, 64 * 3, 7*256, 500, 8000, 100000, 702713};
-  int types[] = {1, 2, 3, 4, 5, 6, 7, 8, 11, 16, 22, 30, 32, 42, 48, 52, 53, 64, 80};
-  int i, j, k;
+  size_t lengths[] = { 7, 64 * 3, 7 * 256, 500, 8000, 100000, 702713 };
+  size_t types[] = { 1, 2, 3, 4, 5, 6, 7, 8, 11, 16, 22, 30, 32, 42, 48, 52, 53, 64, 80 };
+  int i, j;
+  size_t k;
   int ok;
-  for (i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++) {
+  for (i = 0; i < sizeof(lengths) / sizeof(lengths[0]); i++) {
     for (j = 0; j < sizeof(types) / sizeof(types[0]); j++) {
-      int n = sizes[i];
-      int t = types[j];
-      char * d = malloc(t * n);
-      char * d2 = malloc(t * n);
-      char * o = malloc(t * n + BLOSC_MAX_OVERHEAD);
-      for (k = 0; k < n; k++) {
+      size_t num_elements = lengths[i];
+      size_t type_size = types[j];
+      size_t buffer_size = num_elements * type_size;
+      char * d = malloc_cleaned(buffer_size);
+      char * d2 = malloc_cleaned(buffer_size);
+      char * o = malloc_cleaned(buffer_size + BLOSC_MAX_OVERHEAD);
+      for (k = 0; k < buffer_size; k++) {
         d[k] = rand();
       }
-      blosc_compress(5, 1, t, t * n, d, o, t * n + BLOSC_MAX_OVERHEAD);
-      blosc_decompress(o, d2, t * n);
-      ok = (memcmp(d, d2, t * n) == 0);
+      blosc_compress(5, 1, type_size, buffer_size, d, o, buffer_size + BLOSC_MAX_OVERHEAD);
+      blosc_decompress(o, d2, buffer_size);
+      ok = (memcmp(d, d2, buffer_size) == 0);
       free(d);
       free(d2);
       free(o);
@@ -94,23 +129,25 @@ static char * test_shuffle()
 
 static char * test_noshuffle()
 {
-  int sizes[] = {7, 64 * 3, 7*256, 500, 8000, 100000, 702713};
-  int types[] = {1, 2, 3, 4, 5, 6, 7, 8, 11, 16, 22, 30, 32, 42, 48, 52, 53, 64, 80};
-  int i, j, k;
+  size_t lengths[] = { 7, 64 * 3, 7 * 256, 500, 8000, 100000, 702713 };
+  size_t types[] = { 1, 2, 3, 4, 5, 6, 7, 8, 11, 16, 22, 30, 32, 42, 48, 52, 53, 64, 80 };
+  int i, j;
+  size_t k;
   int ok;
-  for (i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++) {
+  for (i = 0; i < sizeof(lengths) / sizeof(lengths[0]); i++) {
     for (j = 0; j < sizeof(types) / sizeof(types[0]); j++) {
-      int n = sizes[i];
-      int t = types[j];
-      char * d = malloc(t * n);
-      char * d2 = malloc(t * n);
-      char * o = malloc(t * n + BLOSC_MAX_OVERHEAD);
-      for (k = 0; k < n; k++) {
+      size_t num_elements = lengths[i];
+      size_t type_size = types[j];
+      size_t buffer_size = num_elements * type_size;
+      char * d = malloc_cleaned(buffer_size);
+      char * d2 = malloc_cleaned(buffer_size);
+      char * o = malloc_cleaned(buffer_size + BLOSC_MAX_OVERHEAD);
+      for (k = 0; k < buffer_size; k++) {
         d[k] = rand();
       }
-      blosc_compress(5, 0, t, t * n, d, o, t * n + BLOSC_MAX_OVERHEAD);
-      blosc_decompress(o, d2, t * n);
-      ok = (memcmp(d, d2, t * n) == 0);
+      blosc_compress(5, 0, type_size, buffer_size, d, o, buffer_size + BLOSC_MAX_OVERHEAD);
+      blosc_decompress(o, d2, buffer_size);
+      ok = (memcmp(d, d2, buffer_size) == 0);
       free(d);
       free(d2);
       free(o);
@@ -121,25 +158,323 @@ static char * test_noshuffle()
   return 0;
 }
 
+static char * test_shuffle_generic_then_unshuffle_generic()
+{
+  size_t lengths[] = { 7, 64 * 3, 7 * 256, 500, 8000, 100000, 702713 };
+  size_t types[] = { 1, 2, 3, 4, 5, 6, 7, 8, 11, 16, 22, 30, 32, 42, 48, 52, 53, 64, 80 };
+  int i, j;
+  size_t k;
+  int ok;
+  for (i = 0; i < sizeof(lengths) / sizeof(lengths[0]); i++) {
+    for (j = 0; j < sizeof(types) / sizeof(types[0]); j++) {
+      size_t num_elements = lengths[i];
+      size_t type_size = types[j];
+      size_t buffer_size = num_elements * type_size;
+      char * d = malloc_cleaned(buffer_size);
+      char * d2 = malloc_cleaned(buffer_size);
+      char * o = malloc_cleaned(buffer_size);
+      for (k = 0; k < buffer_size; k++) {
+        d[k] = (char)k;
+      }
+      /* Generic shuffle, then generic unshuffle. */
+      shuffle_generic(type_size, buffer_size, d, o);
+      unshuffle_generic(type_size, buffer_size, o, d2);
+      ok = (memcmp(d, d2, buffer_size) == 0);
+      free(d);
+      free(d2);
+      free(o);
+      mu_assert("ERROR: shuffle_generic+unshuffle_generic test failed", ok);
+    }
+  }
+
+  return 0;
+}
+
+#if defined(SHUFFLE_SSE2_ENABLED)
+
+static char * test_shuffle_sse2_vs_shuffle_generic()
+{
+  size_t lengths[] = { 7, 64 * 3, 7 * 256, 500, 8000, 100000, 702713 };
+  size_t types[] = { 1, 2, 3, 4, 5, 6, 7, 8, 11, 16, 22, 30, 32, 42, 48, 52, 53, 64, 80 };
+  int i, j;
+  size_t k;
+  int ok;
+  for (i = 0; i < sizeof(lengths) / sizeof(lengths[0]); i++) {
+    for (j = 0; j < sizeof(types) / sizeof(types[0]); j++) {
+      size_t num_elements = lengths[i];
+      size_t type_size = types[j];
+      size_t buffer_size = num_elements * type_size;
+      char * d = malloc_cleaned(buffer_size);
+      char * o = malloc_cleaned(buffer_size);
+      char * o_generic = malloc_cleaned(buffer_size);
+      for (k = 0; k < buffer_size; k++) {
+        d[k] = (char)k;
+      }
+      /* Shuffle with accelerated and generic shuffles. */
+      shuffle_sse2(type_size, buffer_size, d, o);
+      shuffle_generic(type_size, buffer_size, d, o_generic);
+      ok = (memcmp(o, o_generic, buffer_size) == 0);
+      free(d);
+      free(o);
+      free(o_generic);
+      mu_assert("ERROR: shuffle_sse2 vs. shuffle_generic test failed", ok);
+    }
+  }
+
+  return 0;
+}
+
+static char * test_shuffle_generic_then_unshuffle_sse2()
+{
+  size_t lengths[] = { 7, 64 * 3, 7 * 256, 500, 8000, 100000, 702713 };
+  size_t types[] = { 1, 2, 3, 4, 5, 6, 7, 8, 11, 16, 22, 30, 32, 42, 48, 52, 53, 64, 80 };
+  int i, j;
+  size_t k;
+  int ok;
+  for (i = 0; i < sizeof(lengths) / sizeof(lengths[0]); i++) {
+    for (j = 0; j < sizeof(types) / sizeof(types[0]); j++) {
+      size_t num_elements = lengths[i];
+      size_t type_size = types[j];
+      size_t buffer_size = num_elements * type_size;
+      char * d = malloc_cleaned(buffer_size);
+      char * d2 = malloc_cleaned(buffer_size);
+      char * o = malloc_cleaned(buffer_size);
+      for (k = 0; k < buffer_size; k++) {
+        d[k] = (char)k;
+      }
+      /* Generic shuffle, then accelerated unshuffle. */
+      shuffle_generic(type_size, buffer_size, d, o);
+      unshuffle_sse2(type_size, buffer_size, o, d2);
+      ok = (memcmp(d, d2, buffer_size) == 0);
+      free(d);
+      free(d2);
+      free(o);
+      mu_assert("ERROR: shuffle_generic+unshuffle_sse2 test failed", ok);
+    }
+  }
+
+  return 0;
+}
+
+static char * test_shuffle_sse2_then_unshuffle_generic()
+{
+  size_t lengths[] = { 7, 64 * 3, 7 * 256, 500, 8000, 100000, 702713 };
+  size_t types[] = { 1, 2, 3, 4, 5, 6, 7, 8, 11, 16, 22, 30, 32, 42, 48, 52, 53, 64, 80 };
+  int i, j;
+  size_t k;
+  int ok;
+  for (i = 0; i < sizeof(lengths) / sizeof(lengths[0]); i++) {
+    for (j = 0; j < sizeof(types) / sizeof(types[0]); j++) {
+      size_t num_elements = lengths[i];
+      size_t type_size = types[j];
+      size_t buffer_size = num_elements * type_size;
+      char * d = malloc_cleaned(buffer_size);
+      char * d2 = malloc_cleaned(buffer_size);
+      char * o = malloc_cleaned(buffer_size);
+      for (k = 0; k < buffer_size; k++) {
+        d[k] = (char)k;
+      }
+      /* Accelerated shuffle then generic unshuffle. */
+      shuffle_sse2(type_size, buffer_size, d, o);
+      unshuffle_generic(type_size, buffer_size, o, d2);
+      ok = (memcmp(d, d2, buffer_size) == 0);
+      free(d);
+      free(d2);
+      free(o);
+      mu_assert("ERROR: shuffle_sse2+unshuffle_generic test failed", ok);
+    }
+  }
+
+  return 0;
+}
+
+static char * test_shuffle_sse2_then_unshuffle_sse2()
+{
+  size_t lengths[] = { 7, 64 * 3, 7 * 256, 500, 8000, 100000, 702713 };
+  size_t types[] = { 1, 2, 3, 4, 5, 6, 7, 8, 11, 16, 22, 30, 32, 42, 48, 52, 53, 64, 80 };
+  int i, j;
+  size_t k;
+  int ok;
+  for (i = 0; i < sizeof(lengths) / sizeof(lengths[0]); i++) {
+    for (j = 0; j < sizeof(types) / sizeof(types[0]); j++) {
+      size_t num_elements = lengths[i];
+      size_t type_size = types[j];
+      size_t buffer_size = num_elements * type_size;
+      char * d = malloc_cleaned(buffer_size);
+      char * d2 = malloc_cleaned(buffer_size);
+      char * o = malloc_cleaned(buffer_size);
+      for (k = 0; k < buffer_size; k++) {
+        d[k] = (char)k;
+      }
+      /* Accelerated shuffle then accelerated unshuffle. */
+      shuffle_sse2(type_size, buffer_size, d, o);
+      unshuffle_sse2(type_size, buffer_size, o, d2);
+      ok = (memcmp(d, d2, buffer_size) == 0);
+      free(d);
+      free(d2);
+      free(o);
+      mu_assert("ERROR: shuffle_sse2+unshuffle_sse2 test failed", ok);
+    }
+  }
+
+  return 0;
+}
+
+#endif /* defined(SHUFFLE_SSE2_ENABLED) */
+
+#if defined(SHUFFLE_AVX2_ENABLED)
+
+static char * test_shuffle_avx2_vs_shuffle_generic()
+{
+  size_t lengths[] = { 7, 64 * 3, 7 * 256, 500, 8000, 100000, 702713 };
+  size_t types[] = { 1, 2, 3, 4, 5, 6, 7, 8, 11, 16, 22, 30, 32, 42, 48, 52, 53, 64, 80 };
+  int i, j;
+  size_t k;
+  int ok;
+  for (i = 0; i < sizeof(lengths) / sizeof(lengths[0]); i++) {
+    for (j = 0; j < sizeof(types) / sizeof(types[0]); j++) {
+      size_t num_elements = lengths[i];
+      size_t type_size = types[j];
+      size_t buffer_size = num_elements * type_size;
+      char * d = malloc_cleaned(buffer_size);
+      char * o = malloc_cleaned(buffer_size);
+      char * o_generic = malloc_cleaned(buffer_size);
+      for (k = 0; k < buffer_size; k++) {
+        d[k] = (char)k;
+      }
+      /* Shuffle with accelerated and generic shuffles. */
+      shuffle_avx2(type_size, buffer_size, d, o);
+      shuffle_generic(type_size, buffer_size, d, o_generic);
+      ok = (memcmp(o, o_generic, buffer_size) == 0);
+      free(d);
+      free(o);
+      free(o_generic);
+      mu_assert("ERROR: shuffle_avx2 vs. shuffle_generic test failed", ok);
+    }
+  }
+
+  return 0;
+}
+
+static char * test_shuffle_generic_then_unshuffle_avx2()
+{
+  size_t lengths[] = { 7, 64 * 3, 7 * 256, 500, 8000, 100000, 702713 };
+  size_t types[] = { 1, 2, 3, 4, 5, 6, 7, 8, 11, 16, 22, 30, 32, 42, 48, 52, 53, 64, 80 };
+  int i, j;
+  size_t k;
+  int ok;
+  for (i = 0; i < sizeof(lengths) / sizeof(lengths[0]); i++) {
+    for (j = 0; j < sizeof(types) / sizeof(types[0]); j++) {
+      size_t num_elements = lengths[i];
+      size_t type_size = types[j];
+      size_t buffer_size = num_elements * type_size;
+      char * d = malloc_cleaned(buffer_size);
+      char * d2 = malloc_cleaned(buffer_size);
+      char * o = malloc_cleaned(buffer_size);
+      for (k = 0; k < buffer_size; k++) {
+        d[k] = (char)k;
+      }
+      /* Generic shuffle, then accelerated unshuffle. */
+      shuffle_generic(type_size, buffer_size, d, o);
+      unshuffle_avx2(type_size, buffer_size, o, d2);
+      ok = (memcmp(d, d2, buffer_size) == 0);
+      free(d);
+      free(d2);
+      free(o);
+      mu_assert("ERROR: shuffle_generic+unshuffle_avx2 test failed", ok);
+    }
+  }
+
+  return 0;
+}
+
+static char * test_shuffle_avx2_then_unshuffle_generic()
+{
+  size_t lengths[] = { 7, 64 * 3, 7 * 256, 500, 8000, 100000, 702713 };
+  size_t types[] = { 1, 2, 3, 4, 5, 6, 7, 8, 11, 16, 22, 30, 32, 42, 48, 52, 53, 64, 80 };
+  int i, j;
+  size_t k;
+  int ok;
+  for (i = 0; i < sizeof(lengths) / sizeof(lengths[0]); i++) {
+    for (j = 0; j < sizeof(types) / sizeof(types[0]); j++) {
+      size_t num_elements = lengths[i];
+      size_t type_size = types[j];
+      size_t buffer_size = num_elements * type_size;
+      char * d = malloc_cleaned(buffer_size);
+      char * d2 = malloc_cleaned(buffer_size);
+      char * o = malloc_cleaned(buffer_size);
+      for (k = 0; k < buffer_size; k++) {
+        d[k] = (char)k;
+      }
+      /* Accelerated shuffle then generic unshuffle. */
+      shuffle_avx2(type_size, buffer_size, d, o);
+      unshuffle_generic(type_size, buffer_size, o, d2);
+      ok = (memcmp(d, d2, buffer_size) == 0);
+      free(d);
+      free(d2);
+      free(o);
+      mu_assert("ERROR: shuffle_avx2+unshuffle_generic test failed", ok);
+    }
+  }
+
+  return 0;
+}
+
+static char * test_shuffle_avx2_then_unshuffle_avx2()
+{
+  size_t lengths[] = { 7, 64 * 3, 7 * 256, 500, 8000, 100000, 702713 };
+  size_t types[] = { 1, 2, 3, 4, 5, 6, 7, 8, 11, 16, 22, 30, 32, 42, 48, 52, 53, 64, 80 };
+  int i, j;
+  size_t k;
+  int ok;
+  for (i = 0; i < sizeof(lengths) / sizeof(lengths[0]); i++) {
+    for (j = 0; j < sizeof(types) / sizeof(types[0]); j++) {
+      size_t num_elements = lengths[i];
+      size_t type_size = types[j];
+      size_t buffer_size = num_elements * type_size;
+      char * d = malloc_cleaned(buffer_size);
+      char * d2 = malloc_cleaned(buffer_size);
+      char * o = malloc_cleaned(buffer_size);
+      for (k = 0; k < buffer_size; k++) {
+        d[k] = (char)k;
+      }
+      /* Accelerated shuffle then accelerated unshuffle. */
+      shuffle_avx2(type_size, buffer_size, d, o);
+      unshuffle_avx2(type_size, buffer_size, o, d2);
+      ok = (memcmp(d, d2, buffer_size) == 0);
+      free(d);
+      free(d2);
+      free(o);
+      mu_assert("ERROR: shuffle_avx2+unshuffle_avx2 test failed", ok);
+    }
+  }
+
+  return 0;
+}
+
+#endif /* defined(SHUFFLE_AVX2_ENABLED) */
+
 static char * test_getitem()
 {
-  int sizes[] = {7, 64 * 3, 7*256, 500, 8000, 100000, 702713};
-  int types[] = {1, 2, 3, 4, 5, 6, 7, 8, 11, 16, 22, 30, 32, 42, 48, 52, 53, 64, 80};
-  int i, j, k;
+  size_t lengths[] = { 7, 64 * 3, 7 * 256, 500, 8000, 100000, 702713 };
+  size_t types[] = { 1, 2, 3, 4, 5, 6, 7, 8, 11, 16, 22, 30, 32, 42, 48, 52, 53, 64, 80 };
+  int i, j;
+  size_t k;
   int ok;
-  for (i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++) {
+  for (i = 0; i < sizeof(lengths) / sizeof(lengths[0]); i++) {
     for (j = 0; j < sizeof(types) / sizeof(types[0]); j++) {
-      int n = sizes[i];
-      int t = types[j];
-      char * d = malloc(t * n);
-      char * d2 = malloc(t * n);
-      char * o = malloc(t * n + BLOSC_MAX_OVERHEAD);
-      for (k = 0; k < n; k++) {
+      size_t num_elements = lengths[i];
+      size_t type_size = types[j];
+      size_t buffer_size = num_elements * type_size;
+      char * d = malloc_cleaned(buffer_size);
+      char * d2 = malloc_cleaned(buffer_size);
+      char * o = malloc_cleaned(buffer_size + BLOSC_MAX_OVERHEAD);
+      for (k = 0; k < buffer_size; k++) {
         d[k] = rand();
       }
-      blosc_compress(5, 1, t, t * n, d, o, t * n + BLOSC_MAX_OVERHEAD);
-      blosc_getitem(o, 0, n, d2);
-      ok = (memcmp(d, d2, t * n) == 0);
+      blosc_compress(5, 1, type_size, buffer_size, d, o, buffer_size + BLOSC_MAX_OVERHEAD);
+      blosc_getitem(o, 0, num_elements, d2);
+      ok = (memcmp(d, d2, buffer_size) == 0);
       free(d);
       free(d2);
       free(o);
@@ -154,9 +489,36 @@ static char *all_tests() {
   mu_run_test(test_maxout_less);
   mu_run_test(test_maxout_equal);
   mu_run_test(test_maxout_great);
+
+  mu_run_test(test_getitem);
+
+  /* Basic shuffle/unshuffle tests with compression */
   mu_run_test(test_shuffle);
   mu_run_test(test_noshuffle);
-  mu_run_test(test_getitem);
+
+  /* Roundtrip test with generic shuffle/unshuffle routines. */
+  mu_run_test(test_shuffle_generic_then_unshuffle_generic);
+
+#if defined(SHUFFLE_SSE2_ENABLED)
+  /* One-way comparison between generic and SSE shuffles. */
+  mu_run_test(test_shuffle_sse2_vs_shuffle_generic);
+
+  /* Roundtrip tests between generic and SSE2 shuffle/unshuffle routines. */
+  mu_run_test(test_shuffle_generic_then_unshuffle_sse2);
+  mu_run_test(test_shuffle_sse2_then_unshuffle_generic);
+  mu_run_test(test_shuffle_sse2_then_unshuffle_sse2);
+#endif /* defined(SHUFFLE_SSE2_ENABLED) */
+
+#if defined(SHUFFLE_AVX2_ENABLED)
+  /* One-way comparison between generic and SSE shuffles. */
+  mu_run_test(test_shuffle_sse2_vs_shuffle_generic);
+
+  /* Roundtrip tests between generic and SSE2 shuffle/unshuffle routines. */
+  mu_run_test(test_shuffle_generic_then_unshuffle_sse2);
+  mu_run_test(test_shuffle_sse2_then_unshuffle_generic);
+  mu_run_test(test_shuffle_sse2_then_unshuffle_sse2);
+#endif /* defined(SHUFFLE_AVX2_ENABLED) */
+
   return 0;
 }
 
@@ -171,10 +533,10 @@ int main(int argc, char **argv) {
   blosc_set_nthreads(1);
 
   /* Initialize buffers */
-  src = malloc(size);
-  srccpy = malloc(size);
-  dest = malloc(size+16);
-  dest2 = malloc(size);
+  src = malloc_cleaned(size);
+  srccpy = malloc_cleaned(size);
+  dest = malloc_cleaned(size + 16);
+  dest2 = malloc_cleaned(size);
   _src = (int32_t *)src;
   for (i=0; i < (size/4); i++) {
     _src[i] = i;


### PR DESCRIPTION
This is a retry of #114. It turned out I'd forgotten to define a symbol (``BLOSC_TESTING``) in ``tests/CMakeLists.txt`` so even though the normally-hidden symbols were exported from the new "testing" build of blosc they weren't visible from the point of view of the test programs which caused compilation to fail.

I've tested this PR on Windows and Linux (Ubuntu 12.04 LTS amd64) and the tests now compile, link, and run correctly on both.