### PR TITLE
Turn on useful warnings from gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,7 @@ endif()
 # flags
 # set -Wall and other useful warning flags
 if(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
-     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wwrite-strings -Wstrict-prototypes")
+     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wwrite-strings -Wstrict-prototypes -Wno-unused-function")
 endif(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
 
 # @NOTE: -O3 is enabled in Release mode (CMAKE_BUILD_TYPE="Release")
@@ -262,12 +262,12 @@ endif(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR 
 # Probably "-msse2" should be appended to CMAKE_C_FLAGS_RELEASE.
 if(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
      if(COMPILER_SUPPORT_SSE2)
-         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse2" CACHE STRING "C flags." FORCE)
+         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse2")
      endif(COMPILER_SUPPORT_SSE2)
 endif(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
 
 if(MSVC)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Ox" CACHE STRING "C flags." FORCE)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Ox")
 
     # Turn off misguided "secure CRT" warnings in MSVC.
     # Microsoft wants people to use the MS-specific <function>_s

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,23 +251,22 @@ if(DEACTIVATE_AVX2)
 endif()
 
 # flags
-# set -Wall and other useful warning flags
+# Set -Wall and other useful warning flags.
 if(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
-     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wwrite-strings -Wstrict-prototypes -Wno-unused-function")
+    add_compile_options("-Wall" "-Wwrite-strings" "-Wno-unused-function")
 endif(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
 
 # @NOTE: -O3 is enabled in Release mode (CMAKE_BUILD_TYPE="Release")
 
-# Set the "-msse2" build flag only if the CMAKE_C_FLAGS is not already set.
-# Probably "-msse2" should be appended to CMAKE_C_FLAGS_RELEASE.
+# Set the "-msse2" build flag if supported.
 if(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
      if(COMPILER_SUPPORT_SSE2)
-         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse2")
+         add_compile_options("-msse2")
      endif(COMPILER_SUPPORT_SSE2)
 endif(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
 
 if(MSVC)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Ox")
+    add_compile_options("/Ox")
 
     # Turn off misguided "secure CRT" warnings in MSVC.
     # Microsoft wants people to use the MS-specific <function>_s

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@
 #    DEV: static includes blosc.a and blosc.h
 
 
-cmake_minimum_required(VERSION 2.8.10)
+cmake_minimum_required(VERSION 2.8.12)
 if (NOT CMAKE_VERSION VERSION_LESS 3.3)
     cmake_policy(SET CMP0063 NEW)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,7 @@ endif()
 # flags
 # set -Wall and other useful warning flags
 if(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
-     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wwrite-strings -Wstrict-prototypes -Werror")
+     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wwrite-strings -Wstrict-prototypes")
 endif(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
 
 # @NOTE: -O3 is enabled in Release mode (CMAKE_BUILD_TYPE="Release")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,21 +251,23 @@ if(DEACTIVATE_AVX2)
 endif()
 
 # flags
-# @TODO: set -Wall
+# set -Wall and other useful warning flags
+if(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
+     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wwrite-strings -Wstrict-prototypes -Werror")
+endif(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
+
 # @NOTE: -O3 is enabled in Release mode (CMAKE_BUILD_TYPE="Release")
 
 # Set the "-msse2" build flag only if the CMAKE_C_FLAGS is not already set.
 # Probably "-msse2" should be appended to CMAKE_C_FLAGS_RELEASE.
 if(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
-     if(NOT CMAKE_C_FLAGS AND COMPILER_SUPPORT_SSE2)
-         set(CMAKE_C_FLAGS -msse2 CACHE STRING "C flags." FORCE)
-     endif(NOT CMAKE_C_FLAGS AND COMPILER_SUPPORT_SSE2)
+     if(COMPILER_SUPPORT_SSE2)
+         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse2" CACHE STRING "C flags." FORCE)
+     endif(COMPILER_SUPPORT_SSE2)
 endif(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
 
 if(MSVC)
-    if(NOT CMAKE_C_FLAGS)
-        set(CMAKE_C_FLAGS "/Ox" CACHE STRING "C flags." FORCE)
-    endif(NOT CMAKE_C_FLAGS)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Ox" CACHE STRING "C flags." FORCE)
 
     # Turn off misguided "secure CRT" warnings in MSVC.
     # Microsoft wants people to use the MS-specific <function>_s

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,7 @@ endif()
 # flags
 # Set -Wall and other useful warning flags.
 if(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
-    add_compile_options("-Wall" "-Wwrite-strings" "-Wno-unused-function")
+    add_compile_options(-Wall -Wwrite-strings -Wno-unused-function)
 endif(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
 
 # @NOTE: -O3 is enabled in Release mode (CMAKE_BUILD_TYPE="Release")
@@ -261,12 +261,14 @@ endif(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR 
 # Set the "-msse2" build flag if supported.
 if(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
      if(COMPILER_SUPPORT_SSE2)
-         add_compile_options("-msse2")
+         add_compile_options(-msse2)
      endif(COMPILER_SUPPORT_SSE2)
 endif(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
 
 if(MSVC)
-    add_compile_options("/Ox")
+    if(NOT CMAKE_C_FLAGS)
+        set(CMAKE_C_FLAGS "/Ox" CACHE STRING "C flags." FORCE)
+    endif(NOT CMAKE_C_FLAGS)
 
     # Turn off misguided "secure CRT" warnings in MSVC.
     # Microsoft wants people to use the MS-specific <function>_s

--- a/bench/bench.c
+++ b/bench/bench.c
@@ -190,6 +190,7 @@ void do_bench(char *compressor, char *shuffle, int nthreads, int size, int elsiz
   else if (strcmp(shuffle, "noshuffle") == 0) {
       doshuffle = BLOSC_NOSHUFFLE;
     }
+  else abort();
 
   blosc_set_nthreads(nthreads);
   if(blosc_set_compressor(compressor) < 0){
@@ -201,7 +202,9 @@ void do_bench(char *compressor, char *shuffle, int nthreads, int size, int elsiz
   /* Initialize buffers */
   srccpy = malloc(size);
   retcode = posix_memalign( (void **)(&src), 32, size);
+  if (retcode) abort();
   retcode = posix_memalign( (void **)(&dest2), 32, size);
+  if (retcode) abort();
 
   /* zero src to initialize byte on it, and not only multiples of 4 */
   memset(src, 0, size);
@@ -209,6 +212,7 @@ void do_bench(char *compressor, char *shuffle, int nthreads, int size, int elsiz
   memcpy(srccpy, src, size);
   for (j = 0; j < nchunks; j++) {
      retcode = posix_memalign( (void **)(&dest[j]), 32, size+BLOSC_MAX_OVERHEAD);
+     if (retcode) abort();
   }
 
   fprintf(ofile, "--> %d, %d, %d, %d, %s, %s\n", nthreads, size, elsize, rshift, compressor, shuffle);

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -850,7 +850,7 @@ static int serial_blosc(struct blosc_context* context)
 /* Threaded version for compression/decompression */
 static int parallel_blosc(struct blosc_context* context)
 {
-  __attribute__((unused)) int rc;
+  int rc;
 
   /* Check whether we need to restart threads */
   blosc_set_nthreads_(context);
@@ -1590,7 +1590,7 @@ static void *t_blosc(void *ctxt)
   uint8_t *tmp;
   uint8_t *tmp2;
   uint8_t *tmp3;
-  __attribute__((unused)) int rc;
+  int rc;
 
   while(1)
   {
@@ -2067,7 +2067,7 @@ int blosc_release_threadpool(struct blosc_context* context)
 {
   int32_t t;
   void* status;
-  __attribute__((unused)) int rc;
+  int rc;
   int rc2;
 
   if (context->threads_started > 0)

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -307,7 +307,7 @@ static int compname_to_clibcode(const char *compname)
 }
 
 /* Return the library name associated with the compressor code */
-static char *clibcode_to_clibname(int clibcode)
+static const char *clibcode_to_clibname(int clibcode)
 {
   if (clibcode == BLOSC_BLOSCLZ_LIB) return BLOSC_BLOSCLZ_LIBNAME;
   if (clibcode == BLOSC_LZ4_LIB) return BLOSC_LZ4_LIBNAME;
@@ -323,10 +323,10 @@ static char *clibcode_to_clibname(int clibcode)
  */
 
 /* Get the compressor name associated with the compressor code */
-int blosc_compcode_to_compname(int compcode, char **compname)
+int blosc_compcode_to_compname(int compcode, const char **compname)
 {
   int code = -1;    /* -1 means non-existent compressor code */
-  char *name = NULL;
+  const char *name = NULL;
 
   /* Map the compressor code */
   if (compcode == BLOSC_BLOSCLZ)
@@ -528,7 +528,6 @@ static int zstd_wrap_decompress(const char* input, size_t compressed_length,
 /* Compute acceleration for blosclz */
 static int get_accel(const struct blosc_context* context) {
   int32_t clevel = context->clevel;
-  int32_t typesize = context->typesize;
 
   if (context->compcode == BLOSC_LZ4) {
     /* This acceleration setting based on discussions held in:
@@ -554,7 +553,7 @@ static int blosc_c(const struct blosc_context* context, int32_t blocksize,
   int32_t maxout;
   int32_t typesize = context->typesize;
   const uint8_t *_tmp = src;
-  char *compname;
+  const char *compname;
   int accel;
   int bscount;
   int doshuffle = (header_flags & BLOSC_DOSHUFFLE) && (typesize > 1);
@@ -686,7 +685,7 @@ static int blosc_d(struct blosc_context* context, int32_t blocksize,
   int32_t ntbytes = 0;           /* number of uncompressed bytes in block */
   uint8_t *_tmp = dest;
   int32_t typesize = context->typesize;
-  char *compname;
+  const char *compname;
   int bscount;
   int doshuffle = (header_flags & BLOSC_DOSHUFFLE) && (typesize > 1);
   int dobitshuffle = ((header_flags & BLOSC_DOBITSHUFFLE) &&
@@ -1122,7 +1121,7 @@ static int write_compression_header(struct blosc_context* context, int clevel, i
 
   default:
   {
-    char *compname;
+    const char *compname;
     compname = clibcode_to_clibname(compformat);
     fprintf(stderr, "Blosc has not been compiled with '%s' ", compname);
     fprintf(stderr, "compression support.  Please use one having it.");
@@ -1308,7 +1307,7 @@ int blosc_compress(int clevel, int doshuffle, size_t typesize, size_t nbytes,
      previous ones into account */
   envvar = getenv("BLOSC_NOLOCK");
   if (envvar != NULL) {
-    char *compname;
+    const char *compname;
     blosc_compcode_to_compname(g_compressor, &compname);
     result = blosc_compress_ctx(clevel, doshuffle, typesize,
 				nbytes, src, dest, destsize,
@@ -1860,9 +1859,9 @@ int blosc_set_nthreads_(struct blosc_context* context)
   return context->numthreads;
 }
 
-char* blosc_get_compressor(void)
+const char* blosc_get_compressor(void)
 {
-  char* compname;
+  const char* compname;
   blosc_compcode_to_compname(g_compressor, &compname);
 
   return compname;
@@ -1880,7 +1879,7 @@ int blosc_set_compressor(const char *compname)
   return code;
 }
 
-char* blosc_list_compressors(void)
+const char* blosc_list_compressors(void)
 {
   static int compressors_list_done = 0;
   static char ret[256];
@@ -1905,18 +1904,16 @@ char* blosc_list_compressors(void)
   return ret;
 }
 
-char* blosc_get_version_string(void)
+const char* blosc_get_version_string(void)
 {
-  static char ret[256];
-  strcpy(ret, BLOSC_VERSION_STRING);
-  return ret;
+  return BLOSC_VERSION_STRING;
 }
 
-int blosc_get_complib_info(char *compname, char **complib, char **version)
+int blosc_get_complib_info(const char *compname, char **complib, char **version)
 {
   int clibcode;
-  char *clibname;
-  char *clibversion = "unknown";
+  const char *clibname;
+  const char *clibversion = "unknown";
 
 #if (defined(HAVE_LZ4) && defined(LZ4_VERSION_MAJOR)) || (defined(HAVE_SNAPPY) && defined(SNAPPY_VERSION)) || defined(ZSTD_VERSION_MAJOR)
   char sbuffer[256];
@@ -2018,11 +2015,11 @@ void blosc_cbuffer_versions(const void *cbuffer, int *version,
 
 
 /* Return the compressor library/format used in a compressed buffer. */
-char *blosc_cbuffer_complib(const void *cbuffer)
+const char *blosc_cbuffer_complib(const void *cbuffer)
 {
   uint8_t *_src = (uint8_t *)(cbuffer);  /* current pos for source buffer */
   int clibcode;
-  char *complib;
+  const char *complib;
 
   /* Read the compressor format/library info */
   clibcode = (_src[2] & 0xe0) >> 5;

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -850,7 +850,7 @@ static int serial_blosc(struct blosc_context* context)
 /* Threaded version for compression/decompression */
 static int parallel_blosc(struct blosc_context* context)
 {
-  int rc;
+  __attribute__((unused)) int rc;
 
   /* Check whether we need to restart threads */
   blosc_set_nthreads_(context);
@@ -1590,7 +1590,7 @@ static void *t_blosc(void *ctxt)
   uint8_t *tmp;
   uint8_t *tmp2;
   uint8_t *tmp3;
-  int rc;
+  __attribute__((unused)) int rc;
 
   while(1)
   {
@@ -2067,7 +2067,7 @@ int blosc_release_threadpool(struct blosc_context* context)
 {
   int32_t t;
   void* status;
-  int rc;
+  __attribute__((unused)) int rc;
   int rc2;
 
   if (context->threads_started > 0)

--- a/blosc/blosc.h
+++ b/blosc/blosc.h
@@ -311,7 +311,7 @@ BLOSC_EXPORT int blosc_set_nthreads(int nthreads);
 /**
   Returns the current compressor that is used for compression.
   */
-BLOSC_EXPORT char* blosc_get_compressor(void);
+BLOSC_EXPORT const char* blosc_get_compressor(void);
 
 
 /**
@@ -333,7 +333,7 @@ BLOSC_EXPORT int blosc_set_compressor(const char* compname);
   for it in this build, -1 is returned.  Else, the compressor code is
   returned.
  */
-BLOSC_EXPORT int blosc_compcode_to_compname(int compcode, char **compname);
+BLOSC_EXPORT int blosc_compcode_to_compname(int compcode, const char **compname);
 
 
 /**
@@ -356,14 +356,14 @@ BLOSC_EXPORT int blosc_compname_to_compcode(const char *compname);
 
   This function should always succeed.
   */
-BLOSC_EXPORT char* blosc_list_compressors(void);
+BLOSC_EXPORT const char* blosc_list_compressors(void);
 
 /**
   Return the version of blosc in string format.
 
   Useful for dynamic libraries.
 */
-BLOSC_EXPORT char* blosc_get_version_string(void);
+BLOSC_EXPORT const char* blosc_get_version_string(void);
 
 
 /**
@@ -380,7 +380,7 @@ BLOSC_EXPORT char* blosc_get_version_string(void);
   If the compressor is supported, it returns the code for the library
   (>=0).  If it is not supported, this function returns -1.
   */
-BLOSC_EXPORT int blosc_get_complib_info(char *compname, char **complib, char **version);
+BLOSC_EXPORT int blosc_get_complib_info(const char *compname, char **complib, char **version);
 
 
 /**
@@ -442,7 +442,7 @@ BLOSC_EXPORT void blosc_cbuffer_versions(const void *cbuffer, int *version,
 
   This function should always succeed.
   */
-BLOSC_EXPORT char *blosc_cbuffer_complib(const void *cbuffer);
+BLOSC_EXPORT const char *blosc_cbuffer_complib(const void *cbuffer);
 
 
 

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -442,7 +442,6 @@ int blosclz_decompress(const void* input, int length, void* output, int maxout) 
   const uint8_t* ip = (const uint8_t*)input;
   const uint8_t* ip_limit = ip + length;
   uint8_t* op = (uint8_t*)output;
-  uint8_t* op_limit = op + maxout;
   int32_t ctrl = (*ip++) & 31;
   int32_t loop = 1;
 

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -79,7 +79,7 @@
 
 
 
-static inline uint8_t *get_run(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
+static __attribute__((unused)) uint8_t *get_run(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
   uint8_t x = ip[-1];
   int64_t value, value2;
   /* Broadcast the value for every byte in a 64-bit register */

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -79,7 +79,7 @@
 
 
 
-static __attribute__((unused)) uint8_t *get_run(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
+static uint8_t *get_run(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
   uint8_t x = ip[-1];
   int64_t value, value2;
   /* Broadcast the value for every byte in a 64-bit register */

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -79,7 +79,7 @@
 
 
 
-static uint8_t *get_run(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
+static inline uint8_t *get_run(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
   uint8_t x = ip[-1];
   int64_t value, value2;
   /* Broadcast the value for every byte in a 64-bit register */

--- a/blosc/fastcopy.c
+++ b/blosc/fastcopy.c
@@ -353,10 +353,8 @@ static inline unsigned char *chunk_memcpy_32_unrolled(unsigned char *out, const 
 static inline unsigned char *chunk_memcpy_unaligned(unsigned char *out, const unsigned char *from, unsigned len) {
 #if defined(__AVX2__)
   unsigned sz = sizeof(__m256i);
-  __m256i chunk;
 #elif defined(__SSE2__)
   unsigned sz = sizeof(__m128i);
-  __m128i chunk;
 #endif
   unsigned rem = len % sz;
   unsigned ilen;

--- a/blosc/shuffle-generic.h
+++ b/blosc/shuffle-generic.h
@@ -29,7 +29,7 @@ extern "C" {
   implementations to process any remaining elements in a block which
   is not a multiple of (type_size * vector_size).
 */
-static inline void shuffle_generic_inline(const size_t type_size,
+static void shuffle_generic_inline(const size_t type_size,
     const size_t vectorizable_blocksize, const size_t blocksize,
     const uint8_t* const _src, uint8_t* const _dest)
 {
@@ -58,7 +58,7 @@ static inline void shuffle_generic_inline(const size_t type_size,
   implementations to process any remaining elements in a block which
   is not a multiple of (type_size * vector_size).
 */
-static inline void unshuffle_generic_inline(const size_t type_size,
+static void unshuffle_generic_inline(const size_t type_size,
   const size_t vectorizable_blocksize, const size_t blocksize,
   const uint8_t* const _src, uint8_t* const _dest)
 {

--- a/blosc/shuffle-generic.h
+++ b/blosc/shuffle-generic.h
@@ -29,7 +29,7 @@ extern "C" {
   implementations to process any remaining elements in a block which
   is not a multiple of (type_size * vector_size).
 */
-static void shuffle_generic_inline(const size_t type_size,
+static inline void shuffle_generic_inline(const size_t type_size,
     const size_t vectorizable_blocksize, const size_t blocksize,
     const uint8_t* const _src, uint8_t* const _dest)
 {
@@ -58,7 +58,7 @@ static void shuffle_generic_inline(const size_t type_size,
   implementations to process any remaining elements in a block which
   is not a multiple of (type_size * vector_size).
 */
-static void unshuffle_generic_inline(const size_t type_size,
+static inline void unshuffle_generic_inline(const size_t type_size,
   const size_t vectorizable_blocksize, const size_t blocksize,
   const uint8_t* const _src, uint8_t* const _dest)
 {

--- a/blosc/shuffle.c
+++ b/blosc/shuffle.c
@@ -252,21 +252,21 @@ static blosc_cpu_features blosc_get_cpu_features(void) {
   }
 #endif /* defined(_XCR_XFEATURE_ENABLED_MASK) */
 
-#if defined(BLOSC_DUMP_CPU_INFO)
-  printf("Shuffle CPU Information:\n");
-  printf("SSE2 available: %s\n", sse2_available ? "True" : "False");
-  printf("SSE3 available: %s\n", sse3_available ? "True" : "False");
-  printf("SSSE3 available: %s\n", ssse3_available ? "True" : "False");
-  printf("SSE4.1 available: %s\n", sse41_available ? "True" : "False");
-  printf("SSE4.2 available: %s\n", sse42_available ? "True" : "False");
-  printf("AVX2 available: %s\n", avx2_available ? "True" : "False");
-  printf("AVX512BW available: %s\n", avx512bw_available ? "True" : "False");
-  printf("XSAVE available: %s\n", xsave_available ? "True" : "False");
-  printf("XSAVE enabled: %s\n", xsave_enabled_by_os ? "True" : "False");
-  printf("XMM state enabled: %s\n", xmm_state_enabled ? "True" : "False");
-  printf("YMM state enabled: %s\n", ymm_state_enabled ? "True" : "False");
-  printf("ZMM state enabled: %s\n", zmm_state_enabled ? "True" : "False");
-#endif /* defined(BLOSC_DUMP_CPU_INFO) */
+  if (0) {
+    printf("Shuffle CPU Information:\n");
+    printf("SSE2 available: %s\n", sse2_available ? "True" : "False");
+    printf("SSE3 available: %s\n", sse3_available ? "True" : "False");
+    printf("SSSE3 available: %s\n", ssse3_available ? "True" : "False");
+    printf("SSE4.1 available: %s\n", sse41_available ? "True" : "False");
+    printf("SSE4.2 available: %s\n", sse42_available ? "True" : "False");
+    printf("AVX2 available: %s\n", avx2_available ? "True" : "False");
+    printf("AVX512BW available: %s\n", avx512bw_available ? "True" : "False");
+    printf("XSAVE available: %s\n", xsave_available ? "True" : "False");
+    printf("XSAVE enabled: %s\n", xsave_enabled_by_os ? "True" : "False");
+    printf("XMM state enabled: %s\n", xmm_state_enabled ? "True" : "False");
+    printf("YMM state enabled: %s\n", ymm_state_enabled ? "True" : "False");
+    printf("ZMM state enabled: %s\n", zmm_state_enabled ? "True" : "False");
+  }
 
   /* Using the gathered CPU information, determine which implementation to use. */
   /* technically could fail on sse2 cpu on os without xmm support, but that
@@ -294,7 +294,7 @@ static blosc_cpu_features blosc_get_cpu_features(void) {
 
 #endif
 
-static shuffle_implementation_t get_shuffle_implementation() {
+static shuffle_implementation_t get_shuffle_implementation(void) {
   blosc_cpu_features cpu_features = blosc_get_cpu_features();
   shuffle_implementation_t impl_generic;
 
@@ -351,7 +351,7 @@ __forceinline
 #else
 inline
 #endif
-void init_shuffle_implementation() {
+void init_shuffle_implementation(void) {
   /* Initialization could (in rare cases) take place concurrently on
      multiple threads, but it shouldn't matter because the
      initialization should return the same result on each thread (so

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -23,7 +23,7 @@ size_t size = 1*MB;
 
 
 
-static char *test_cbuffer_sizes() {
+static const char *test_cbuffer_sizes(void) {
   size_t nbytes_, cbytes_, blocksize;
 
   blosc_cbuffer_sizes(dest, &nbytes_, &cbytes_, &blocksize);
@@ -34,7 +34,7 @@ static char *test_cbuffer_sizes() {
   return 0;
 }
 
-static char *test_cbuffer_metainfo() {
+static const char *test_cbuffer_metainfo(void) {
   size_t typesize_;
   int flags;
 
@@ -45,7 +45,7 @@ static char *test_cbuffer_metainfo() {
 }
 
 
-static char *test_cbuffer_versions() {
+static const char *test_cbuffer_versions(void) {
   int version_;
   int versionlz_;
 
@@ -56,8 +56,8 @@ static char *test_cbuffer_versions() {
 }
 
 
-static char *test_cbuffer_complib() {
-  char *complib;
+static const char *test_cbuffer_complib(void) {
+  const char *complib;
 
   complib = blosc_cbuffer_complib(dest);
   mu_assert("ERROR: complib incorrect", strcmp(complib, "BloscLZ") == 0);
@@ -65,7 +65,7 @@ static char *test_cbuffer_complib() {
 }
 
 
-static char *test_nthreads() {
+static const char *test_nthreads(void) {
   int nthreads;
 
   nthreads = blosc_set_nthreads(4);
@@ -75,7 +75,7 @@ static char *test_nthreads() {
   return 0;
 }
 
-static char *test_blocksize() {
+static const char *test_blocksize(void) {
   int blocksize;
 
   blocksize = blosc_get_blocksize();
@@ -88,7 +88,7 @@ static char *test_blocksize() {
 }
 
 
-static char *all_tests() {
+static const char *all_tests(void) {
   mu_run_test(test_cbuffer_sizes);
   mu_run_test(test_cbuffer_metainfo);
   mu_run_test(test_cbuffer_versions);
@@ -101,7 +101,7 @@ static char *all_tests() {
 #define BUFFER_ALIGN_SIZE   8
 
 int main(int argc, char **argv) {
-  char *result;
+  const char *result;
 
   printf("STARTING TESTS for %s", argv[0]);
 

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -38,7 +38,7 @@
 /* This is MinUnit in action (http://www.jera.com/techinfo/jtns/jtn002.html) */
 #define mu_assert(message, test) do { if (!(test)) return message; } while (0)
 #define mu_run_test(test) do \
-    { char *message = test(); tests_run++;                          \
+    { const char *message = test(); tests_run++;                          \
       if (message) { printf("%c", 'F'); return message;}            \
       else printf("%c", '.'); } while (0)
 
@@ -56,7 +56,7 @@ extern int tests_run;
     The allocated memory is 'cleaned' before returning to avoid
     accidental re-use of data within or between tests.
  */
-static void* blosc_test_malloc(const size_t alignment, const size_t size)
+static inline void* blosc_test_malloc(const size_t alignment, const size_t size)
 {
   const int32_t clean_value = 0x99;
   void *block = NULL;
@@ -90,7 +90,7 @@ static void* blosc_test_malloc(const size_t alignment, const size_t size)
 }
 
 /** Frees memory allocated by blosc_test_malloc. */
-static void blosc_test_free(void* ptr)
+static inline void blosc_test_free(void* ptr)
 {
 #if defined(_WIN32)
     _aligned_free(ptr);
@@ -100,7 +100,7 @@ static void blosc_test_free(void* ptr)
 }
 
 /** Fills a buffer with random values. */
-static void blosc_test_fill_random(void* const ptr, const size_t size)
+static inline void blosc_test_fill_random(void* const ptr, const size_t size)
 {
   size_t k;
   uint8_t* const byte_ptr = (uint8_t*)ptr;
@@ -114,7 +114,7 @@ static void blosc_test_fill_random(void* const ptr, const size_t size)
 */
 
 /** Parse a `int32_t` value from a string, checking for overflow. */
-static int blosc_test_parse_uint32_t(const char* const str, uint32_t* value)
+static inline int blosc_test_parse_uint32_t(const char* const str, uint32_t* value)
 {
   char* str_end;
   int32_t signed_value = strtol(str, &str_end, 10);
@@ -135,7 +135,7 @@ static int blosc_test_parse_uint32_t(const char* const str, uint32_t* value)
 
 /** Print an error message when a test program has been invoked
     with an invalid number of arguments. */
-static void blosc_test_print_bad_argcount_msg(
+static inline void blosc_test_print_bad_argcount_msg(
   const int32_t num_expected_args, const int32_t num_actual_args)
 {
   fprintf(stderr, "Invalid number of arguments specified.\nExpected %d arguments but was given %d.",
@@ -144,7 +144,7 @@ static void blosc_test_print_bad_argcount_msg(
 
 /** Print an error message when a test program has been invoked
     with an invalid argument value. */
-static void blosc_test_print_bad_arg_msg(const int32_t arg_index)
+static inline void blosc_test_print_bad_arg_msg(const int32_t arg_index)
 {
   fprintf(stderr, "Invalid value specified for argument at index %d.\n", arg_index);
 }

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -48,6 +48,8 @@ extern int tests_run;
 #define MB  (1024*KB)
 #define GB  (1024*MB)
 
+#define UNUSED __attribute__((unused))
+
 /*
   Memory functions.
 */
@@ -56,7 +58,7 @@ extern int tests_run;
     The allocated memory is 'cleaned' before returning to avoid
     accidental re-use of data within or between tests.
  */
-static inline void* blosc_test_malloc(const size_t alignment, const size_t size)
+static UNUSED void* blosc_test_malloc(const size_t alignment, const size_t size)
 {
   const int32_t clean_value = 0x99;
   void *block = NULL;
@@ -90,7 +92,7 @@ static inline void* blosc_test_malloc(const size_t alignment, const size_t size)
 }
 
 /** Frees memory allocated by blosc_test_malloc. */
-static inline void blosc_test_free(void* ptr)
+static UNUSED void blosc_test_free(void* ptr)
 {
 #if defined(_WIN32)
     _aligned_free(ptr);
@@ -100,7 +102,7 @@ static inline void blosc_test_free(void* ptr)
 }
 
 /** Fills a buffer with random values. */
-static inline void blosc_test_fill_random(void* const ptr, const size_t size)
+static UNUSED void blosc_test_fill_random(void* const ptr, const size_t size)
 {
   size_t k;
   uint8_t* const byte_ptr = (uint8_t*)ptr;
@@ -114,7 +116,7 @@ static inline void blosc_test_fill_random(void* const ptr, const size_t size)
 */
 
 /** Parse a `int32_t` value from a string, checking for overflow. */
-static inline int blosc_test_parse_uint32_t(const char* const str, uint32_t* value)
+static UNUSED int blosc_test_parse_uint32_t(const char* const str, uint32_t* value)
 {
   char* str_end;
   int32_t signed_value = strtol(str, &str_end, 10);
@@ -135,7 +137,7 @@ static inline int blosc_test_parse_uint32_t(const char* const str, uint32_t* val
 
 /** Print an error message when a test program has been invoked
     with an invalid number of arguments. */
-static inline void blosc_test_print_bad_argcount_msg(
+static UNUSED void blosc_test_print_bad_argcount_msg(
   const int32_t num_expected_args, const int32_t num_actual_args)
 {
   fprintf(stderr, "Invalid number of arguments specified.\nExpected %d arguments but was given %d.",
@@ -144,7 +146,7 @@ static inline void blosc_test_print_bad_argcount_msg(
 
 /** Print an error message when a test program has been invoked
     with an invalid argument value. */
-static inline void blosc_test_print_bad_arg_msg(const int32_t arg_index)
+static UNUSED void blosc_test_print_bad_arg_msg(const int32_t arg_index)
 {
   fprintf(stderr, "Invalid value specified for argument at index %d.\n", arg_index);
 }

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -48,8 +48,6 @@ extern int tests_run;
 #define MB  (1024*KB)
 #define GB  (1024*MB)
 
-#define UNUSED __attribute__((unused))
-
 /*
   Memory functions.
 */
@@ -58,7 +56,7 @@ extern int tests_run;
     The allocated memory is 'cleaned' before returning to avoid
     accidental re-use of data within or between tests.
  */
-static UNUSED void* blosc_test_malloc(const size_t alignment, const size_t size)
+static void* blosc_test_malloc(const size_t alignment, const size_t size)
 {
   const int32_t clean_value = 0x99;
   void *block = NULL;
@@ -92,7 +90,7 @@ static UNUSED void* blosc_test_malloc(const size_t alignment, const size_t size)
 }
 
 /** Frees memory allocated by blosc_test_malloc. */
-static UNUSED void blosc_test_free(void* ptr)
+static void blosc_test_free(void* ptr)
 {
 #if defined(_WIN32)
     _aligned_free(ptr);
@@ -102,7 +100,7 @@ static UNUSED void blosc_test_free(void* ptr)
 }
 
 /** Fills a buffer with random values. */
-static UNUSED void blosc_test_fill_random(void* const ptr, const size_t size)
+static void blosc_test_fill_random(void* const ptr, const size_t size)
 {
   size_t k;
   uint8_t* const byte_ptr = (uint8_t*)ptr;
@@ -116,7 +114,7 @@ static UNUSED void blosc_test_fill_random(void* const ptr, const size_t size)
 */
 
 /** Parse a `int32_t` value from a string, checking for overflow. */
-static UNUSED int blosc_test_parse_uint32_t(const char* const str, uint32_t* value)
+static int blosc_test_parse_uint32_t(const char* const str, uint32_t* value)
 {
   char* str_end;
   int32_t signed_value = strtol(str, &str_end, 10);
@@ -137,7 +135,7 @@ static UNUSED int blosc_test_parse_uint32_t(const char* const str, uint32_t* val
 
 /** Print an error message when a test program has been invoked
     with an invalid number of arguments. */
-static UNUSED void blosc_test_print_bad_argcount_msg(
+static void blosc_test_print_bad_argcount_msg(
   const int32_t num_expected_args, const int32_t num_actual_args)
 {
   fprintf(stderr, "Invalid number of arguments specified.\nExpected %d arguments but was given %d.",
@@ -146,7 +144,7 @@ static UNUSED void blosc_test_print_bad_argcount_msg(
 
 /** Print an error message when a test program has been invoked
     with an invalid argument value. */
-static UNUSED void blosc_test_print_bad_arg_msg(const int32_t arg_index)
+static void blosc_test_print_bad_arg_msg(const int32_t arg_index)
 {
   fprintf(stderr, "Invalid value specified for argument at index %d.\n", arg_index);
 }

--- a/tests/test_compressor.c
+++ b/tests/test_compressor.c
@@ -23,8 +23,8 @@ size_t size = 8 * 1000 * 1000;  /* must be divisible by typesize */
 
 
 /* Check compressor */
-static char *test_compressor() {
-  char* compressor;
+static const char *test_compressor(void) {
+  const char* compressor;
 
   /* Before any blosc_compress() the compressor must be blosclz */
   compressor = blosc_get_compressor();
@@ -50,8 +50,8 @@ static char *test_compressor() {
 
 
 /* Check compressing + decompressing */
-static char *test_compress_decompress() {
-  char* compressor;
+static const char *test_compress_decompress(void) {
+  const char* compressor;
 
   /* Activate the BLOSC_COMPRESSOR variable */
   setenv("BLOSC_COMPRESSOR", "lz4", 0);
@@ -84,7 +84,7 @@ static char *test_compress_decompress() {
 
 
 /* Check compression level */
-static char *test_clevel() {
+static const char *test_clevel(void) {
   int cbytes2;
 
   /* Get a compressed buffer */
@@ -104,7 +104,7 @@ static char *test_clevel() {
 }
 
 /* Check noshuffle */
-static char *test_noshuffle() {
+static const char *test_noshuffle(void) {
   int cbytes2;
 
   /* Get a compressed buffer */
@@ -126,7 +126,7 @@ static char *test_noshuffle() {
 
 
 /* Check regular shuffle */
-static char *test_shuffle() {
+static const char *test_shuffle(void) {
   int cbytes2;
 
   /* Get a compressed buffer */
@@ -147,7 +147,7 @@ static char *test_shuffle() {
 }
 
 /* Check bitshuffle */
-static char *test_bitshuffle() {
+static const char *test_bitshuffle(void) {
   int cbytes2;
 
   /* Get a compressed buffer */
@@ -170,7 +170,7 @@ static char *test_bitshuffle() {
 
 
 /* Check typesize */
-static char *test_typesize() {
+static const char *test_typesize(void) {
   int cbytes2;
 
   /* Get a compressed buffer */
@@ -190,7 +190,7 @@ static char *test_typesize() {
 }
 
 
-static char *all_tests() {
+static const char *all_tests(void) {
   mu_run_test(test_compressor);
   mu_run_test(test_compress_decompress);
   mu_run_test(test_clevel);
@@ -206,7 +206,7 @@ static char *all_tests() {
 
 int main(int argc, char **argv) {
   int64_t *_src;
-  char *result;
+  const char *result;
   size_t i;
 
   printf("STARTING TESTS for %s", argv[0]);

--- a/tests/test_maxout.c
+++ b/tests/test_maxout.c
@@ -23,7 +23,7 @@ size_t size = 1000;             /* must be divisible by 4 */
 
 
 /* Check maxout with maxout < size */
-static char *test_maxout_less() {
+static const char *test_maxout_less(void) {
 
   /* Get a compressed buffer */
   cbytes = blosc_compress(clevel, doshuffle, typesize, size, src, dest, size+15);
@@ -34,7 +34,7 @@ static char *test_maxout_less() {
 
 
 /* Check maxout with maxout < size (memcpy version) */
-static char *test_maxout_less_memcpy() {
+static const char *test_maxout_less_memcpy(void) {
 
   /* Get a compressed buffer */
   cbytes = blosc_compress(0, doshuffle, typesize, size, src, dest, size+15);
@@ -45,7 +45,7 @@ static char *test_maxout_less_memcpy() {
 
 
 /* Check maxout with maxout == size */
-static char *test_maxout_equal() {
+static const char *test_maxout_equal(void) {
 
   /* Get a compressed buffer */
   cbytes = blosc_compress(clevel, doshuffle, typesize, size, src, dest, size+16);
@@ -60,7 +60,7 @@ static char *test_maxout_equal() {
 
 
 /* Check maxout with maxout == size (memcpy version) */
-static char *test_maxout_equal_memcpy() {
+static const char *test_maxout_equal_memcpy(void) {
 
   /* Get a compressed buffer */
   cbytes = blosc_compress(0, doshuffle, typesize, size, src, dest, size+16);
@@ -75,7 +75,7 @@ static char *test_maxout_equal_memcpy() {
 
 
 /* Check maxout with maxout > size */
-static char *test_maxout_great() {
+static const char *test_maxout_great(void) {
   /* Get a compressed buffer */
   cbytes = blosc_compress(clevel, doshuffle, typesize, size, src, dest, size+17);
   mu_assert("ERROR: cbytes is not correct", cbytes == size+16);
@@ -89,7 +89,7 @@ static char *test_maxout_great() {
 
 
 /* Check maxout with maxout > size (memcpy version) */
-static char *test_maxout_great_memcpy() {
+static const char *test_maxout_great_memcpy(void) {
   /* Get a compressed buffer */
   cbytes = blosc_compress(0, doshuffle, typesize, size, src, dest, size+17);
   mu_assert("ERROR: cbytes is not correct", cbytes == size+16);
@@ -102,7 +102,7 @@ static char *test_maxout_great_memcpy() {
 }
 
 
-static char *all_tests() {
+static const char *all_tests(void) {
   mu_run_test(test_maxout_less);
   mu_run_test(test_maxout_less_memcpy);
   mu_run_test(test_maxout_equal);
@@ -117,7 +117,7 @@ static char *all_tests() {
 
 int main(int argc, char **argv) {
   int32_t *_src;
-  char *result;
+  const char *result;
   size_t i;
 
   printf("STARTING TESTS for %s", argv[0]);

--- a/tests/test_noinit.c
+++ b/tests/test_noinit.c
@@ -26,7 +26,7 @@ size_t size = 4 * 1000 * 1000;             /* must be divisible by 4 */
 
 
 /* Check just compressing */
-static char *test_compress() {
+static const char *test_compress(void) {
 
   /* Get a compressed buffer */
   cbytes = blosc_compress(clevel, doshuffle, typesize, size, src,
@@ -38,7 +38,7 @@ static char *test_compress() {
 
 
 /* Check compressing + decompressing */
-static char *test_compress_decompress() {
+static const char *test_compress_decompress(void) {
 
   /* Get a compressed buffer */
   cbytes = blosc_compress(clevel, doshuffle, typesize, size, src,
@@ -53,7 +53,7 @@ static char *test_compress_decompress() {
 }
 
 
-static char *all_tests() {
+static const char *all_tests(void) {
   mu_run_test(test_compress);
   mu_run_test(test_compress_decompress);
 
@@ -64,15 +64,15 @@ static char *all_tests() {
 
 int main(int argc, char **argv) {
   int32_t *_src;
-  char *result;
+  const char *result;
   size_t i;
-  int pid, nchildren = 4;
+  int nchildren = 4;
 
   printf("STARTING TESTS for %s\n", argv[0]);
 
   /* Launch several subprocesses */
   for (i = 1; i <= nchildren; i++) {
-    pid = fork();
+    fork();
   }
 
   blosc_set_nthreads(4);

--- a/tests/test_nolock.c
+++ b/tests/test_nolock.c
@@ -24,7 +24,7 @@ size_t size = 4 * 1000 * 1000;             /* must be divisible by 4 */
 
 
 /* Check just compressing */
-static char *test_compress() {
+static const char *test_compress(void) {
 
   /* Get a compressed buffer */
   cbytes = blosc_compress(clevel, doshuffle, typesize, size, src,
@@ -36,7 +36,7 @@ static char *test_compress() {
 
 
 /* Check compressing + decompressing */
-static char *test_compress_decompress() {
+static const char *test_compress_decompress(void) {
 
   /* Get a compressed buffer */
   cbytes = blosc_compress(clevel, doshuffle, typesize, size, src,
@@ -51,7 +51,7 @@ static char *test_compress_decompress() {
 }
 
 
-static char *all_tests() {
+static const char *all_tests(void) {
   mu_run_test(test_compress);
   mu_run_test(test_compress_decompress);
 
@@ -62,9 +62,9 @@ static char *all_tests() {
 
 int main(int argc, char **argv) {
   int32_t *_src;
-  char *result;
+  const char *result;
   size_t i;
-  int pid, nchildren = 4;
+  int nchildren = 4;
 
   printf("STARTING TESTS for %s\n", argv[0]);
 
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
 
   /* Launch several subprocesses */
   for (i = 1; i <= nchildren; i++) {
-    pid = fork();
+    fork();
   }
 
   blosc_init();

--- a/tests/test_nthreads.c
+++ b/tests/test_nthreads.c
@@ -23,7 +23,7 @@ size_t size = 4 * 1000 * 1000;             /* must be divisible by 4 */
 
 
 /* Check just compressing */
-static char *test_compress() {
+static const char *test_compress(void) {
   int nthreads;
 
   /* Before any blosc_compress() or blosc_decompress() the number of
@@ -44,7 +44,7 @@ static char *test_compress() {
 
 
 /* Check compressing + decompressing */
-static char *test_compress_decompress() {
+static const char *test_compress_decompress(void) {
   int nthreads;
 
   nthreads = blosc_get_nthreads();
@@ -69,7 +69,7 @@ static char *test_compress_decompress() {
 }
 
 
-static char *all_tests() {
+static const char *all_tests(void) {
   mu_run_test(test_compress);
   mu_run_test(test_compress_decompress);
 
@@ -80,9 +80,8 @@ static char *all_tests() {
 
 int main(int argc, char **argv) {
   int32_t *_src;
-  char *result;
+  const char *result;
   size_t i;
-  int pid, nchildren = 4;
 
   printf("STARTING TESTS for %s", argv[0]);
 

--- a/tests/test_shuffle_roundtrip_avx2.c
+++ b/tests/test_shuffle_roundtrip_avx2.c
@@ -18,12 +18,6 @@
 
 #if defined(SHUFFLE_AVX2_ENABLED)
   #include "../blosc/shuffle-avx2.h"
-#else
-  #if defined(_MSC_VER)
-  #pragma message("AVX2 shuffle tests not enabled.")
-  #else
-  #warning AVX2 shuffle tests not enabled.
-  #endif
 #endif  /* defined(SHUFFLE_AVX2_ENABLED) */
 
 


### PR DESCRIPTION
Fix code that gcc warns for. Remove unused variables, const poisoning,
and use declare functions (void) instead of ().

Please note that it changes the signatures of the API. The ABI is not changed.

I need someone to double-check the CMakeLists.txt changes.