### PR TITLE
appveyor badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,10 @@
 :Author: Francesc Alted
 :Contact: francesc@blosc.org
 :URL: http://www.blosc.org
+:Appveyor: |appveyor|
+           
+.. |appveyor| image:: https://ci.appveyor.com/api/projects/status/gccmb03j8ghbj0ig/branch/master?svg=true
+        :target: https://ci.appveyor.com/project/esc/c-blosc/branch/master
 
 What is it?
 ===========


### PR DESCRIPTION
For the moment Appveyor image not show properly, not sure why, if I visit https://ci.appveyor.com/api/projects/status/github/FrancescAlted/c-blosc I get `{"message":"Project not found or access denied."}` but in case I visit my own I get a proper image https://ci.appveyor.com/api/projects/status/github/FrancescElies/c-blosc

For python-blosc project this worked fine https://ci.appveyor.com/api/projects/status/github/esc/python-blosc