### PR TITLE
SSE2 shuffle support for irregular vector sizes

### DIFF
--- a/blosc/shuffle-generic.c
+++ b/blosc/shuffle-generic.c
@@ -12,32 +12,14 @@
 void shuffle_generic(const size_t bytesoftype, const size_t blocksize,
 		     const uint8_t* const _src, uint8_t* const _dest)
 {
-  size_t i, j, neblock, leftover;
-
   /* Non-optimized shuffle */
-  neblock = blocksize / bytesoftype;  /* Number of elements in a block */
-  for (j = 0; j < bytesoftype; j++) {
-    for (i = 0; i < neblock; i++) {
-      _dest[j*neblock+i] = _src[i*bytesoftype+j];
-    }
-  }
-  leftover = blocksize % bytesoftype;
-  memcpy(_dest + neblock*bytesoftype, _src + neblock*bytesoftype, leftover);
+  shuffle_generic_inline(bytesoftype, 0, blocksize, _src, _dest);
 }
 
 /* Unshuffle a block.  This can never fail. */
 void unshuffle_generic(const size_t bytesoftype, const size_t blocksize,
                        const uint8_t* const _src, uint8_t* const _dest)
 {
-  size_t i, j, neblock, leftover;
-
   /* Non-optimized unshuffle */
-  neblock = blocksize / bytesoftype;  /* Number of elements in a block */
-  for (i = 0; i < neblock; i++) {
-    for (j = 0; j < bytesoftype; j++) {
-      _dest[i*bytesoftype+j] = _src[j*neblock+i];
-    }
-  }
-  leftover = blocksize % bytesoftype;
-  memcpy(_dest + neblock*bytesoftype, _src + neblock*bytesoftype, leftover);
+  unshuffle_generic_inline(bytesoftype, 0, blocksize, _src, _dest);
 }


### PR DESCRIPTION
I've modified the SSE2 shuffle (and a minor modification to the generic shuffle) so if given a buffer containing a number of elements which isn't a multiple of the vector size, the vectorized version can still be used to process most of the elements before finishing up with the generic shuffle.

The performance should be the same for the cases where the vectorized shuffle was already being used. Performance of many common cases should be improved now since they'll be able to leverage vectorization no matter how many elements need to be shuffled.