### PR TITLE
fix compression of empty string

### DIFF
--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -1080,7 +1080,7 @@ static int initialize_context_compression(struct blosc_context* context,
             BLOSC_MAX_BUFFERSIZE);
     return -1;
   }
-  if (destsize <= BLOSC_MAX_OVERHEAD) {
+  if (destsize < BLOSC_MAX_OVERHEAD) {
     fprintf(stderr, "Output buffer size should be larger than %d bytes\n",
             BLOSC_MAX_OVERHEAD);
     return -1;

--- a/tests/test_compress_roundtrip.c
+++ b/tests/test_compress_roundtrip.c
@@ -83,7 +83,7 @@ int main(int argc, char **argv)
     return EXIT_FAILURE;
   }
 
-  if (!blosc_test_parse_uint32_t(argv[2], &num_elements) || (num_elements < 1))
+  if (!blosc_test_parse_uint32_t(argv[2], &num_elements) || (num_elements < 0))
   {
     blosc_test_print_bad_arg_msg(2);
     return EXIT_FAILURE;

--- a/tests/test_compress_roundtrip.csv
+++ b/tests/test_compress_roundtrip.csv
@@ -1,4 +1,5 @@
 "Size of element type (bytes)","Number of elements","Buffer alignment size (bytes)","Compression level","Shuffle enabled","Blosc thread count"
+1,0,32,0,0,1
 1,7,32,5,0,1
 1,192,32,5,0,1
 1,1792,32,5,0,1

--- a/tests/test_maxout.c
+++ b/tests/test_maxout.c
@@ -101,10 +101,10 @@ static const char *test_maxout_great_memcpy(void) {
   return 0;
 }
 
-/* Check maxout with maxout <= BLOSC_MAX_OVERHEAD */
+/* Check maxout with maxout < BLOSC_MAX_OVERHEAD */
 static const char *test_max_overhead(void) {
   blosc_init();
-  cbytes = blosc_compress(0, doshuffle, typesize, size, src, dest, BLOSC_MAX_OVERHEAD);
+  cbytes = blosc_compress(0, doshuffle, typesize, size, src, dest, BLOSC_MAX_OVERHEAD - 1);
   mu_assert("ERROR: cbytes is not correct", cbytes < 0);
   blosc_destroy();
 


### PR DESCRIPTION
The check here was faulty, in case of the empty string, the output
buffer will be exactly BLOSC_MAX_OVERHEAD. I.e. the output buffer will
contain only exactly the blosc header and nothing else.