### PR TITLE
always use win32 threads on Windows

### DIFF
--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -56,7 +56,7 @@
   #include <inttypes.h>
 #endif  /* _WIN32 */
 
-#if defined(_WIN32) && !defined(__GNUC__)
+#if defined(_WIN32)
   #include "win32/pthread.h"
   #include "win32/pthread.c"
 #else


### PR DESCRIPTION
On Windows with non-GNU compilers, `blosc.c` uses `win32/pthread.c` as a lightweight pthreads replacement using native Windows threads.

This PR changes it to use `win32/pthread.c` on **all Windows builds** even with GNU compilers.   Although MinGW etcetera provides a more full-featured pthreads replacement, it doesn't seem to accomplish anything here since the functionality in `win32/pthread.c` is sufficient for Blosc.  Furthermore, using the MinGW pthreads adds an additional library dependency to libblosc that is annoying for binary distribution.  (For example, it got in the way of distributing cross-compiled Windows binaries for use with Julia, since we want the resulting `libblosc.dll` to be usable on any Windows machine even where MinGW is not installed).

I've been patching c-blosc locally with this change, but it doesn't seem like there is any reason not to make the change globally.