### PR TITLE
Enable fork-safe operation via pthread_atfork hook.

### DIFF
--- a/blosc/win32/pthread.h
+++ b/blosc/win32/pthread.h
@@ -45,6 +45,7 @@
 #define pthread_mutex_init(a,b) InitializeCriticalSection((a))
 #define pthread_mutex_destroy(a) DeleteCriticalSection((a))
 #define pthread_mutex_lock EnterCriticalSection
+#define pthread_mutex_trylock TryEnterCriticalSection
 #define pthread_mutex_unlock LeaveCriticalSection
 
 /*

--- a/tests/test_forksafe.c
+++ b/tests/test_forksafe.c
@@ -1,0 +1,104 @@
+/*********************************************************************
+  Blosc - Blocked Shuffling and Compression Library
+
+  Roundtrip compression/decompression tests.
+
+  Creation date: 2010-06-07
+  Author: Francesc Alted <francesc@blosc.org>
+
+  See LICENSES/BLOSC.txt for details about copyright and rights to use.
+**********************************************************************/
+
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <signal.h>
+
+#include "test_common.h"
+
+
+int clevel = 3;
+int doshuffle = 1;
+size_t typesize = 4;
+size_t size = 5*MB;
+#define BUFFER_ALIGN_SIZE   8
+
+void *src, *dest, *dest2;
+size_t nbytes, cbytes;
+
+int tests_run = 0;
+
+static char *test_forksafe(void) {
+  /* Compress the input data and store it in dest. */
+  blosc_set_nthreads(4);
+  cbytes = blosc_compress(clevel, doshuffle, typesize, size, src, dest, size);
+
+  pid_t newpid = fork();
+  if (newpid == 0) {
+    nbytes = blosc_decompress(dest, dest2, size);
+    exit(0);
+  }
+
+  int success = 0;
+	int status;
+  for(float sec = 0; sec < 1; ) {
+    if(waitpid(newpid, &status, WNOHANG) != 0) {
+      success = 1;
+      break;
+    }
+
+    usleep(5000);
+    sec += 5000 * 1e-6;
+  }
+
+  if(!success) {
+    kill(newpid, SIGKILL);
+    waitpid(newpid, &status, 0);
+  }
+
+  mu_assert("ERROR: Child deadlocked post-fork.", success == 1);
+
+  return 0;
+}
+
+
+static const char *all_tests(void) {
+  mu_run_test(test_forksafe);
+
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  const char *result;
+
+  printf("STARTING TESTS for %s", argv[0]);
+
+  blosc_init();
+
+  /* Initialize buffers */
+  src = blosc_test_malloc(BUFFER_ALIGN_SIZE, size);
+  dest = blosc_test_malloc(BUFFER_ALIGN_SIZE, size + 16);
+  dest2 = blosc_test_malloc(BUFFER_ALIGN_SIZE, size);
+
+  /* Fill the input data buffer with random values. */
+  blosc_test_fill_random(src, size);
+
+  /* Run all the suite */
+  result = all_tests();
+  if (result != 0) {
+    printf(" (%s)\n", result);
+  }
+  else {
+    printf(" ALL TESTS PASSED");
+  }
+  printf("\tTests run: %d\n", tests_run);
+
+  blosc_test_free(src);
+  blosc_test_free(dest);
+  blosc_test_free(dest2);
+
+  blosc_destroy();
+
+  return result != 0;
+}


### PR DESCRIPTION
The blosc global context object maintains a thread-pool and internal
mutexs, and is unsafe to reused in a child process post fork. This
causes deadlocks in child processes post-fork, which affects any
blosc-consuming libraries. The `_ctx` context apis (set_releasegil in
python-blosc) provide a workaround, but have a non-zero overhead and are
non-default. (https://github.com/Blosc/bloscpack/issues/58)

This update provides fork-safety by discarding and reinitializing the
global context in the post-fork child. The behavior "leaks" the previous
context in the child by skipping cleanup, however the context object is
already in an invalid state and likely can't be reliably reused. 

* Add init with pthread_atfork hook.

  Update blosc to reinitialize child global context post-fork,
  discarding potentially inconsistent global context. Resolves issues with
  deadlock-on-decompression in child process post fork if blosc has
  already been initialized.

* Add test for compressor fork-safety.