### PR TITLE
Only default to a specific build type when using a single-configurati…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,15 +124,21 @@ endif(NOT DEACTIVATE_ZLIB)
 
 # create the config.h file
 configure_file ("blosc/config.h.in"  "blosc/config.h" )
+
 # now make sure that you set the build directory on your "Include" path when compiling
 include_directories("${PROJECT_BINARY_DIR}/blosc/")
 
-# force the default build type to Release.
-if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE "Release" CACHE STRING
-        "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel."
-        FORCE)
-endif(NOT CMAKE_BUILD_TYPE)
+# If the build type is not set, default to Release.
+set(BLOSC_DEFAULT_BUILD_TYPE Release)
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "No build type specified. Defaulting to '${BLOSC_DEFAULT_BUILD_TYPE}'.")
+    set(CMAKE_BUILD_TYPE ${BLOSC_DEFAULT_BUILD_TYPE} CACHE STRING
+        "Choose the type of build." FORCE)
+
+    # Set the possible values of build type for cmake-gui
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+        "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
 
 # Based on the target system's processor and the compiler being used,
 # set build variables indicating which hardware features can be targeted


### PR DESCRIPTION
In the CMake build script, blosc currently defaults to the ``Release`` configuration if no build type has been explicitly specified (e.g., via ``-DCMAKE_BUILD_TYPE=Debug``). This behavior is fine for "single-configuration" generators like Makefiles; however, it causes some issues with multi-configuration generators like MSBuild / Visual Studio where the generated build scripts include all of the configurations (and the desired configuration is then chosen at build-time instead of configure-time).

This PR fixes the issue. I've tested on Ubuntu 12.04 LTS (same as travis-ci uses) and confirmed the behavior isn't changed there. On Windows + Visual Studio, the build type is no longer forced at configure-time.