### PR TITLE
CMake tweaks to allow subproject use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 bench/bench
 build/
+
+*.sw?

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,11 +297,6 @@ endif()
 # subdirectories
 add_subdirectory(blosc)
 
-if (BLOSC_IS_SUBPROJECT)
-    add_library(blosc ALIAS blosc_static)
-    message(STATUS "Enabled `blosc` alias target to static library.")
-endif()
-
 if(BUILD_TESTS)
     enable_testing()
     add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@
 #
 #   BUILD_STATIC: default ON
 #       build the static version of the Blosc library
+#   BUILD_SHARED: default ON
+#       build the shared library version of the Blosc library
 #   BUILD_TESTS: default ON
 #       build test programs and generates the "test" target
 #   BUILD_BENCHMARKS: default ON
@@ -84,6 +86,8 @@ message("Configuring for Blosc version: " ${BLOSC_VERSION_STRING})
 # options
 option(BUILD_STATIC
     "Build a static version of the blosc library." ON)
+option(BUILD_SHARED
+    "Build a shared library version of the blosc library." ON)
 option(BUILD_TESTS
     "Build test programs form the blosc compression library" ON)
 option(BUILD_BENCHMARKS
@@ -107,7 +111,7 @@ option(PREFER_EXTERNAL_ZLIB
 option(PREFER_EXTERNAL_ZSTD
     "Find and use external Zstd library instead of included sources." ON)
 
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 
 if(NOT DEACTIVATE_LZ4)
@@ -272,9 +276,31 @@ if(WIN32)
     include_directories("${CMAKE_CURRENT_SOURCE_DIR}/blosc")
 endif(WIN32)
 
+if (NOT DEFINED BLOSC_IS_SUBPROJECT)
+  if ("^${CMAKE_SOURCE_DIR}$" STREQUAL "^${PROJECT_SOURCE_DIR}$")
+    set (BLOSC_IS_SUBPROJECT FALSE)
+  else ()
+    set (BLOSC_IS_SUBPROJECT TRUE)
+    message(STATUS "Detected that BLOSC is used a subproject.")
+  endif ()
+endif ()
+
+if (NOT DEFINED BLOSC_INSTALL)
+    if (BLOSC_IS_SUBPROJECT)
+        set(BLOSC_INSTALL FALSE)
+    else()
+        set(BLOSC_INSTALL TRUE)
+    endif()
+endif()
+
 
 # subdirectories
 add_subdirectory(blosc)
+
+if (BLOSC_IS_SUBPROJECT)
+    add_library(blosc ALIAS blosc_static)
+    message(STATUS "Enabled `blosc` alias target to static library.")
+endif()
 
 if(BUILD_TESTS)
     enable_testing()
@@ -287,30 +313,34 @@ endif(BUILD_BENCHMARKS)
 
 
 # uninstall target
-configure_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
-    IMMEDIATE @ONLY)
+if (BLOSC_INSTALL)
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+        IMMEDIATE @ONLY)
 
-add_custom_target(uninstall
-    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+    add_custom_target(uninstall
+        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
 
+endif()
 
 # packaging
-include(InstallRequiredSystemLibraries)
+if (NOT BLOSC_IS_SUBPROJECT)
+    include(InstallRequiredSystemLibraries)
 
-set(CPACK_GENERATOR TGZ ZIP)
-set(CPACK_SOURCE_GENERATOR TGZ ZIP)
-set(CPACK_PACKAGE_VERSION_MAJOR ${BLOSC_VERSION_MAJOR})
-set(CPACK_PACKAGE_VERSION_MINOR ${BLOSC_VERSION_MINOR})
-set(CPACK_PACKAGE_VERSION_PATCH ${BLOSC_VERSION_PATCH})
-set(CPACK_PACKAGE_VERSION ${BLOSC_STRING_VERSION})
-set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/README.rst")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY
-    "A blocking, shuffling and lossless compression library")
-set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSES/BLOSC.txt")
-set(CPACK_SOURCE_IGNORE_FILES "/build.*;.*~;\\\\.git.*;\\\\.DS_Store")
-set(CPACK_STRIP_FILES TRUE)
-set(CPACK_SOURCE_STRIP_FILES TRUE)
+    set(CPACK_GENERATOR TGZ ZIP)
+    set(CPACK_SOURCE_GENERATOR TGZ ZIP)
+    set(CPACK_PACKAGE_VERSION_MAJOR ${BLOSC_VERSION_MAJOR})
+    set(CPACK_PACKAGE_VERSION_MINOR ${BLOSC_VERSION_MINOR})
+    set(CPACK_PACKAGE_VERSION_PATCH ${BLOSC_VERSION_PATCH})
+    set(CPACK_PACKAGE_VERSION ${BLOSC_STRING_VERSION})
+    set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/README.rst")
+    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY
+        "A blocking, shuffling and lossless compression library")
+    set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSES/BLOSC.txt")
+    set(CPACK_SOURCE_IGNORE_FILES "/build.*;.*~;\\\\.git.*;\\\\.DS_Store")
+    set(CPACK_STRIP_FILES TRUE)
+    set(CPACK_SOURCE_STRIP_FILES TRUE)
 
-include(CPack)
+    include(CPack)
+endif()

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -6,6 +6,11 @@
 :Contact: francesc@blosc.org
 :URL: http://www.blosc.org
 
+Changes in master
+=============================
+
+- Enabled use as a CMake subproject, exporting shared & static library targets
+  for super-projects to use. #178
 
 Changes from 1.11.0 to 1.11.1
 =============================

--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -6,7 +6,7 @@ set(INTERNAL_LIBS ${PROJECT_SOURCE_DIR}/internal-complibs)
 # Hide symbols by default unless they're specifically exported.
 # This makes it easier to keep the set of exported symbols the
 # same across all compilers/platforms.
-#set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_C_VISIBILITY_PRESET hidden)
 
 # includes
 if(NOT DEACTIVATE_LZ4)

--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -1,12 +1,12 @@
 # a simple way to detect that we are using CMAKE
 add_definitions(-DUSING_CMAKE)
 
-set(INTERNAL_LIBS ${CMAKE_SOURCE_DIR}/internal-complibs)
+set(INTERNAL_LIBS ${PROJECT_SOURCE_DIR}/internal-complibs)
 
 # Hide symbols by default unless they're specifically exported.
 # This makes it easier to keep the set of exported symbols the
 # same across all compilers/platforms.
-set(CMAKE_C_VISIBILITY_PRESET hidden)
+#set(CMAKE_C_VISIBILITY_PRESET hidden)
 
 # includes
 if(NOT DEACTIVATE_LZ4)
@@ -116,15 +116,17 @@ if (NOT DEACTIVATE_ZSTD)
 endif (NOT DEACTIVATE_ZSTD)
 
 # targets
-add_library(blosc_shared SHARED ${SOURCES})
-set_target_properties(blosc_shared PROPERTIES OUTPUT_NAME blosc)
-set_target_properties(blosc_shared PROPERTIES
-        VERSION ${version_string}
-        SOVERSION 1  # Change this when an ABI change happens
-    )
-set_property(
-    TARGET blosc_shared
-    APPEND PROPERTY COMPILE_DEFINITIONS BLOSC_SHARED_LIBRARY)
+if (BUILD_SHARED)
+    add_library(blosc_shared SHARED ${SOURCES})
+    set_target_properties(blosc_shared PROPERTIES OUTPUT_NAME blosc)
+    set_target_properties(blosc_shared PROPERTIES
+            VERSION ${version_string}
+            SOVERSION 1  # Change this when an ABI change happens
+        )
+    set_property(
+        TARGET blosc_shared
+        APPEND PROPERTY COMPILE_DEFINITIONS BLOSC_SHARED_LIBRARY)
+endif()
 
 # Based on the target architecture and hardware features supported
 # by the C compiler, set hardware architecture optimization flags
@@ -182,7 +184,10 @@ if (BUILD_TESTS)
     endif()
 endif()
 
-target_link_libraries(blosc_shared ${LIBS})
+if (BUILD_SHARED)
+    target_link_libraries(blosc_shared ${LIBS})
+endif()
+
 if (BUILD_TESTS)
     target_link_libraries(blosc_shared_testing ${LIBS})
 endif()
@@ -198,8 +203,10 @@ endif(BUILD_STATIC)
 
 
 # install
-install(FILES blosc.h blosc-export.h DESTINATION include COMPONENT DEV)
-install(TARGETS blosc_shared DESTINATION ${lib_dir} COMPONENT LIB)
-if(BUILD_STATIC)
-    install(TARGETS blosc_static DESTINATION ${lib_dir} COMPONENT DEV)
-endif(BUILD_STATIC)
+if(BLOSC_INSTALL)
+    install(FILES blosc.h blosc-export.h DESTINATION include COMPONENT DEV)
+    install(TARGETS blosc_shared DESTINATION ${lib_dir} COMPONENT LIB)
+    if(BUILD_STATIC)
+        install(TARGETS blosc_static DESTINATION ${lib_dir} COMPONENT DEV)
+    endif(BUILD_STATIC)
+endif(BLOSC_INSTALL)


### PR DESCRIPTION
Hi,

This PR makes several minor tweaks to the CMake configs to enable projects to more easily include blosc as CMake subprojects (included in-tree with git submodules or subtree, or just `cp`).

Notably:

- Include `BUILD_SHARED` option which corresponds to `BUILD_STATIC`, enabling the shared library build. This defaults to ON
- Use `${PROJECT_SOURCE_DIR}` where appropriate
- Add a `blosc` target alias which lets people simply do `target_link_libraries(my_thing thing_lib blosc)` to get blosc compiled in as a static library
- Add `BLOSC_INSTALL` option to control installation. Defaults to on.
- Only set up CPack if blosc is NOT being used as a sub-project.

I have confirmed that both normal installation and use as a sub-project works after these changes. I can prepare a demonstration of how I used this in a project of mine if you'd like.

Cheers,
K
