### PR TITLE
Declare fsize at the beginning on main

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,9 @@ environment:
     matrix:
         - MINGW_CONFIGURATIONS: "4.9@x86_64@seh@posix, 5@x86_64@seh@posix, 6@x86_64@seh@posix, 7@x86_64@seh@posix"
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 9
+          CONAN_RUN_TESTS: "1"
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 12
           CONAN_RUN_TESTS: "1"
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015

--- a/compat/filegen.c
+++ b/compat/filegen.c
@@ -34,6 +34,7 @@ int main(int argc, char *argv[]) {
   size_t osize = SIZE * sizeof(int32_t);
   int dsize = SIZE * sizeof(int32_t);
   int csize;
+  long fsize;
   int i;
 
   FILE *f;
@@ -77,7 +78,7 @@ int main(int argc, char *argv[]) {
     /* Read from argv[2] into data_out. */
     f = fopen(argv[2], "rb");
     fseek(f, 0, SEEK_END);
-    long fsize = ftell(f);
+    fsize = ftell(f);
     fseek(f, 0, SEEK_SET);
     if (fread(data_out, 1, (size_t) fsize, f) == fsize) {
       printf("Checking %s\n", argv[2]);


### PR DESCRIPTION
Moves the `fsize` type definition to the top of `main` to comply with C89's constraints. Should fix a compilation error on VS 2008 (needed for Python 2.7 support on Windows).