### PR TITLE
Fix blosc_test_malloc on FreeBSD

### DIFF
--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -62,7 +62,7 @@ static void* blosc_test_malloc(const size_t alignment, const size_t size)
   void *block = NULL;
   int32_t res = 0;
 
-#if _ISOC11_SOURCE
+#if _ISOC11_SOURCE || (__STDC_VERSION__ >= 201112L && !defined(__APPLE__))
   /* C11 aligned allocation. 'size' must be a multiple of the alignment. */
   block = aligned_alloc(alignment, size);
 #elif defined(_WIN32)


### PR DESCRIPTION
The c compiler in FreeBSD system base is clang.
Seems that it do not have the macro `_ISOC11_SOURCE` but `__STDC_VERSION__`.