### PR TITLE
Propagate include directories to superprojects

### DIFF
--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -6,44 +6,48 @@ set(INTERNAL_LIBS ${PROJECT_SOURCE_DIR}/internal-complibs)
 # Hide symbols by default unless they're specifically exported.
 # This makes it easier to keep the set of exported symbols the
 # same across all compilers/platforms.
+cmake_policy(SET CMP0063 NEW)
 set(CMAKE_C_VISIBILITY_PRESET hidden)
 
 # includes
+set(BLOSC_INCLUDE_DIRS ${BLOSC_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
 if(NOT DEACTIVATE_LZ4)
     if (LZ4_FOUND)
-        include_directories( ${LZ4_INCLUDE_DIR} )
+        set(BLOSC_INCLUDE_DIRS ${BLOSC_INCLUDE_DIRS} ${LZ4_INCLUDE_DIR})
     else(LZ4_FOUND)
         set(LZ4_LOCAL_DIR ${INTERNAL_LIBS}/lz4-1.7.2)
-        include_directories( ${LZ4_LOCAL_DIR} )
+        set(BLOSC_INCLUDE_DIRS ${BLOSC_INCLUDE_DIRS} ${LZ4_LOCAL_DIR})
     endif(LZ4_FOUND)
 endif(NOT DEACTIVATE_LZ4)
 
 if(NOT DEACTIVATE_SNAPPY)
     if (SNAPPY_FOUND)
-        include_directories( ${SNAPPY_INCLUDE_DIR} )
+        set(BLOSC_INCLUDE_DIRS ${BLOSC_INCLUDE_DIRS} ${SNAPPY_INCLUDE_DIR})
     else(SNAPPY_FOUND)
         set(SNAPPY_LOCAL_DIR ${INTERNAL_LIBS}/snappy-1.1.1)
-        include_directories( ${SNAPPY_LOCAL_DIR} )
+        set(BLOSC_INCLUDE_DIRS ${BLOSC_INCLUDE_DIRS} ${SNAPPY_LOCAL_DIR})
     endif(SNAPPY_FOUND)
 endif(NOT DEACTIVATE_SNAPPY)
 
 if(NOT DEACTIVATE_ZLIB)
     if (ZLIB_FOUND)
-        include_directories( ${ZLIB_INCLUDE_DIR} )
+        set(BLOSC_INCLUDE_DIRS ${BLOSC_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIR})
     else(ZLIB_FOUND)
         set(ZLIB_LOCAL_DIR ${INTERNAL_LIBS}/zlib-1.2.8)
-        include_directories( ${ZLIB_LOCAL_DIR} )
+        set(BLOSC_INCLUDE_DIRS ${BLOSC_INCLUDE_DIRS} ${ZLIB_LOCAL_DIR})
     endif(ZLIB_FOUND)
 endif(NOT DEACTIVATE_ZLIB)
 
 if (NOT DEACTIVATE_ZSTD)
     if (ZSTD_FOUND)
-        include_directories(${ZSTD_INCLUDE_DIR})
+        set(BLOSC_INCLUDE_DIRS ${BLOSC_INCLUDE_DIRS} ${ZSTD_INCLUDE_DIR})
     else (ZSTD_FOUND)
         set(ZSTD_LOCAL_DIR ${INTERNAL_LIBS}/zstd-1.0.0)
-        include_directories(${ZSTD_LOCAL_DIR} ${ZSTD_LOCAL_DIR}/common)
+        set(BLOSC_INCLUDE_DIRS ${BLOSC_INCLUDE_DIRS} ${ZSTD_LOCAL_DIR} ${ZSTD_LOCAL_DIR}/common)
     endif (ZSTD_FOUND)
 endif (NOT DEACTIVATE_ZSTD)
+
+include_directories(${BLOSC_INCLUDE_DIRS})
 
 # library sources
 set(SOURCES blosc.c blosclz.c shuffle-generic.c bitshuffle-generic.c)
@@ -114,6 +118,7 @@ if (NOT DEACTIVATE_ZSTD)
         set(SOURCES ${SOURCES} ${ZSTD_FILES})
     endif (ZSTD_FOUND)
 endif (NOT DEACTIVATE_ZSTD)
+
 
 # targets
 if (BUILD_SHARED)
@@ -186,10 +191,12 @@ endif()
 
 if (BUILD_SHARED)
     target_link_libraries(blosc_shared ${LIBS})
+    target_include_directories(blosc_shared PUBLIC ${BLOSC_INCLUDE_DIRS})
 endif()
 
 if (BUILD_TESTS)
     target_link_libraries(blosc_shared_testing ${LIBS})
+    target_include_directories(blosc_shared_testing PUBLIC ${BLOSC_INCLUDE_DIRS})
 endif()
 
 if(BUILD_STATIC)
@@ -199,8 +206,8 @@ if(BUILD_STATIC)
         set_target_properties(blosc_static PROPERTIES PREFIX lib)
     endif()
     target_link_libraries(blosc_static ${LIBS})
+    target_include_directories(blosc_static PUBLIC ${BLOSC_INCLUDE_DIRS})
 endif(BUILD_STATIC)
-
 
 # install
 if(BLOSC_INSTALL)

--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -6,7 +6,9 @@ set(INTERNAL_LIBS ${PROJECT_SOURCE_DIR}/internal-complibs)
 # Hide symbols by default unless they're specifically exported.
 # This makes it easier to keep the set of exported symbols the
 # same across all compilers/platforms.
-cmake_policy(SET CMP0063 NEW)
+if (NOT CMAKE_VERSION VERSION_LESS 3.3)
+    cmake_policy(SET CMP0063 NEW)
+endif()
 set(CMAKE_C_VISIBILITY_PRESET hidden)
 
 # includes


### PR DESCRIPTION
Hi,

As an add-on to #178, this PR propagates the include directories of blosc to targets that link to it. This means that superprojects can simply `ADD_SUBDIRECTORY(src/ext/blosc)` and `TARGET_LINK_LIBRARIES(myexe blosc_static)`, and the include directories needed to compile code against blosc are automatically included.

Cheers,
K