### PR TITLE
[MRG] Make set_nthreads a noop

### DIFF
--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -1616,11 +1616,12 @@ int blosc_set_nthreads(int nthreads_new)
 {
   int ret = g_threads;
 
-  /* Re-initialize Blosc */
-  blosc_destroy();
-  blosc_init();
-
-  g_threads = nthreads_new;
+  if (nthreads_new != ret){
+    /* Re-initialize Blosc */
+    blosc_destroy();
+    blosc_init();
+    g_threads = nthreads_new;
+  }
 
   return ret;
 }


### PR DESCRIPTION
If the number of threads is not changing, do not reinitialise the thread pool in ```blosc_set_nthreads```. I think this should be a harmless change, but I'm not familiar enough with the code to be sure it is a good idea.

Context: I'm compressing many small pieces of independent data. For each of these compression calls, I set the number of threads to a configured value - to avoid depending on uncontrolled global state. Surprisingly, when the number of calls is large (let's say 400K) and the compressed data is not so large (let's say, 16K per call), the time wasted on pool reinitialisation becomes noticeable.