### PR TITLE
Add a pkg-config file to installed prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,13 +310,18 @@ endif(BUILD_BENCHMARKS)
 # uninstall target
 if (BLOSC_INSTALL)
     configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/blosc.pc.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/blosc.pc"
+        @ONLY)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/blosc.pc"
+            DESTINATION lib/pkgconfig COMPONENT DEV)
+
+    configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
         "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
         IMMEDIATE @ONLY)
-
     add_custom_target(uninstall
         COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
-
 endif()
 
 # packaging

--- a/blosc.pc.in
+++ b/blosc.pc.in
@@ -1,0 +1,14 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+sharedlibdir=${libdir}
+includedir=${prefix}/include
+
+Name: blosc
+Description: A blocking, shuffling and lossless compression library
+URL: http://blosc.org/
+Version: @BLOSC_VERSION_STRING@
+
+Requires:
+Libs: -L${libdir} -L${sharedlibdir} -lblosc
+Cflags: -I${includedir}


### PR DESCRIPTION
Hi,

This PR simply adds a pkg-config definition file, such that programs using pkg-config can find blosc and set their CFLAGS and LDFLAGS appropriately.

Cheers,
Kevin