### PR TITLE
fix the rst table in the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,11 +6,10 @@
 :Contact: francesc@blosc.org
 :URL: http://www.blosc.org
 :Travis CI: |travis|
+:Appveyor: |appveyor|
 
 .. |travis| image:: https://travis-ci.org/Blosc/c-blosc.svg?branch=master
         :target: https://travis-ci.org/Blosc/c-blosc
-
-:Appveyor: |appveyor|
 
 .. |appveyor| image:: https://ci.appveyor.com/api/projects/status/gccmb03j8ghbj0ig/branch/master?svg=true
         :target: https://ci.appveyor.com/project/FrancescAlted/c-blosc/branch/master


### PR DESCRIPTION
This patch makes all badges appear in the same table, currently there is a
seperate table for the appveyor one.