### PR TITLE
Build fixes for MinGW

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -12,7 +12,7 @@ if(UNIX AND NOT APPLE)
 endif(UNIX AND NOT APPLE)
 target_link_libraries(bench blosc_shared)
 
-# have to copy blosc dlls for Visual Studio
+# have to copy blosc dlls on Windows
 if(MSVC)
     add_custom_command(
         TARGET      bench
@@ -21,8 +21,15 @@ if(MSVC)
         ARGS        -E copy_if_different
                     "${PROJECT_BINARY_DIR}/blosc/\$\(Configuration\)/blosc.dll"
                     "${CMAKE_CURRENT_BINARY_DIR}/\$\(Configuration\)/blosc.dll")
-endif(MSVC)
-
+elseif(MINGW)
+    add_custom_command(
+        TARGET      bench
+        POST_BUILD
+        COMMAND     ${CMAKE_COMMAND}
+        ARGS        -E copy_if_different
+                    "${PROJECT_BINARY_DIR}/blosc/libblosc.dll"
+                    "${CMAKE_CURRENT_BINARY_DIR}/libblosc.dll")
+endif()
 
 # tests
 if(BUILD_TESTS)

--- a/bench/bench.c
+++ b/bench/bench.c
@@ -23,7 +23,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#if defined(_WIN32) && !defined(__MINGW32__)
+#if defined(_WIN32)
   /* For QueryPerformanceCounter(), etc. */
   #include <windows.h>
 #elif defined(__MACH__)
@@ -70,7 +70,7 @@ int niter = 3;                  /* default number of iterations */
 double totalsize = 0.;          /* total compressed/decompressed size */
 
 /* System-specific high-precision timing functions. */
-#if defined(_WIN32) && !defined(__MINGW32__)
+#if defined(_WIN32)
 
 /* The type of timestamp used on this system. */
 #define blosc_timestamp_t LARGE_INTEGER
@@ -129,7 +129,7 @@ double get_usec_chunk(blosc_timestamp_t last, blosc_timestamp_t current, int nit
 }
 
 /* Define posix_memalign for Windows */
-#if defined(_WIN32) && !defined(__MINGW32__)
+#if defined(_WIN32)
 #include <malloc.h>
 
 int posix_memalign(void **memptr, size_t alignment, size_t size)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,7 +39,15 @@ foreach(source ${SOURCES})
             ARGS        -E copy_if_different
                         "${PROJECT_BINARY_DIR}/blosc/\$\(Configuration\)/blosc_testing.dll"
                         "${CMAKE_CURRENT_BINARY_DIR}/\$\(Configuration\)/blosc_testing.dll")
-    endif(MSVC)
+    elseif(MINGW)
+        add_custom_command(
+            TARGET      ${target}
+            POST_BUILD
+            COMMAND     ${CMAKE_COMMAND}
+            ARGS        -E copy_if_different
+                        "${PROJECT_BINARY_DIR}/blosc/libblosc_testing.dll"
+                        "${CMAKE_CURRENT_BINARY_DIR}/libblosc_testing.dll")
+    endif()
 
     target_link_libraries(${target} blosc_testing)
 


### PR DESCRIPTION
This PR contains some small fixes to CMake build scripts and the ``bench`` tool to allow blosc to be compiled with MinGW on Windows.

Steps to build with MinGW (for future reference), starting from the ``blosc`` repository folder:
```
mkdir build
cd build
cmake -G "MinGW Makefiles" ..
cmake --build .
ctest
```