### PR TITLE
Add test of exported symbols to prevent regressions

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ class CbloscConan(ConanFile):
     options = {"shared": [True, False]}
     default_options = "shared=False"
     generators = "cmake"
-    exports_sources = "*", "!test_package/*", "!appveyor*", "!.*.yml", "!*.py", "!.*"
+    exports_sources = "*", "!test_package/*", "!appveyor*", "!.*.yml", "!bench/plot-speeds.py", "!build.py", "!.*"
 
     @property
     def run_tests(self):
@@ -48,7 +48,8 @@ class CbloscConan(ConanFile):
                 prefix = "LD_LIBRARY_PATH=%s" % outdir
             else:
                 return
-            self.run("%s ctest %s" % (prefix, test_args))
+            with tools.environment_append({'CTEST_OUTPUT_ON_FAILURE': '1'}):
+                self.run("%s ctest %s" % (prefix, test_args))
 
     def package(self):
         self.copy("blosc.h", dst="include", src="blosc")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -105,3 +105,21 @@ foreach(source ${SOURCES})
         add_test(${target} ${target})
     endif()
 endforeach(source)
+
+if (NOT WIN32)
+    # Verify that no unexpected symbols are exported.
+    if (BUILD_SHARED)
+        add_test(
+            NAME     blosc_test_shared_symbols
+            COMMAND  python
+                     "${CMAKE_CURRENT_SOURCE_DIR}/check_symbols.py"
+                     "$<TARGET_FILE:blosc_shared>")
+    endif()
+    if (BUILD_STATIC)
+        add_test(
+            NAME     blosc_test_static_symbols
+            COMMAND  python
+                     "${CMAKE_CURRENT_SOURCE_DIR}/check_symbols.py"
+                     "$<TARGET_FILE:blosc_static>")
+    endif()
+endif()

--- a/tests/check_symbols.py
+++ b/tests/check_symbols.py
@@ -1,0 +1,80 @@
+"""Checks the exported symbols."""
+
+from __future__ import print_function, unicode_literals
+
+import argparse
+import re
+import subprocess
+import sys
+
+
+def check_symbols(path):
+  out = subprocess.check_output(['nm', '--defined-only', '-g', path]).decode()
+
+  allowed_symbols = [
+      '_?LZ4_.*',
+      '_?ZSTD_.*',
+      'blosclz_.*',
+      '_?POOL_.*',
+      'snappy_.*',
+      'blosc_.*',
+      '_?HIST_.*',
+      '_?HUF_.*',
+      '_?ZSTDMT_.*',
+      '_?FSE_.*',
+      '_?XXH.*',
+      'gz.*',
+      'deflate.*',
+      'inflate.*',
+      'uncompress',
+      'compress',
+      'compress2',
+      'compressBound',
+      'adler32.*',
+      'crc32.*',
+      'get_crc_table',
+      'zcalloc',
+      'zcfree',
+      'zError',
+      'zlib.*',
+      'g_debuglevel',
+      'z_errmsg',
+      'g_ZSTD_.*',
+      '_?ERR_.*',
+      '_Z[A-Z0-9]+snappy.*',
+      '_[_a-z].*',
+      '.*__gxx_personality.*',
+  ]
+  allowed_symbols_pattern = '^' + '|'.join(
+      '(?:%s)' % x for x in allowed_symbols) + '$'
+  filename = None
+  failed = False
+  for line in out.split('\n'):
+    line = line.strip()
+    if not line:
+      continue
+    if line.endswith(':'):
+      filename = line[:-1]
+    else:
+      addr, symbol_type, name = line.split(' ')
+      del addr
+      del symbol_type
+      if re.match(allowed_symbols_pattern, name):
+        continue
+      print('ERROR: Found unexpected symbol in %s: %s' % (filename, name))
+      failed = True
+  return not failed
+
+
+def main():
+  ap = argparse.ArgumentParser()
+  ap.add_argument('library', type=str)
+  args = ap.parse_args()
+  if not check_symbols(args.library):
+    sys.exit(1)
+  else:
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
These tests ensure that no new internal functions are accidentally
exported.