### PR TITLE
Fix errors when building on multiple cores (e.g. -jN in gcc)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ foreach(source ${SOURCES})
     endif()
 
     target_link_libraries(${target} blosc_testing)
+    add_dependencies(${target} blosc_shared_testing)
 
     # If there's a CSV file present for this test, read it to get the list
     # of test parameters then add a test for each parameter set.


### PR DESCRIPTION
Running make with the -jN option was causing the tests to be built before the blosc_testing library had been built, resulting in linker errors. Adding this dependency fixes the issue...