### PR TITLE
Fastcopy

### DIFF
--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -49,8 +49,8 @@ endif (NOT DEACTIVATE_ZSTD)
 include_directories(${BLOSC_INCLUDE_DIRS})
 
 # library sources
-set(SOURCES blosc.c blosclz.c shuffle-generic.c bitshuffle-generic.c
-        blosc-common.h blosc-export.h memcopy.h)
+set(SOURCES blosc.c blosclz.c fastcopy.c shuffle-generic.c bitshuffle-generic.c
+        blosc-common.h blosc-export.h)
 if(COMPILER_SUPPORT_SSE2)
     message(STATUS "Adding run-time support for SSE2")
     set(SOURCES ${SOURCES} shuffle-sse2.c bitshuffle-sse2.c)

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -1191,7 +1191,7 @@ int blosc_compress_context(struct blosc_context* context)
       ntbytes = 0;
     }
     else {
-      memcpy(context->dest+BLOSC_MAX_OVERHEAD, context->src,
+      memcpy(context->dest + BLOSC_MAX_OVERHEAD, context->src,
              context->sourcesize);
       ntbytes = context->sourcesize + BLOSC_MAX_OVERHEAD;
     }

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -659,7 +659,7 @@ static int blosc_c(const struct blosc_context* context, int32_t blocksize,
       if ((ntbytes+neblock) > maxbytes) {
         return 0;    /* Non-compressible data */
       }
-      fast_copy(dest, _tmp+j*neblock, neblock);
+      fastcopy(dest, _tmp + j * neblock, neblock);
       cbytes = neblock;
     }
     _sw32(dest - 4, cbytes);
@@ -714,7 +714,7 @@ static int blosc_d(struct blosc_context* context, int32_t blocksize,
     ctbytes += (int32_t)sizeof(int32_t);
     /* Uncompress */
     if (cbytes == neblock) {
-      fast_copy(_tmp, src, neblock);
+      fastcopy(_tmp, src, neblock);
       nbytes = neblock;
     }
     else {
@@ -805,8 +805,8 @@ static int serial_blosc(struct blosc_context* context)
     if (context->compress) {
       if (*(context->header_flags) & BLOSC_MEMCPYED) {
         /* We want to memcpy only */
-        fast_copy(context->dest+BLOSC_MAX_OVERHEAD+j*context->blocksize,
-                context->src+j*context->blocksize, bsize);
+        fastcopy(context->dest + BLOSC_MAX_OVERHEAD + j * context->blocksize,
+                 context->src + j * context->blocksize, bsize);
         cbytes = bsize;
       }
       else {
@@ -823,8 +823,8 @@ static int serial_blosc(struct blosc_context* context)
     else {
       if (*(context->header_flags) & BLOSC_MEMCPYED) {
         /* We want to memcpy only */
-        fast_copy(context->dest+j*context->blocksize,
-                context->src+BLOSC_MAX_OVERHEAD+j*context->blocksize, bsize);
+        fastcopy(context->dest + j * context->blocksize,
+                 context->src + BLOSC_MAX_OVERHEAD + j * context->blocksize, bsize);
         cbytes = bsize;
       }
       else {
@@ -1528,8 +1528,8 @@ int blosc_getitem(const void *src, int start, int nitems, void *dest)
     /* Do the actual data copy */
     if (flags & BLOSC_MEMCPYED) {
       /* We want to memcpy only */
-      fast_copy((uint8_t *)dest + ntbytes,
-                (uint8_t *)src + BLOSC_MAX_OVERHEAD + j*blocksize + startb, bsize2);
+      fastcopy((uint8_t *) dest + ntbytes,
+               (uint8_t *) src + BLOSC_MAX_OVERHEAD + j * blocksize + startb, bsize2);
       cbytes = bsize2;
     }
     else {
@@ -1547,7 +1547,7 @@ int blosc_getitem(const void *src, int start, int nitems, void *dest)
         break;
       }
       /* Copy to destination */
-      fast_copy((uint8_t *)dest + ntbytes, tmp2 + startb, bsize2);
+      fastcopy((uint8_t *) dest + ntbytes, tmp2 + startb, bsize2);
       cbytes = bsize2;
     }
     ntbytes += cbytes;
@@ -1657,7 +1657,8 @@ static void *t_blosc(void *ctxt)
       if (compress) {
         if (flags & BLOSC_MEMCPYED) {
           /* We want to memcpy only */
-          fast_copy(dest+BLOSC_MAX_OVERHEAD+nblock_*blocksize, src+nblock_*blocksize, bsize);
+          fastcopy(dest + BLOSC_MAX_OVERHEAD + nblock_ * blocksize, src + nblock_ * blocksize,
+                   bsize);
           cbytes = bsize;
         }
         else {
@@ -1669,7 +1670,8 @@ static void *t_blosc(void *ctxt)
       else {
         if (flags & BLOSC_MEMCPYED) {
           /* We want to memcpy only */
-          fast_copy(dest+nblock_*blocksize, src+BLOSC_MAX_OVERHEAD+nblock_*blocksize, bsize);
+          fastcopy(dest + nblock_ * blocksize, src + BLOSC_MAX_OVERHEAD + nblock_ * blocksize,
+                   bsize);
           cbytes = bsize;
         }
         else {
@@ -1711,7 +1713,7 @@ static void *t_blosc(void *ctxt)
         /* End of critical section */
 
         /* Copy the compressed buffer to destination */
-        fast_copy(dest+ntdest, tmp2, cbytes);
+        fastcopy(dest + ntdest, tmp2, cbytes);
       }
       else {
         nblock_++;

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -13,8 +13,10 @@
 #include <errno.h>
 #include <string.h>
 #include <sys/types.h>
-#include <sys/stat.h>
 #include <assert.h>
+
+#include "fastcopy.h"
+
 #if defined(USING_CMAKE)
   #include "config.h"
 #endif /*  USING_CMAKE */
@@ -60,9 +62,6 @@
 #else
   #include <pthread.h>
 #endif
-
-#include "fastcopy.h"
-#define MEMCPY fast_copy
 
 
 /* Some useful units */
@@ -660,7 +659,7 @@ static int blosc_c(const struct blosc_context* context, int32_t blocksize,
       if ((ntbytes+neblock) > maxbytes) {
         return 0;    /* Non-compressible data */
       }
-      MEMCPY(dest, _tmp+j*neblock, neblock);
+      fast_copy(dest, _tmp+j*neblock, neblock);
       cbytes = neblock;
     }
     _sw32(dest - 4, cbytes);
@@ -715,7 +714,7 @@ static int blosc_d(struct blosc_context* context, int32_t blocksize,
     ctbytes += (int32_t)sizeof(int32_t);
     /* Uncompress */
     if (cbytes == neblock) {
-      MEMCPY(_tmp, src, neblock);
+      fast_copy(_tmp, src, neblock);
       nbytes = neblock;
     }
     else {
@@ -806,9 +805,8 @@ static int serial_blosc(struct blosc_context* context)
     if (context->compress) {
       if (*(context->header_flags) & BLOSC_MEMCPYED) {
         /* We want to memcpy only */
-        MEMCPY(context->dest+BLOSC_MAX_OVERHEAD+j*context->blocksize,
-                context->src+j*context->blocksize,
-                bsize);
+        fast_copy(context->dest+BLOSC_MAX_OVERHEAD+j*context->blocksize,
+                context->src+j*context->blocksize, bsize);
         cbytes = bsize;
       }
       else {
@@ -825,9 +823,8 @@ static int serial_blosc(struct blosc_context* context)
     else {
       if (*(context->header_flags) & BLOSC_MEMCPYED) {
         /* We want to memcpy only */
-        MEMCPY(context->dest+j*context->blocksize,
-                context->src+BLOSC_MAX_OVERHEAD+j*context->blocksize,
-                bsize);
+        fast_copy(context->dest+j*context->blocksize,
+                context->src+BLOSC_MAX_OVERHEAD+j*context->blocksize, bsize);
         cbytes = bsize;
       }
       else {
@@ -1175,30 +1172,20 @@ int blosc_compress_context(struct blosc_context* context)
 {
   int32_t ntbytes = 0;
 
-  if (!(*(context->header_flags) & BLOSC_MEMCPYED)) {
     /* Do the actual compression */
     ntbytes = do_job(context);
     if (ntbytes < 0) {
       return -1;
     }
     if ((ntbytes == 0) && (context->sourcesize+BLOSC_MAX_OVERHEAD <= context->destsize)) {
-      /* Last chance for fitting `src` buffer in `dest`.  Update flags
-       and do a memcpy later on. */
+      /* Last chance for fitting `src` buffer in `dest`.  Update flags and force a copy. */
       *(context->header_flags) |= BLOSC_MEMCPYED;
+      context->num_output_bytes = BLOSC_MAX_OVERHEAD;  /* reset the output bytes in previous step */
+      ntbytes = do_job(context);
+      if (ntbytes < 0) {
+        return -1;
+      }
     }
-  }
-
-  if (*(context->header_flags) & BLOSC_MEMCPYED) {
-    if (context->sourcesize + BLOSC_MAX_OVERHEAD > context->destsize) {
-      /* We are exceeding maximum output size */
-      ntbytes = 0;
-    }
-    else {
-      MEMCPY(context->dest + BLOSC_MAX_OVERHEAD, context->src,
-             context->sourcesize);
-      ntbytes = context->sourcesize + BLOSC_MAX_OVERHEAD;
-    }
-  }
 
   /* Set the number of compressed bytes in header */
   _sw32(context->dest + 12, ntbytes);
@@ -1386,17 +1373,10 @@ int blosc_run_decompression_with_context(struct blosc_context* context,
     return -1;
   }
 
-  /* Check whether this buffer is memcpy'ed */
-  if (*(context->header_flags) & BLOSC_MEMCPYED) {
-      MEMCPY(dest, (uint8_t *)src+BLOSC_MAX_OVERHEAD, context->sourcesize);
-      ntbytes = context->sourcesize;
-  }
-  else {
-    /* Do the actual decompression */
-    ntbytes = do_job(context);
-    if (ntbytes < 0) {
-      return -1;
-    }
+  /* Do the actual decompression */
+  ntbytes = do_job(context);
+  if (ntbytes < 0) {
+    return -1;
   }
 
   assert(ntbytes <= (int32_t)destsize);
@@ -1548,9 +1528,8 @@ int blosc_getitem(const void *src, int start, int nitems, void *dest)
     /* Do the actual data copy */
     if (flags & BLOSC_MEMCPYED) {
       /* We want to memcpy only */
-      MEMCPY((uint8_t *)dest + ntbytes,
-          (uint8_t *)src + BLOSC_MAX_OVERHEAD + j*blocksize + startb,
-             bsize2);
+      fast_copy((uint8_t *)dest + ntbytes,
+                (uint8_t *)src + BLOSC_MAX_OVERHEAD + j*blocksize + startb, bsize2);
       cbytes = bsize2;
     }
     else {
@@ -1568,7 +1547,7 @@ int blosc_getitem(const void *src, int start, int nitems, void *dest)
         break;
       }
       /* Copy to destination */
-      MEMCPY((uint8_t *)dest + ntbytes, tmp2 + startb, bsize2);
+      fast_copy((uint8_t *)dest + ntbytes, tmp2 + startb, bsize2);
       cbytes = bsize2;
     }
     ntbytes += cbytes;
@@ -1678,8 +1657,7 @@ static void *t_blosc(void *ctxt)
       if (compress) {
         if (flags & BLOSC_MEMCPYED) {
           /* We want to memcpy only */
-          MEMCPY(dest+BLOSC_MAX_OVERHEAD+nblock_*blocksize,
-                 src+nblock_*blocksize, bsize);
+          fast_copy(dest+BLOSC_MAX_OVERHEAD+nblock_*blocksize, src+nblock_*blocksize, bsize);
           cbytes = bsize;
         }
         else {
@@ -1691,8 +1669,7 @@ static void *t_blosc(void *ctxt)
       else {
         if (flags & BLOSC_MEMCPYED) {
           /* We want to memcpy only */
-          MEMCPY(dest+nblock_*blocksize,
-                 src+BLOSC_MAX_OVERHEAD+nblock_*blocksize, bsize);
+          fast_copy(dest+nblock_*blocksize, src+BLOSC_MAX_OVERHEAD+nblock_*blocksize, bsize);
           cbytes = bsize;
         }
         else {
@@ -1734,7 +1711,7 @@ static void *t_blosc(void *ctxt)
         /* End of critical section */
 
         /* Copy the compressed buffer to destination */
-        MEMCPY(dest+ntdest, tmp2, cbytes);
+        fast_copy(dest+ntdest, tmp2, cbytes);
       }
       else {
         nblock_++;

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -15,7 +15,8 @@
 
 #include <stdio.h>
 #include "blosclz.h"
-#include "memcopy.h"
+#include "fastcopy.h"
+#include "blosc-common.h"
 
 
 /*
@@ -74,6 +75,162 @@
 }
 
 #define IP_BOUNDARY 2
+
+
+
+static inline uint8_t *get_run(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
+  uint8_t x = ip[-1];
+  int64_t value, value2;
+  /* Broadcast the value for every byte in a 64-bit register */
+  memset(&value, x, 8);
+  /* safe because the outer check against ip limit */
+  while (ip < (ip_bound - sizeof(int64_t))) {
+#if defined(BLOSC_STRICT_ALIGN)
+    memcpy(&value2, ref, 8);
+#else
+    value2 = ((int64_t*)ref)[0];
+#endif
+    if (value != value2) {
+      /* Find the byte that starts to differ */
+      while (*ref++ == x) ip++;
+      return ip;
+    }
+    else {
+      ip += 8;
+      ref += 8;
+    }
+  }
+  /* Look into the remainder */
+  while ((ip < ip_bound) && (*ref++ == x)) ip++;
+  return ip;
+}
+
+#ifdef __SSE2__
+static inline uint8_t *get_run_16(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
+  uint8_t x = ip[-1];
+  __m128i value, value2, cmp;
+
+  /* Broadcast the value for every byte in a 128-bit register */
+  memset(&value, x, sizeof(__m128i));
+  /* safe because the outer check against ip limit */
+  while (ip < (ip_bound - sizeof(__m128i))) {
+    value2 = _mm_loadu_si128((__m128i *)ref);
+    cmp = _mm_cmpeq_epi32(value, value2);
+    if (_mm_movemask_epi8(cmp) != 0xFFFF) {
+      /* Find the byte that starts to differ */
+      while (*ref++ == x) ip++;
+      return ip;
+    }
+    else {
+      ip += sizeof(__m128i);
+      ref += sizeof(__m128i);
+    }
+  }
+  /* Look into the remainder */
+  while ((ip < ip_bound) && (*ref++ == x)) ip++;
+  return ip;
+}
+#endif
+
+
+#ifdef __AVX2__
+static inline uint8_t *get_run_32(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
+  uint8_t x = ip[-1];
+  __m256i value, value2, cmp;
+
+  /* Broadcast the value for every byte in a 256-bit register */
+  memset(&value, x, sizeof(__m256i));
+  /* safe because the outer check against ip limit */
+  while (ip < (ip_bound - (sizeof(__m256i)))) {
+    value2 = _mm256_loadu_si256((__m256i *)ref);
+    cmp = _mm256_cmpeq_epi64(value, value2);
+    if (_mm256_movemask_epi8(cmp) != 0xFFFFFFFF) {
+      /* Find the byte that starts to differ */
+      while (*ref++ == x) ip++;
+      return ip;
+    }
+    else {
+      ip += sizeof(__m256i);
+      ref += sizeof(__m256i);
+    }
+  }
+  /* Look into the remainder */
+  while ((ip < ip_bound) && (*ref++ == x)) ip++;
+  return ip;
+}
+#endif
+
+
+uint8_t *get_match(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
+  while (ip < (ip_bound - sizeof(int64_t))) {
+#if !defined(BLOSC_STRICT_ALIGN)
+    if (((int64_t*)ref)[0] != ((int64_t*)ip)[0]) {
+#endif
+      /* Find the byte that starts to differ */
+      while (*ref++ == *ip++) {}
+      return ip;
+#if !defined(BLOSC_STRICT_ALIGN)
+    }
+    else {
+      ip += sizeof(int64_t);
+      ref += sizeof(int64_t);
+    }
+#endif
+  }
+  /* Look into the remainder */
+  while ((ip < ip_bound) && (*ref++ == *ip++)) {}
+  return ip;
+}
+
+
+#if defined(__SSE2__)
+uint8_t *get_match_16(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
+  __m128i value, value2, cmp;
+
+  while (ip < (ip_bound - sizeof(__m128i))) {
+    value = _mm_loadu_si128((__m128i *) ip);
+    value2 = _mm_loadu_si128((__m128i *) ref);
+    cmp = _mm_cmpeq_epi32(value, value2);
+    if (_mm_movemask_epi8(cmp) != 0xFFFF) {
+      /* Find the byte that starts to differ */
+      while (*ref++ == *ip++) {}
+      return ip;
+    }
+    else {
+      ip += sizeof(__m128i);
+      ref += sizeof(__m128i);
+    }
+  }
+  /* Look into the remainder */
+  while ((ip < ip_bound) && (*ref++ == *ip++)) {}
+  return ip;
+}
+#endif
+
+
+#if defined(__AVX2__)
+uint8_t *get_match_32(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
+  __m256i value, value2, cmp;
+
+  while (ip < (ip_bound - sizeof(__m256i))) {
+    value = _mm256_loadu_si256((__m256i *) ip);
+    value2 = _mm256_loadu_si256((__m256i *)ref);
+    cmp = _mm256_cmpeq_epi64(value, value2);
+    if (_mm256_movemask_epi8(cmp) != 0xFFFFFFFF) {
+      /* Find the byte that starts to differ */
+      while (*ref++ == *ip++) {}
+      return ip;
+    }
+    else {
+      ip += sizeof(__m256i);
+      ref += sizeof(__m256i);
+    }
+  }
+  /* Look into the remainder */
+  while ((ip < ip_bound) && (*ref++ == *ip++)) {}
+  return ip;
+}
+#endif
 
 
 int blosclz_compress(const int opt_level, const void* input, int length,
@@ -338,7 +495,7 @@ int blosclz_decompress(const void* input, int length, void* output, int maxout) 
         /* copy from reference */
         ref--;
         len += 3;
-        op = safe_copy(op, ref, len);
+        op = safe_copy(op, ref, (unsigned)len);
       }
     }
     else {
@@ -356,7 +513,7 @@ int blosclz_decompress(const void* input, int length, void* output, int maxout) 
       // On GCC-6, fast_copy this is still faster than plain memcpy
       // However, using recent CLANG/LLVM 9.0, there is almost no difference
       // in performance.  In the long run plain memcpy should be preferred.
-      op = fast_copy(op, ip, ctrl);
+      op = fast_copy(op, ip, (unsigned)ctrl);
       ip += ctrl;
 
       loop = (int32_t)BLOSCLZ_EXPECT_CONDITIONAL(ip < ip_limit);

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -495,7 +495,7 @@ int blosclz_decompress(const void* input, int length, void* output, int maxout) 
         /* copy from reference */
         ref--;
         len += 3;
-        op = safe_copy(op, ref, (unsigned)len);
+        op = safecopy(op, ref, (unsigned) len);
       }
     }
     else {
@@ -510,10 +510,10 @@ int blosclz_decompress(const void* input, int length, void* output, int maxout) 
 #endif
 
       // memcpy(op, ip, ctrl); op += ctrl; ip += ctrl;
-      // On GCC-6, fast_copy this is still faster than plain memcpy
+      // On GCC-6, fastcopy this is still faster than plain memcpy
       // However, using recent CLANG/LLVM 9.0, there is almost no difference
-      // in performance.  In the long run plain memcpy should be preferred.
-      op = fast_copy(op, ip, (unsigned)ctrl);
+      // in performance.
+      op = fastcopy(op, ip, (unsigned) ctrl);
       ip += ctrl;
 
       loop = (int32_t)BLOSCLZ_EXPECT_CONDITIONAL(ip < ip_limit);

--- a/blosc/fastcopy.c
+++ b/blosc/fastcopy.c
@@ -444,7 +444,7 @@ static inline unsigned char *chunk_memcpy_aligned(unsigned char *out, const unsi
 
 
 /* Byte by byte semantics: copy LEN bytes from FROM and write them to OUT. Return OUT + LEN. */
-unsigned char *fast_copy(unsigned char *out, const unsigned char *from, unsigned len) {
+unsigned char *fastcopy(unsigned char *out, const unsigned char *from, unsigned len) {
   switch (len) {
     case 32:
       return copy_32_bytes(out, from);
@@ -477,8 +477,8 @@ unsigned char *fast_copy(unsigned char *out, const unsigned char *from, unsigned
 }
 
 
-/* Same as fast_copy() but without overwriting origin or destination when they overlap */
-unsigned char* safe_copy(unsigned char *out, const unsigned char *from, unsigned len) {
+/* Same as fastcopy() but without overwriting origin or destination when they overlap */
+unsigned char* safecopy(unsigned char *out, const unsigned char *from, unsigned len) {
 #if defined(__AVX2__)
   unsigned sz = sizeof(__m256i);
 #elif defined(__SSE2__)
@@ -493,6 +493,6 @@ unsigned char* safe_copy(unsigned char *out, const unsigned char *from, unsigned
     return out;
   }
   else {
-    return fast_copy(out, from, len);
+    return fastcopy(out, from, len);
   }
 }

--- a/blosc/fastcopy.c
+++ b/blosc/fastcopy.c
@@ -18,167 +18,8 @@
     * Support for SSE2/AVX2 copy instructions for these routines
 **********************************************************************/
 
-
-#ifndef MEMCOPY_H_
-#define MEMCOPY_H_
-
 #include <assert.h>
 #include "blosc-common.h"
-
-
-static inline uint8_t *get_run(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
-  uint8_t x = ip[-1];
-  int64_t value, value2;
-  /* Broadcast the value for every byte in a 64-bit register */
-  memset(&value, x, 8);
-  /* safe because the outer check against ip limit */
-  while (ip < (ip_bound - sizeof(int64_t))) {
-#if defined(BLOSC_STRICT_ALIGN)
-    memcpy(&value2, ref, 8);
-#else
-    value2 = ((int64_t*)ref)[0];
-#endif
-    if (value != value2) {
-      /* Find the byte that starts to differ */
-      while (*ref++ == x) ip++;
-      return ip;
-    }
-    else {
-      ip += 8;
-      ref += 8;
-    }
-  }
-  /* Look into the remainder */
-  while ((ip < ip_bound) && (*ref++ == x)) ip++;
-  return ip;
-}
-
-#ifdef __SSE2__
-static inline uint8_t *get_run_16(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
-  uint8_t x = ip[-1];
-  __m128i value, value2, cmp;
-
-  /* Broadcast the value for every byte in a 128-bit register */
-  memset(&value, x, sizeof(__m128i));
-  /* safe because the outer check against ip limit */
-  while (ip < (ip_bound - sizeof(__m128i))) {
-    value2 = _mm_loadu_si128((__m128i *)ref);
-    cmp = _mm_cmpeq_epi32(value, value2);
-    if (_mm_movemask_epi8(cmp) != 0xFFFF) {
-      /* Find the byte that starts to differ */
-      while (*ref++ == x) ip++;
-      return ip;
-    }
-    else {
-      ip += sizeof(__m128i);
-      ref += sizeof(__m128i);
-    }
-  }
-  /* Look into the remainder */
-  while ((ip < ip_bound) && (*ref++ == x)) ip++;
-  return ip;
-}
-#endif
-
-
-#ifdef __AVX2__
-static inline uint8_t *get_run_32(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
-  uint8_t x = ip[-1];
-  __m256i value, value2, cmp;
-
-  /* Broadcast the value for every byte in a 256-bit register */
-  memset(&value, x, sizeof(__m256i));
-  /* safe because the outer check against ip limit */
-  while (ip < (ip_bound - (sizeof(__m256i)))) {
-    value2 = _mm256_loadu_si256((__m256i *)ref);
-    cmp = _mm256_cmpeq_epi64(value, value2);
-    if (_mm256_movemask_epi8(cmp) != 0xFFFFFFFF) {
-      /* Find the byte that starts to differ */
-      while (*ref++ == x) ip++;
-      return ip;
-    }
-    else {
-      ip += sizeof(__m256i);
-      ref += sizeof(__m256i);
-    }
-  }
-  /* Look into the remainder */
-  while ((ip < ip_bound) && (*ref++ == x)) ip++;
-  return ip;
-}
-#endif
-
-
-uint8_t *get_match(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
-  while (ip < (ip_bound - sizeof(int64_t))) {
-#if !defined(BLOSC_STRICT_ALIGN)
-    if (((int64_t*)ref)[0] != ((int64_t*)ip)[0]) {
-#endif
-      /* Find the byte that starts to differ */
-      while (*ref++ == *ip++) {}
-      return ip;
-#if !defined(BLOSC_STRICT_ALIGN)
-    }
-    else {
-      ip += sizeof(int64_t);
-      ref += sizeof(int64_t);
-    }
-#endif
-  }
-  /* Look into the remainder */
-  while ((ip < ip_bound) && (*ref++ == *ip++)) {}
-  return ip;
-}
-
-
-#if defined(__SSE2__)
-uint8_t *get_match_16(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
-  __m128i value, value2, cmp;
-
-  while (ip < (ip_bound - sizeof(__m128i))) {
-    value = _mm_loadu_si128((__m128i *) ip);
-    value2 = _mm_loadu_si128((__m128i *) ref);
-    cmp = _mm_cmpeq_epi32(value, value2);
-    if (_mm_movemask_epi8(cmp) != 0xFFFF) {
-      /* Find the byte that starts to differ */
-      while (*ref++ == *ip++) {}
-      return ip;
-    }
-    else {
-      ip += sizeof(__m128i);
-      ref += sizeof(__m128i);
-    }
-  }
-  /* Look into the remainder */
-  while ((ip < ip_bound) && (*ref++ == *ip++)) {}
-  return ip;
-}
-#endif
-
-
-#if defined(__AVX2__)
-uint8_t *get_match_32(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
-  __m256i value, value2, cmp;
-
-  while (ip < (ip_bound - sizeof(__m256i))) {
-    value = _mm256_loadu_si256((__m256i *) ip);
-    value2 = _mm256_loadu_si256((__m256i *)ref);
-    cmp = _mm256_cmpeq_epi64(value, value2);
-    if (_mm256_movemask_epi8(cmp) != 0xFFFFFFFF) {
-      /* Find the byte that starts to differ */
-      while (*ref++ == *ip++) {}
-      return ip;
-    }
-    else {
-      ip += sizeof(__m256i);
-      ref += sizeof(__m256i);
-    }
-  }
-  /* Look into the remainder */
-  while ((ip < ip_bound) && (*ref++ == *ip++)) {}
-  return ip;
-}
-#endif
 
 
 static inline unsigned char *copy_1_bytes(unsigned char *out, const unsigned char *from) {
@@ -237,7 +78,7 @@ static inline unsigned char *copy_16_bytes(unsigned char *out, const unsigned ch
   _mm_storeu_si128((__m128i*)out, chunk);
   from += 16; out += 16;
 #elif !defined(BLOSC_STRICT_ALIGN)
-   *(uint64_t*)out = *(uint64_t*)from;
+  *(uint64_t*)out = *(uint64_t*)from;
    from += 8; out += 8;
    *(uint64_t*)out = *(uint64_t*)from;
    from += 8; out += 8;
@@ -265,7 +106,7 @@ static inline unsigned char *copy_32_bytes(unsigned char *out, const unsigned ch
   _mm_storeu_si128((__m128i*)out, chunk);
   from += 16; out += 16;
 #elif !defined(BLOSC_STRICT_ALIGN)
-   *(uint64_t*)out = *(uint64_t*)from;
+  *(uint64_t*)out = *(uint64_t*)from;
    from += 8; out += 8;
    *(uint64_t*)out = *(uint64_t*)from;
    from += 8; out += 8;
@@ -302,24 +143,24 @@ static inline unsigned char *copy_bytes(unsigned char *out, const unsigned char 
 #else
   switch (len) {
     case 7:
-        return copy_7_bytes(out, from);
+      return copy_7_bytes(out, from);
     case 6:
-        return copy_6_bytes(out, from);
+      return copy_6_bytes(out, from);
     case 5:
-        return copy_5_bytes(out, from);
+      return copy_5_bytes(out, from);
     case 4:
-        return copy_4_bytes(out, from);
+      return copy_4_bytes(out, from);
     case 3:
-        return copy_3_bytes(out, from);
+      return copy_3_bytes(out, from);
     case 2:
-        return copy_2_bytes(out, from);
+      return copy_2_bytes(out, from);
     case 1:
-        return copy_1_bytes(out, from);
+      return copy_1_bytes(out, from);
     case 0:
-        return out;
+      return out;
     default:
-        assert(0);
-    }
+      assert(0);
+  }
 #endif /* BLOSC_STRICT_ALIGN */
   return out;
 }
@@ -603,7 +444,7 @@ static inline unsigned char *chunk_memcpy_aligned(unsigned char *out, const unsi
 
 
 /* Byte by byte semantics: copy LEN bytes from FROM and write them to OUT. Return OUT + LEN. */
-static inline unsigned char *fast_copy(unsigned char *out, const unsigned char *from, unsigned len) {
+unsigned char *fast_copy(unsigned char *out, const unsigned char *from, unsigned len) {
   switch (len) {
     case 32:
       return copy_32_bytes(out, from);
@@ -637,7 +478,7 @@ static inline unsigned char *fast_copy(unsigned char *out, const unsigned char *
 
 
 /* Same as fast_copy() but without overwriting origin or destination when they overlap */
-static inline unsigned char* safe_copy(unsigned char *out, const unsigned char *from, unsigned len) {
+unsigned char* safe_copy(unsigned char *out, const unsigned char *from, unsigned len) {
 #if defined(__AVX2__)
   unsigned sz = sizeof(__m256i);
 #elif defined(__SSE2__)
@@ -655,6 +496,3 @@ static inline unsigned char* safe_copy(unsigned char *out, const unsigned char *
     return fast_copy(out, from, len);
   }
 }
-
-
-#endif /* MEMCOPY_H_ */

--- a/blosc/fastcopy.h
+++ b/blosc/fastcopy.h
@@ -11,9 +11,9 @@
 #define BLOSC_FASTCOPY_H
 
 /* Same semantics than memcpy() */
-unsigned char *fast_copy(unsigned char *out, const unsigned char *from, unsigned len);
+unsigned char *fastcopy(unsigned char *out, const unsigned char *from, unsigned len);
 
-/* Same as fast_copy() but without overwriting origin or destination when they overlap */
-unsigned char* safe_copy(unsigned char *out, const unsigned char *from, unsigned len);
+/* Same as fastcopy() but without overwriting origin or destination when they overlap */
+unsigned char* safecopy(unsigned char *out, const unsigned char *from, unsigned len);
 
 #endif //BLOSC_FASTCOPY_H

--- a/blosc/fastcopy.h
+++ b/blosc/fastcopy.h
@@ -1,0 +1,19 @@
+/*********************************************************************
+  Blosc - Blocked Shuffling and Compression Library
+
+  Author: Francesc Alted <francesc@blosc.org>
+  Creation date: 2018-01-03
+
+  See LICENSES/BLOSC.txt for details about copyright and rights to use.
+**********************************************************************/
+
+#ifndef BLOSC_FASTCOPY_H
+#define BLOSC_FASTCOPY_H
+
+/* Same semantics than memcpy() */
+unsigned char *fast_copy(unsigned char *out, const unsigned char *from, unsigned len);
+
+/* Same as fast_copy() but without overwriting origin or destination when they overlap */
+unsigned char* safe_copy(unsigned char *out, const unsigned char *from, unsigned len);
+
+#endif //BLOSC_FASTCOPY_H


### PR DESCRIPTION
Using new fastcopy() routine (usually faster than stock memcpy()) in blosc.c.  Got some nice speed-ups, specially when large blocks needs to be copied.