### PR TITLE
Allow hardware features to be specified over the command-line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,17 @@ endif()
 # by this (the host) system, because we want to be able to support compiling
 # for newer hardware on older machines as well as cross-compilation.
 message(STATUS "Building for system processor ${CMAKE_SYSTEM_PROCESSOR}")
-if(CMAKE_SYSTEM_PROCESSOR STREQUAL i386 OR
+
+# Allow hardware features to be specified over the command-line (e.g. -DCOMPILER_SUPPORT_AVX2).
+if(DEFINED COMPILER_SUPPORT_SSE2 AND NOT DEFINED COMPILER_SUPPORT_AVX2)
+    set(COMPILER_SUPPORT_AVX2 FALSE)
+elseif(DEFINED COMPILER_SUPPORT_AVX2 AND NOT DEFINED COMPILER_SUPPORT_SSE2)
+    set(COMPILER_SUPPORT_SSE2 ${COMPILER_SUPPORT_AVX2})
+endif()
+
+if(DEFINED COMPILER_SUPPORT_SSE2 AND DEFINED COMPILER_SUPPORT_AVX2)
+    message(STATUS "Taking hardware features from command-line (SSE2=${COMPILER_SUPPORT_SSE2}, AVX2=${COMPILER_SUPPORT_AVX2}).")
+elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL i386 OR
    CMAKE_SYSTEM_PROCESSOR STREQUAL i686 OR
    CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR
    CMAKE_SYSTEM_PROCESSOR STREQUAL amd64 OR


### PR DESCRIPTION
In my particular case, I would like to be able to prepare a build of blosc on new hardware (an AVX2 compatible machine), but have this run on older hardware (e.g. machines without AVX2 support).

The existing CMakeLists.txt file suggests that some choices were made to permit cross-compilation, however I couldn't find any existing options to allow me to do this without patching the actual CMakeLists.txt file.

The change I have made here is to ensure that the existing auto-detection only runs if both `COMPILER_SUPPORT_SSE2` and `COMPILER_SUPPORT_AVX2` are not already defined. To make things easier for the user, I have also covered the case where only one of these is specified over the command-line (in which case, a sensible default is chosen for the missing variable).

I should note that in my case, I am integrating blosc into our build system here, which prefers the passing of command-line options over patching the source tree.