### PR TITLE
Fix double destroy of blosc context

### DIFF
--- a/examples/multithread.c
+++ b/examples/multithread.c
@@ -83,9 +83,6 @@ int main(){
         return dsize;
     }
 
-    /* After using it, destroy the Blosc environment */
-    blosc_destroy();
-
     for(i=0;i<SIZE;i++){
       if(data[i] != data_dest[i]) {
 	printf("Decompressed data differs from original!\n");
@@ -95,6 +92,9 @@ int main(){
 
     printf("Succesful roundtrip!\n");
   }
+
+  /* After using it, destroy the Blosc environment */
+  blosc_destroy();
 
   return 0;
 }


### PR DESCRIPTION
The global context is destroyed whenever blosc_set_nthreads() is called, so explicitly destroying it in the loop causes blosc_set_nthreads() to try to destroy it again, leading to a glibc double free error. Moving blosc_destroy() out of the loop prevents the double free.