### PR TITLE
Use vendored `stdint.h` for older Visual Studio

### DIFF
--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -14,8 +14,20 @@
 
 
 #include <stdio.h>
-#include <stdint.h>
 #include <stdlib.h>
+
+#if defined(_WIN32) && !defined(__MINGW32__)
+  #include <windows.h>
+  /* stdint.h only available in VS2010 (VC++ 16.0) and newer */
+  #if defined(_MSC_VER) && _MSC_VER < 1600
+    #include "win32/stdint-windows.h"
+  #else
+    #include <stdint.h>
+  #endif
+#else
+  #include <stdint.h>
+#endif  /* _WIN32 */
+
 #include "blosclz.h"
 #include "fastcopy.h"
 #include "blosc-common.h"


### PR DESCRIPTION
Fixes https://github.com/Blosc/c-blosc/issues/248

On older versions of Visual Studio, `stdint.h` is not included. In these cases, we need to use our vendored copy of `stdint.h` as a stand-in. For newer versions of Visual Studio or other compilers, `stdint.h` is generally included. So this workaround is unneeded in those cases and we handle them accordingly as well.

cc @alimanfoo