### PR TITLE
Stable channel by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
    global:
      - CONAN_USERNAME: "francescalted"
      - CONAN_LOGIN_USERNAME: "francescalted"
-     - CONAN_CHANNEL: "testing"
+     - CONAN_CHANNEL: "stable"
      - CONAN_UPLOAD: "https://api.bintray.com/conan/blosc/Conan"
      - CONAN_TOTAL_PAGES: 2
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
 
     CONAN_USERNAME: "francescalted"
     CONAN_LOGIN_USERNAME: "francescalted"
-    CONAN_CHANNEL: "testing"
+    CONAN_CHANNEL: "stable"
     CONAN_UPLOAD: "https://api.bintray.com/conan/blosc/Conan"
 
 


### PR DESCRIPTION
For the CI, when you push the tag, the channel was overwritten to "testing", just the opposite we pretended. With this PR all the packages will have the **stable** channel in CI (only uploaded when you tag). 