### PR TITLE
Prefix all internal non-local symbols with "blosc_internal_"

### DIFF
--- a/blosc/bitshuffle-avx2.c
+++ b/blosc/bitshuffle-avx2.c
@@ -51,8 +51,8 @@ static void printymm(__m256i ymm0)
 
 
 /* Transpose bits within bytes. */
-int64_t bshuf_trans_bit_byte_avx2(void* in, void* out, const size_t size,
-                                  const size_t elem_size) {
+static int64_t bshuf_trans_bit_byte_avx2(void* in, void* out, const size_t size,
+                                         const size_t elem_size) {
 
     char* in_b = (char*) in;
     char* out_b = (char*) out;
@@ -75,34 +75,31 @@ int64_t bshuf_trans_bit_byte_avx2(void* in, void* out, const size_t size,
             *out_i32 = bt;
         }
     }
-    count = bshuf_trans_bit_byte_remainder(in, out, size, elem_size,
+    count = blosc_internal_bshuf_trans_bit_byte_remainder(in, out, size, elem_size,
             nbyte - nbyte % 32);
     return count;
 }
 
-
 /* Transpose bits within elements. */
-int64_t bshuf_trans_bit_elem_avx2(void* in, void* out, const size_t size,
-                                  const size_t elem_size, void* tmp_buf) {
-
+int64_t blosc_internal_bshuf_trans_bit_elem_avx2(void* in, void* out, const size_t size,
+                                                 const size_t elem_size, void* tmp_buf) {
     int64_t count;
 
     CHECK_MULT_EIGHT(size);
 
-    count = bshuf_trans_byte_elem_sse2(in, out, size, elem_size, tmp_buf);
+    count = blosc_internal_bshuf_trans_byte_elem_sse2(in, out, size, elem_size, tmp_buf);
     CHECK_ERR(count);
     count = bshuf_trans_bit_byte_avx2(out, tmp_buf, size, elem_size);
     CHECK_ERR(count);
-    count = bshuf_trans_bitrow_eight(tmp_buf, out, size, elem_size);
+    count = blosc_internal_bshuf_trans_bitrow_eight(tmp_buf, out, size, elem_size);
 
     return count;
 }
 
-
 /* For data organized into a row for each bit (8 * elem_size rows), transpose
  * the bytes. */
-int64_t bshuf_trans_byte_bitrow_avx2(void* in, void* out, const size_t size,
-                                     const size_t elem_size) {
+static int64_t bshuf_trans_byte_bitrow_avx2(void* in, void* out, const size_t size,
+                                            const size_t elem_size) {
 
     char* in_b = (char*) in;
     char* out_b = (char*) out;
@@ -114,7 +111,7 @@ int64_t bshuf_trans_byte_bitrow_avx2(void* in, void* out, const size_t size,
     CHECK_MULT_EIGHT(size);
 
     if (elem_size % 4)
-      return bshuf_trans_byte_bitrow_sse2(in, out, size, elem_size);
+      return blosc_internal_bshuf_trans_byte_bitrow_sse2(in, out, size, elem_size);
 
     __m256i ymm_0[8];
     __m256i ymm_1[8];
@@ -196,8 +193,8 @@ int64_t bshuf_trans_byte_bitrow_avx2(void* in, void* out, const size_t size,
 
 
 /* Shuffle bits within the bytes of eight element blocks. */
-int64_t bshuf_shuffle_bit_eightelem_avx2(void* in, void* out, const size_t size,
-                                         const size_t elem_size) {
+static int64_t bshuf_shuffle_bit_eightelem_avx2(void* in, void* out, const size_t size,
+                                                const size_t elem_size) {
 
     CHECK_MULT_EIGHT(size);
 
@@ -213,7 +210,7 @@ int64_t bshuf_shuffle_bit_eightelem_avx2(void* in, void* out, const size_t size,
     int32_t bt;
 
     if (elem_size % 4) {
-        return bshuf_shuffle_bit_eightelem_sse2(in, out, size, elem_size);
+        return blosc_internal_bshuf_shuffle_bit_eightelem_sse2(in, out, size, elem_size);
     } else {
         for (jj = 0; jj + 31 < 8 * elem_size; jj += 32) {
             for (ii = 0; ii + 8 * elem_size - 1 < nbyte;
@@ -233,8 +230,8 @@ int64_t bshuf_shuffle_bit_eightelem_avx2(void* in, void* out, const size_t size,
 
 
 /* Untranspose bits within elements. */
-int64_t bshuf_untrans_bit_elem_avx2(void* in, void* out, const size_t size,
-                                    const size_t elem_size, void* tmp_buf) {
+int64_t blosc_internal_bshuf_untrans_bit_elem_avx2(void* in, void* out, const size_t size,
+                                                   const size_t elem_size, void* tmp_buf) {
 
     int64_t count;
 

--- a/blosc/bitshuffle-avx2.h
+++ b/blosc/bitshuffle-avx2.h
@@ -21,15 +21,15 @@ extern "C" {
   AVX2-accelerated bitshuffle routine.
 */
 BLOSC_NO_EXPORT int64_t
-bshuf_trans_bit_elem_avx2(void* in, void* out, const size_t size,
-			  const size_t elem_size, void* tmp_buf);
+blosc_internal_bshuf_trans_bit_elem_avx2(void* in, void* out, const size_t size,
+                                         const size_t elem_size, void* tmp_buf);
 
 /**
   AVX2-accelerated bitunshuffle routine.
 */
 BLOSC_NO_EXPORT int64_t
-bshuf_untrans_bit_elem_avx2(void* in, void* out, const size_t size,
-			    const size_t elem_size, void* tmp_buf);
+blosc_internal_bshuf_untrans_bit_elem_avx2(void* in, void* out, const size_t size,
+                                           const size_t elem_size, void* tmp_buf);
 
 #ifdef __cplusplus
 }

--- a/blosc/bitshuffle-generic.h
+++ b/blosc/bitshuffle-generic.h
@@ -82,28 +82,28 @@ extern "C" {
 
 /* Private functions */
 BLOSC_NO_EXPORT int64_t
-bshuf_trans_byte_elem_remainder(const void* in, void* out, const size_t size,
-                                const size_t elem_size, const size_t start);
+blosc_internal_bshuf_trans_byte_elem_remainder(const void* in, void* out, const size_t size,
+                                               const size_t elem_size, const size_t start);
 
 BLOSC_NO_EXPORT int64_t
-bshuf_trans_byte_elem_scal(const void* in, void* out, const size_t size,
-                           const size_t elem_size);
+blosc_internal_bshuf_trans_byte_elem_scal(const void* in, void* out, const size_t size,
+                                          const size_t elem_size);
 
 BLOSC_NO_EXPORT int64_t
-bshuf_trans_bit_byte_remainder(const void* in, void* out, const size_t size,
-                               const size_t elem_size, const size_t start_byte);
+blosc_internal_bshuf_trans_bit_byte_remainder(const void* in, void* out, const size_t size,
+                                              const size_t elem_size, const size_t start_byte);
 
 BLOSC_NO_EXPORT int64_t
-bshuf_trans_elem(const void* in, void* out, const size_t lda,
-                 const size_t ldb, const size_t elem_size);
+blosc_internal_bshuf_trans_elem(const void* in, void* out, const size_t lda,
+                                const size_t ldb, const size_t elem_size);
 
 BLOSC_NO_EXPORT int64_t
-bshuf_trans_bitrow_eight(const void* in, void* out, const size_t size,
-                         const size_t elem_size);
+blosc_internal_bshuf_trans_bitrow_eight(const void* in, void* out, const size_t size,
+                                        const size_t elem_size);
 
 BLOSC_NO_EXPORT int64_t
-bshuf_shuffle_bit_eightelem_scal(const void* in, void* out,
-                                 const size_t size, const size_t elem_size);
+blosc_internal_bshuf_shuffle_bit_eightelem_scal(const void* in, void* out,
+                                                const size_t size, const size_t elem_size);
 
 
 /* Bitshuffle the data.
@@ -125,8 +125,8 @@ bshuf_shuffle_bit_eightelem_scal(const void* in, void* out,
  */
 
 BLOSC_NO_EXPORT int64_t
-bshuf_trans_bit_elem_scal(const void* in, void* out, const size_t size,
-                          const size_t elem_size, void* tmp_buf);
+blosc_internal_bshuf_trans_bit_elem_scal(const void* in, void* out, const size_t size,
+                                         const size_t elem_size, void* tmp_buf);
 
 /* Unshuffle bitshuffled data.
  *
@@ -150,8 +150,8 @@ bshuf_trans_bit_elem_scal(const void* in, void* out, const size_t size,
  */
 
 BLOSC_NO_EXPORT int64_t
-bshuf_untrans_bit_elem_scal(const void* in, void* out, const size_t size,
-                            const size_t elem_size, void* tmp_buf);
+blosc_internal_bshuf_untrans_bit_elem_scal(const void* in, void* out, const size_t size,
+                                           const size_t elem_size, void* tmp_buf);
 
 
 #ifdef __cplusplus

--- a/blosc/bitshuffle-sse2.h
+++ b/blosc/bitshuffle-sse2.h
@@ -19,30 +19,30 @@ extern "C" {
 
 
 BLOSC_NO_EXPORT int64_t
-bshuf_trans_byte_elem_sse2(void* in, void* out, const size_t size,
-                           const size_t elem_size, void* tmp_buf);
+blosc_internal_bshuf_trans_byte_elem_sse2(void* in, void* out, const size_t size,
+                                          const size_t elem_size, void* tmp_buf);
 
 BLOSC_NO_EXPORT int64_t
-bshuf_trans_byte_bitrow_sse2(void* in, void* out, const size_t size,
-                             const size_t elem_size);
+blosc_internal_bshuf_trans_byte_bitrow_sse2(void* in, void* out, const size_t size,
+                                            const size_t elem_size);
 
 BLOSC_NO_EXPORT int64_t
-bshuf_shuffle_bit_eightelem_sse2(void* in, void* out, const size_t size,
-                                 const size_t elem_size);
+blosc_internal_bshuf_shuffle_bit_eightelem_sse2(void* in, void* out, const size_t size,
+                                                const size_t elem_size);
 
 /**
   SSE2-accelerated bitshuffle routine.
 */
 BLOSC_NO_EXPORT int64_t
-bshuf_trans_bit_elem_sse2(void* in, void* out, const size_t size,
-                          const size_t elem_size, void* tmp_buf);
+blosc_internal_bshuf_trans_bit_elem_sse2(void* in, void* out, const size_t size,
+                                         const size_t elem_size, void* tmp_buf);
 
 /**
   SSE2-accelerated bitunshuffle routine.
 */
 BLOSC_NO_EXPORT int64_t
-bshuf_untrans_bit_elem_sse2(void* in, void* out, const size_t size,
-                            const size_t elem_size, void* tmp_buf);
+blosc_internal_bshuf_untrans_bit_elem_sse2(void* in, void* out, const size_t size,
+                                           const size_t elem_size, void* tmp_buf);
 
 #ifdef __cplusplus
 }

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -563,12 +563,12 @@ static int blosc_c(const struct blosc_context* context, int32_t blocksize,
 
   if (doshuffle) {
     /* Byte shuffling only makes sense if typesize > 1 */
-    shuffle(typesize, blocksize, src, tmp);
+    blosc_internal_shuffle(typesize, blocksize, src, tmp);
     _tmp = tmp;
   }
   /* We don't allow more than 1 filter at the same time (yet) */
   else if (dobitshuffle) {
-    bscount = bitshuffle(typesize, blocksize, src, tmp, tmp2);
+    bscount = blosc_internal_bitshuffle(typesize, blocksize, src, tmp, tmp2);
     if (bscount < 0)
       return bscount;
     _tmp = tmp;
@@ -659,7 +659,7 @@ static int blosc_c(const struct blosc_context* context, int32_t blocksize,
       if ((ntbytes+neblock) > maxbytes) {
         return 0;    /* Non-compressible data */
       }
-      fastcopy(dest, _tmp + j * neblock, neblock);
+      blosc_internal_fastcopy(dest, _tmp + j * neblock, neblock);
       cbytes = neblock;
     }
     _sw32(dest - 4, cbytes);
@@ -715,7 +715,7 @@ static int blosc_d(struct blosc_context* context, int32_t blocksize,
     ctbytes += (int32_t)sizeof(int32_t);
     /* Uncompress */
     if (cbytes == neblock) {
-      fastcopy(_tmp, src, neblock);
+      blosc_internal_fastcopy(_tmp, src, neblock);
       nbytes = neblock;
     }
     else {
@@ -788,10 +788,10 @@ static int blosc_d(struct blosc_context* context, int32_t blocksize,
   } /* Closes j < nsplits */
 
   if (doshuffle) {
-    unshuffle(typesize, blocksize, tmp, dest);
+    blosc_internal_unshuffle(typesize, blocksize, tmp, dest);
   }
   else if (dobitshuffle) {
-    bscount = bitunshuffle(typesize, blocksize, tmp, dest, tmp2);
+    bscount = blosc_internal_bitunshuffle(typesize, blocksize, tmp, dest, tmp2);
     if (bscount < 0)
       return bscount;
   }
@@ -826,8 +826,8 @@ static int serial_blosc(struct blosc_context* context)
     if (context->compress) {
       if (*(context->header_flags) & BLOSC_MEMCPYED) {
         /* We want to memcpy only */
-        fastcopy(context->dest + BLOSC_MAX_OVERHEAD + j * context->blocksize,
-                 context->src + j * context->blocksize, bsize);
+        blosc_internal_fastcopy(context->dest + BLOSC_MAX_OVERHEAD + j * context->blocksize,
+                                context->src + j * context->blocksize, bsize);
         cbytes = bsize;
       }
       else {
@@ -844,8 +844,8 @@ static int serial_blosc(struct blosc_context* context)
     else {
       if (*(context->header_flags) & BLOSC_MEMCPYED) {
         /* We want to memcpy only */
-        fastcopy(context->dest + j * context->blocksize,
-                 context->src + BLOSC_MAX_OVERHEAD + j * context->blocksize, bsize);
+        blosc_internal_fastcopy(context->dest + j * context->blocksize,
+                                context->src + BLOSC_MAX_OVERHEAD + j * context->blocksize, bsize);
         cbytes = bsize;
       }
       else {
@@ -1601,8 +1601,8 @@ int blosc_getitem(const void *src, int start, int nitems, void *dest)
     /* Do the actual data copy */
     if (flags & BLOSC_MEMCPYED) {
       /* We want to memcpy only */
-      fastcopy((uint8_t *) dest + ntbytes,
-               (uint8_t *) src + BLOSC_MAX_OVERHEAD + j * blocksize + startb, bsize2);
+      blosc_internal_fastcopy((uint8_t *) dest + ntbytes,
+                              (uint8_t *) src + BLOSC_MAX_OVERHEAD + j * blocksize + startb, bsize2);
       cbytes = bsize2;
     }
     else {
@@ -1621,7 +1621,7 @@ int blosc_getitem(const void *src, int start, int nitems, void *dest)
         break;
       }
       /* Copy to destination */
-      fastcopy((uint8_t *) dest + ntbytes, tmp2 + startb, bsize2);
+      blosc_internal_fastcopy((uint8_t *) dest + ntbytes, tmp2 + startb, bsize2);
       cbytes = bsize2;
     }
     ntbytes += cbytes;
@@ -1731,8 +1731,8 @@ static void *t_blosc(void *ctxt)
       if (compress) {
         if (flags & BLOSC_MEMCPYED) {
           /* We want to memcpy only */
-          fastcopy(dest + BLOSC_MAX_OVERHEAD + nblock_ * blocksize, src + nblock_ * blocksize,
-                   bsize);
+          blosc_internal_fastcopy(dest + BLOSC_MAX_OVERHEAD + nblock_ * blocksize, src + nblock_ * blocksize,
+                                  bsize);
           cbytes = bsize;
         }
         else {
@@ -1744,8 +1744,8 @@ static void *t_blosc(void *ctxt)
       else {
         if (flags & BLOSC_MEMCPYED) {
           /* We want to memcpy only */
-          fastcopy(dest + nblock_ * blocksize, src + BLOSC_MAX_OVERHEAD + nblock_ * blocksize,
-                   bsize);
+          blosc_internal_fastcopy(dest + nblock_ * blocksize, src + BLOSC_MAX_OVERHEAD + nblock_ * blocksize,
+                                  bsize);
           cbytes = bsize;
         }
         else {
@@ -1787,7 +1787,7 @@ static void *t_blosc(void *ctxt)
         /* End of critical section */
 
         /* Copy the compressed buffer to destination */
-        fastcopy(dest + ntdest, tmp2, cbytes);
+        blosc_internal_fastcopy(dest + ntdest, tmp2, cbytes);
       }
       else {
         nblock_++;

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -177,7 +177,7 @@ static inline uint8_t *get_run_32(uint8_t *ip, const uint8_t *ip_bound, const ui
 
 
 /* Find the byte that starts to differ */
-uint8_t *get_match(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
+static uint8_t *get_match(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
 #if !defined(BLOSC_STRICT_ALIGN)
   while (ip < (ip_bound - sizeof(int64_t))) {
     if (((int64_t*)ref)[0] != ((int64_t*)ip)[0]) {
@@ -198,7 +198,7 @@ uint8_t *get_match(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
 
 
 #if defined(__SSE2__)
-uint8_t *get_match_16(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
+static uint8_t *get_match_16(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
   __m128i value, value2, cmp;
 
   while (ip < (ip_bound - sizeof(__m128i))) {
@@ -223,7 +223,7 @@ uint8_t *get_match_16(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) 
 
 
 #if defined(__AVX2__)
-uint8_t *get_match_32(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
+static uint8_t *get_match_32(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {
   __m256i value, value2, cmp;
 
   while (ip < (ip_bound - sizeof(__m256i))) {
@@ -511,7 +511,7 @@ int blosclz_decompress(const void* input, int length, void* output, int maxout) 
         /* copy from reference */
         ref--;
         len += 3;
-        op = safecopy(op, ref, (unsigned) len);
+        op = blosc_internal_safecopy(op, ref, (unsigned) len);
       }
     }
     else {
@@ -529,7 +529,7 @@ int blosclz_decompress(const void* input, int length, void* output, int maxout) 
          On GCC-6, fastcopy this is still faster than plain memcpy
          However, using recent CLANG/LLVM 9.0, there is almost no difference
          in performance. */
-      op = fastcopy(op, ip, (unsigned) ctrl);
+      op = blosc_internal_fastcopy(op, ip, (unsigned) ctrl);
       ip += ctrl;
 
       loop = (int32_t)BLOSCLZ_EXPECT_CONDITIONAL(ip < ip_limit);

--- a/blosc/fastcopy.c
+++ b/blosc/fastcopy.c
@@ -453,7 +453,7 @@ static BLOSC_INLINE unsigned char *chunk_memcpy_aligned(unsigned char *out, cons
 
 
 /* Byte by byte semantics: copy LEN bytes from FROM and write them to OUT. Return OUT + LEN. */
-unsigned char *fastcopy(unsigned char *out, const unsigned char *from, unsigned len) {
+unsigned char *blosc_internal_fastcopy(unsigned char *out, const unsigned char *from, unsigned len) {
   switch (len) {
     case 32:
       return copy_32_bytes(out, from);
@@ -485,7 +485,7 @@ unsigned char *fastcopy(unsigned char *out, const unsigned char *from, unsigned 
 
 
 /* Same as fastcopy() but without overwriting origin or destination when they overlap */
-unsigned char* safecopy(unsigned char *out, const unsigned char *from, unsigned len) {
+unsigned char* blosc_internal_safecopy(unsigned char *out, const unsigned char *from, unsigned len) {
 #if defined(__AVX2__)
   unsigned sz = sizeof(__m256i);
 #elif defined(__SSE2__)
@@ -500,6 +500,6 @@ unsigned char* safecopy(unsigned char *out, const unsigned char *from, unsigned 
     return out;
   }
   else {
-    return fastcopy(out, from, len);
+    return blosc_internal_fastcopy(out, from, len);
   }
 }

--- a/blosc/fastcopy.h
+++ b/blosc/fastcopy.h
@@ -11,9 +11,9 @@
 #define BLOSC_FASTCOPY_H
 
 /* Same semantics than memcpy() */
-unsigned char *fastcopy(unsigned char *out, const unsigned char *from, unsigned len);
+unsigned char *blosc_internal_fastcopy(unsigned char *out, const unsigned char *from, unsigned len);
 
 /* Same as fastcopy() but without overwriting origin or destination when they overlap */
-unsigned char* safecopy(unsigned char *out, const unsigned char *from, unsigned len);
+unsigned char* blosc_internal_safecopy(unsigned char *out, const unsigned char *from, unsigned len);
 
 #endif /*BLOSC_FASTCOPY_H*/

--- a/blosc/shuffle-avx2.c
+++ b/blosc/shuffle-avx2.c
@@ -638,14 +638,14 @@ unshuffle16_tiled_avx2(uint8_t* const dest, const uint8_t* const src,
 
 /* Shuffle a block.  This can never fail. */
 void
-shuffle_avx2(const size_t bytesoftype, const size_t blocksize,
-             const uint8_t* const _src, uint8_t* const _dest) {
+blosc_internal_shuffle_avx2(const size_t bytesoftype, const size_t blocksize,
+                            const uint8_t* const _src, uint8_t* const _dest) {
   const size_t vectorized_chunk_size = bytesoftype * sizeof(__m256i);
 
   /* If the block size is too small to be vectorized,
      use the generic implementation. */
   if (blocksize < vectorized_chunk_size) {
-    shuffle_generic(bytesoftype, blocksize, _src, _dest);
+    blosc_internal_shuffle_generic(bytesoftype, blocksize, _src, _dest);
     return;
   }
 
@@ -681,7 +681,7 @@ shuffle_avx2(const size_t bytesoftype, const size_t blocksize,
     }
     else {
       /* Non-optimized shuffle */
-      shuffle_generic(bytesoftype, blocksize, _src, _dest);
+      blosc_internal_shuffle_generic(bytesoftype, blocksize, _src, _dest);
       /* The non-optimized function covers the whole buffer,
          so we're done processing here. */
       return;
@@ -698,14 +698,14 @@ shuffle_avx2(const size_t bytesoftype, const size_t blocksize,
 
 /* Unshuffle a block.  This can never fail. */
 void
-unshuffle_avx2(const size_t bytesoftype, const size_t blocksize,
-               const uint8_t* const _src, uint8_t* const _dest) {
+blosc_internal_unshuffle_avx2(const size_t bytesoftype, const size_t blocksize,
+                              const uint8_t* const _src, uint8_t* const _dest) {
   const size_t vectorized_chunk_size = bytesoftype * sizeof(__m256i);
 
   /* If the block size is too small to be vectorized,
      use the generic implementation. */
   if (blocksize < vectorized_chunk_size) {
-    unshuffle_generic(bytesoftype, blocksize, _src, _dest);
+    blosc_internal_unshuffle_generic(bytesoftype, blocksize, _src, _dest);
     return;
   }
 
@@ -741,7 +741,7 @@ unshuffle_avx2(const size_t bytesoftype, const size_t blocksize,
     }
     else {
       /* Non-optimized unshuffle */
-      unshuffle_generic(bytesoftype, blocksize, _src, _dest);
+      blosc_internal_unshuffle_generic(bytesoftype, blocksize, _src, _dest);
       /* The non-optimized function covers the whole buffer,
          so we're done processing here. */
       return;

--- a/blosc/shuffle-avx2.h
+++ b/blosc/shuffle-avx2.h
@@ -20,14 +20,14 @@ extern "C" {
 /**
   AVX2-accelerated shuffle routine.
 */
-BLOSC_NO_EXPORT void shuffle_avx2(const size_t bytesoftype, const size_t blocksize,
-                                   const uint8_t* const _src, uint8_t* const _dest);
+BLOSC_NO_EXPORT void blosc_internal_shuffle_avx2(const size_t bytesoftype, const size_t blocksize,
+                                                 const uint8_t* const _src, uint8_t* const _dest);
 
 /**
   AVX2-accelerated unshuffle routine.
 */
-BLOSC_NO_EXPORT void unshuffle_avx2(const size_t bytesoftype, const size_t blocksize,
-                                     const uint8_t* const _src, uint8_t* const _dest);
+BLOSC_NO_EXPORT void blosc_internal_unshuffle_avx2(const size_t bytesoftype, const size_t blocksize,
+                                                   const uint8_t* const _src, uint8_t* const _dest);
 
 #ifdef __cplusplus
 }

--- a/blosc/shuffle-generic.c
+++ b/blosc/shuffle-generic.c
@@ -9,7 +9,7 @@
 #include "shuffle-generic.h"
 
 /* Shuffle a block.  This can never fail. */
-void shuffle_generic(const size_t bytesoftype, const size_t blocksize,
+void blosc_internal_shuffle_generic(const size_t bytesoftype, const size_t blocksize,
 		     const uint8_t* const _src, uint8_t* const _dest)
 {
   /* Non-optimized shuffle */
@@ -17,8 +17,8 @@ void shuffle_generic(const size_t bytesoftype, const size_t blocksize,
 }
 
 /* Unshuffle a block.  This can never fail. */
-void unshuffle_generic(const size_t bytesoftype, const size_t blocksize,
-                       const uint8_t* const _src, uint8_t* const _dest)
+void blosc_internal_unshuffle_generic(const size_t bytesoftype, const size_t blocksize,
+                                      const uint8_t* const _src, uint8_t* const _dest)
 {
   /* Non-optimized unshuffle */
   unshuffle_generic_inline(bytesoftype, 0, blocksize, _src, _dest);

--- a/blosc/shuffle-generic.h
+++ b/blosc/shuffle-generic.h
@@ -83,14 +83,14 @@ static void unshuffle_generic_inline(const size_t type_size,
 /**
   Generic (non-hardware-accelerated) shuffle routine.
 */
-BLOSC_NO_EXPORT void shuffle_generic(const size_t bytesoftype, const size_t blocksize,
-                                      const uint8_t* const _src, uint8_t* const _dest);
+BLOSC_NO_EXPORT void blosc_internal_shuffle_generic(const size_t bytesoftype, const size_t blocksize,
+                                                    const uint8_t* const _src, uint8_t* const _dest);
 
 /**
   Generic (non-hardware-accelerated) unshuffle routine.
 */
-BLOSC_NO_EXPORT void unshuffle_generic(const size_t bytesoftype, const size_t blocksize,
-                                        const uint8_t* const _src, uint8_t* const _dest);
+BLOSC_NO_EXPORT void blosc_internal_unshuffle_generic(const size_t bytesoftype, const size_t blocksize,
+                                                      const uint8_t* const _src, uint8_t* const _dest);
 
 #ifdef __cplusplus
 }

--- a/blosc/shuffle-sse2.c
+++ b/blosc/shuffle-sse2.c
@@ -512,8 +512,8 @@ unshuffle16_tiled_sse2(uint8_t* const dest, const uint8_t* const orig,
 
 /* Shuffle a block.  This can never fail. */
 void
-shuffle_sse2(const size_t bytesoftype, const size_t blocksize,
-             const uint8_t* const _src, uint8_t* const _dest) {
+blosc_internal_shuffle_sse2(const size_t bytesoftype, const size_t blocksize,
+                            const uint8_t* const _src, uint8_t* const _dest) {
   const size_t vectorized_chunk_size = bytesoftype * sizeof(__m128i);
   /* If the blocksize is not a multiple of both the typesize and
      the vector size, round the blocksize down to the next value
@@ -527,7 +527,7 @@ shuffle_sse2(const size_t bytesoftype, const size_t blocksize,
   /* If the block size is too small to be vectorized,
      use the generic implementation. */
   if (blocksize < vectorized_chunk_size) {
-    shuffle_generic(bytesoftype, blocksize, _src, _dest);
+    blosc_internal_shuffle_generic(bytesoftype, blocksize, _src, _dest);
     return;
   }
 
@@ -552,7 +552,7 @@ shuffle_sse2(const size_t bytesoftype, const size_t blocksize,
     }
     else {
       /* Non-optimized shuffle */
-      shuffle_generic(bytesoftype, blocksize, _src, _dest);
+      blosc_internal_shuffle_generic(bytesoftype, blocksize, _src, _dest);
       /* The non-optimized function covers the whole buffer,
          so we're done processing here. */
       return;
@@ -569,8 +569,8 @@ shuffle_sse2(const size_t bytesoftype, const size_t blocksize,
 
 /* Unshuffle a block.  This can never fail. */
 void
-unshuffle_sse2(const size_t bytesoftype, const size_t blocksize,
-               const uint8_t* const _src, uint8_t* const _dest) {
+blosc_internal_unshuffle_sse2(const size_t bytesoftype, const size_t blocksize,
+                              const uint8_t* const _src, uint8_t* const _dest) {
   const size_t vectorized_chunk_size = bytesoftype * sizeof(__m128i);
   /* If the blocksize is not a multiple of both the typesize and
      the vector size, round the blocksize down to the next value
@@ -585,7 +585,7 @@ unshuffle_sse2(const size_t bytesoftype, const size_t blocksize,
   /* If the block size is too small to be vectorized,
      use the generic implementation. */
   if (blocksize < vectorized_chunk_size) {
-    unshuffle_generic(bytesoftype, blocksize, _src, _dest);
+    blosc_internal_unshuffle_generic(bytesoftype, blocksize, _src, _dest);
     return;
   }
 
@@ -610,7 +610,7 @@ unshuffle_sse2(const size_t bytesoftype, const size_t blocksize,
     }
     else {
       /* Non-optimized unshuffle */
-      unshuffle_generic(bytesoftype, blocksize, _src, _dest);
+      blosc_internal_unshuffle_generic(bytesoftype, blocksize, _src, _dest);
       /* The non-optimized function covers the whole buffer,
          so we're done processing here. */
       return;

--- a/blosc/shuffle-sse2.h
+++ b/blosc/shuffle-sse2.h
@@ -20,14 +20,14 @@ extern "C" {
 /**
   SSE2-accelerated shuffle routine.
 */
-BLOSC_NO_EXPORT void shuffle_sse2(const size_t bytesoftype, const size_t blocksize,
-                                   const uint8_t* const _src, uint8_t* const _dest);
+BLOSC_NO_EXPORT void blosc_internal_shuffle_sse2(const size_t bytesoftype, const size_t blocksize,
+                                                 const uint8_t* const _src, uint8_t* const _dest);
 
 /**
   SSE2-accelerated unshuffle routine.
 */
-BLOSC_NO_EXPORT void unshuffle_sse2(const size_t bytesoftype, const size_t blocksize,
-                                     const uint8_t* const _src, uint8_t* const _dest);
+BLOSC_NO_EXPORT void blosc_internal_unshuffle_sse2(const size_t bytesoftype, const size_t blocksize,
+                                                   const uint8_t* const _src, uint8_t* const _dest);
 
 #ifdef __cplusplus
 }

--- a/blosc/shuffle.c
+++ b/blosc/shuffle.c
@@ -303,10 +303,10 @@ static shuffle_implementation_t get_shuffle_implementation(void) {
   if (cpu_features & BLOSC_HAVE_AVX2) {
     shuffle_implementation_t impl_avx2;
     impl_avx2.name = "avx2";
-    impl_avx2.shuffle = (shuffle_func)shuffle_avx2;
-    impl_avx2.unshuffle = (unshuffle_func)unshuffle_avx2;
-    impl_avx2.bitshuffle = (bitshuffle_func)bshuf_trans_bit_elem_avx2;
-    impl_avx2.bitunshuffle = (bitunshuffle_func)bshuf_untrans_bit_elem_avx2;
+    impl_avx2.shuffle = (shuffle_func)blosc_internal_shuffle_avx2;
+    impl_avx2.unshuffle = (unshuffle_func)blosc_internal_unshuffle_avx2;
+    impl_avx2.bitshuffle = (bitshuffle_func)blosc_internal_bshuf_trans_bit_elem_avx2;
+    impl_avx2.bitunshuffle = (bitunshuffle_func)blosc_internal_bshuf_untrans_bit_elem_avx2;
     return impl_avx2;
   }
 #endif  /* defined(SHUFFLE_AVX2_ENABLED) */
@@ -315,10 +315,10 @@ static shuffle_implementation_t get_shuffle_implementation(void) {
   if (cpu_features & BLOSC_HAVE_SSE2) {
     shuffle_implementation_t impl_sse2;
     impl_sse2.name = "sse2";
-    impl_sse2.shuffle = (shuffle_func)shuffle_sse2;
-    impl_sse2.unshuffle = (unshuffle_func)unshuffle_sse2;
-    impl_sse2.bitshuffle = (bitshuffle_func)bshuf_trans_bit_elem_sse2;
-    impl_sse2.bitunshuffle = (bitunshuffle_func)bshuf_untrans_bit_elem_sse2;
+    impl_sse2.shuffle = (shuffle_func)blosc_internal_shuffle_sse2;
+    impl_sse2.unshuffle = (unshuffle_func)blosc_internal_unshuffle_sse2;
+    impl_sse2.bitshuffle = (bitshuffle_func)blosc_internal_bshuf_trans_bit_elem_sse2;
+    impl_sse2.bitunshuffle = (bitunshuffle_func)blosc_internal_bshuf_untrans_bit_elem_sse2;
     return impl_sse2;
   }
 #endif  /* defined(SHUFFLE_SSE2_ENABLED) */
@@ -326,10 +326,10 @@ static shuffle_implementation_t get_shuffle_implementation(void) {
   /*  Processor doesn't support any of the hardware-accelerated implementations,
       so use the generic implementation. */
   impl_generic.name = "generic";
-  impl_generic.shuffle = (shuffle_func)shuffle_generic;
-  impl_generic.unshuffle = (unshuffle_func)unshuffle_generic;
-  impl_generic.bitshuffle = (bitshuffle_func)bshuf_trans_bit_elem_scal;
-  impl_generic.bitunshuffle = (bitunshuffle_func)bshuf_untrans_bit_elem_scal;
+  impl_generic.shuffle = (shuffle_func)blosc_internal_shuffle_generic;
+  impl_generic.unshuffle = (unshuffle_func)blosc_internal_unshuffle_generic;
+  impl_generic.bitshuffle = (bitshuffle_func)blosc_internal_bshuf_trans_bit_elem_scal;
+  impl_generic.bitunshuffle = (bitunshuffle_func)blosc_internal_bshuf_untrans_bit_elem_scal;
   return impl_generic;
 }
 
@@ -377,8 +377,8 @@ void init_shuffle_implementation(void) {
 /*  Shuffle a block by dynamically dispatching to the appropriate
     hardware-accelerated routine at run-time. */
 void
-shuffle(const size_t bytesoftype, const size_t blocksize,
-        const uint8_t* _src, const uint8_t* _dest) {
+blosc_internal_shuffle(const size_t bytesoftype, const size_t blocksize,
+                       const uint8_t* _src, const uint8_t* _dest) {
   /* Initialize the shuffle implementation if necessary. */
   init_shuffle_implementation();
 
@@ -390,8 +390,8 @@ shuffle(const size_t bytesoftype, const size_t blocksize,
 /*  Unshuffle a block by dynamically dispatching to the appropriate
     hardware-accelerated routine at run-time. */
 void
-unshuffle(const size_t bytesoftype, const size_t blocksize,
-          const uint8_t* _src, const uint8_t* _dest) {
+blosc_internal_unshuffle(const size_t bytesoftype, const size_t blocksize,
+                         const uint8_t* _src, const uint8_t* _dest) {
   /* Initialize the shuffle implementation if necessary. */
   init_shuffle_implementation();
 
@@ -403,9 +403,9 @@ unshuffle(const size_t bytesoftype, const size_t blocksize,
 /*  Bit-shuffle a block by dynamically dispatching to the appropriate
     hardware-accelerated routine at run-time. */
 int
-bitshuffle(const size_t bytesoftype, const size_t blocksize,
-           const uint8_t* const _src, const uint8_t* _dest,
-           const uint8_t* _tmp) {
+blosc_internal_bitshuffle(const size_t bytesoftype, const size_t blocksize,
+                          const uint8_t* const _src, const uint8_t* _dest,
+                          const uint8_t* _tmp) {
   int size = blocksize / bytesoftype;
   /* Initialize the shuffle implementation if necessary. */
   init_shuffle_implementation();
@@ -424,9 +424,9 @@ bitshuffle(const size_t bytesoftype, const size_t blocksize,
 /*  Bit-unshuffle a block by dynamically dispatching to the appropriate
     hardware-accelerated routine at run-time. */
 int
-bitunshuffle(const size_t bytesoftype, const size_t blocksize,
-             const uint8_t* const _src, const uint8_t* _dest,
-             const uint8_t* _tmp) {
+blosc_internal_bitunshuffle(const size_t bytesoftype, const size_t blocksize,
+                            const uint8_t* const _src, const uint8_t* _dest,
+                            const uint8_t* _tmp) {
   int size = blocksize / bytesoftype;
   /* Initialize the shuffle implementation if necessary. */
   init_shuffle_implementation();

--- a/blosc/shuffle.h
+++ b/blosc/shuffle.h
@@ -32,13 +32,13 @@ extern "C" {
   platform and future-proof.
 */
 BLOSC_NO_EXPORT void
-shuffle(const size_t bytesoftype, const size_t blocksize,
-        const uint8_t* _src, const uint8_t* _dest);
+blosc_internal_shuffle(const size_t bytesoftype, const size_t blocksize,
+                       const uint8_t* _src, const uint8_t* _dest);
 
 BLOSC_NO_EXPORT int
-bitshuffle(const size_t bytesoftype, const size_t blocksize,
-           const uint8_t* const _src, const uint8_t* _dest,
-           const uint8_t* _tmp);
+blosc_internal_bitshuffle(const size_t bytesoftype, const size_t blocksize,
+                          const uint8_t* const _src, const uint8_t* _dest,
+                          const uint8_t* _tmp);
 
 /**
   Primary unshuffle and bitunshuffle routine.
@@ -51,14 +51,14 @@ bitshuffle(const size_t bytesoftype, const size_t blocksize,
   platform and future-proof.
 */
 BLOSC_NO_EXPORT void
-unshuffle(const size_t bytesoftype, const size_t blocksize,
-          const uint8_t* _src, const uint8_t* _dest);
+blosc_internal_unshuffle(const size_t bytesoftype, const size_t blocksize,
+                         const uint8_t* _src, const uint8_t* _dest);
 
 
 BLOSC_NO_EXPORT int
-bitunshuffle(const size_t bytesoftype, const size_t blocksize,
-             const uint8_t* const _src, const uint8_t* _dest,
-             const uint8_t* _tmp);
+blosc_internal_bitunshuffle(const size_t bytesoftype, const size_t blocksize,
+                            const uint8_t* const _src, const uint8_t* _dest,
+                            const uint8_t* _tmp);
 
 #ifdef __cplusplus
 }

--- a/tests/test_shuffle_roundtrip_avx2.c
+++ b/tests/test_shuffle_roundtrip_avx2.c
@@ -41,18 +41,18 @@ static int test_shuffle_roundtrip_avx2(size_t type_size, size_t num_elements,
   {
     case 0:
       /* avx2/avx2 */
-      shuffle_avx2(type_size, buffer_size, original, shuffled);
-      unshuffle_avx2(type_size, buffer_size, shuffled, unshuffled);
+      blosc_internal_shuffle_avx2(type_size, buffer_size, original, shuffled);
+      blosc_internal_unshuffle_avx2(type_size, buffer_size, shuffled, unshuffled);
       break;
     case 1:
       /* generic/avx2 */
-      shuffle_generic(type_size, buffer_size, original, shuffled);
-      unshuffle_avx2(type_size, buffer_size, shuffled, unshuffled);
+      blosc_internal_shuffle_generic(type_size, buffer_size, original, shuffled);
+      blosc_internal_unshuffle_avx2(type_size, buffer_size, shuffled, unshuffled);
       break;
     case 2:
       /* avx2/generic */
-      shuffle_avx2(type_size, buffer_size, original, shuffled);
-      unshuffle_generic(type_size, buffer_size, shuffled, unshuffled);
+      blosc_internal_shuffle_avx2(type_size, buffer_size, original, shuffled);
+      blosc_internal_unshuffle_generic(type_size, buffer_size, shuffled, unshuffled);
       break;
     default:
       fprintf(stderr, "Invalid test type specified (%d).", test_type);

--- a/tests/test_shuffle_roundtrip_generic.c
+++ b/tests/test_shuffle_roundtrip_generic.c
@@ -30,8 +30,8 @@ static int test_shuffle_roundtrip_generic(size_t type_size, size_t num_elements,
   blosc_test_fill_random(original, buffer_size);
 
   /* Generic shuffle, then generic unshuffle. */
-  shuffle_generic(type_size, buffer_size, original, shuffled);
-  unshuffle_generic(type_size, buffer_size, shuffled, unshuffled);
+  blosc_internal_shuffle_generic(type_size, buffer_size, original, shuffled);
+  blosc_internal_unshuffle_generic(type_size, buffer_size, shuffled, unshuffled);
 
   /* The round-tripped data matches the original data when the
      result of memcmp is 0. */

--- a/tests/test_shuffle_roundtrip_sse2.c
+++ b/tests/test_shuffle_roundtrip_sse2.c
@@ -48,18 +48,18 @@ static int test_shuffle_roundtrip_sse2(size_t type_size, size_t num_elements,
   {
     case 0:
       /* sse2/sse2 */
-      shuffle_sse2(type_size, buffer_size, original, shuffled);
-      unshuffle_sse2(type_size, buffer_size, shuffled, unshuffled);
+      blosc_internal_shuffle_sse2(type_size, buffer_size, original, shuffled);
+      blosc_internal_unshuffle_sse2(type_size, buffer_size, shuffled, unshuffled);
       break;
     case 1:
       /* generic/sse2 */
-      shuffle_generic(type_size, buffer_size, original, shuffled);
-      unshuffle_sse2(type_size, buffer_size, shuffled, unshuffled);
+      blosc_internal_shuffle_generic(type_size, buffer_size, original, shuffled);
+      blosc_internal_unshuffle_sse2(type_size, buffer_size, shuffled, unshuffled);
       break;
     case 2:
       /* sse2/generic */
-      shuffle_sse2(type_size, buffer_size, original, shuffled);
-      unshuffle_generic(type_size, buffer_size, shuffled, unshuffled);
+      blosc_internal_shuffle_sse2(type_size, buffer_size, original, shuffled);
+      blosc_internal_unshuffle_generic(type_size, buffer_size, shuffled, unshuffled);
       break;
     default:
       fprintf(stderr, "Invalid test type specified (%d).", test_type);


### PR DESCRIPTION
Also mark as static all functions that are only used within a single
translation unit.

This fixes #254.