### PR TITLE
Minor fixes for mingw64

### DIFF
--- a/compat/filegen.c
+++ b/compat/filegen.c
@@ -14,13 +14,15 @@
 #include <string.h>
 
 #if defined(_WIN32) && !defined(__MINGW32__)
-#include <windows.h>
+  #include <windows.h>
   /* stdint.h only available in VS2010 (VC++ 16.0) and newer */
   #if defined(_MSC_VER) && _MSC_VER < 1600
     #include "win32/stdint-windows.h"
   #else
     #include <stdint.h>
   #endif
+#else
+  #include <stdint.h>
 #endif  /* _WIN32 */
 
 #define SIZE (1000 * 1000)

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -29,8 +29,8 @@
 #include <math.h>
 #include "../blosc/blosc.h"
 
-#if defined(_WIN32) && !defined(__MINGW32__)
-  /* MSVC does not have setenv */
+#if defined(_WIN32)
+  /* MSVC and MinGW do not have setenv */
   #define setenv(name, value, overwrite) do {_putenv_s(name, value);} while(0)
 #endif
 


### PR DESCRIPTION
Two minor fixes to build on latest MSYS2 with gcc-7.3 (MinGW64 based Windows build)