### PR TITLE
MAINT: don't pass NULL to fprintf

### DIFF
--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -701,6 +701,9 @@ static int blosc_c(const struct blosc_context* context, int32_t blocksize,
 
     else {
       blosc_compcode_to_compname(context->compcode, &compname);
+      if (compname == NULL) {
+          compname = "(null)";
+      }
       fprintf(stderr, "Blosc has not been compiled with '%s' ", compname);
       fprintf(stderr, "compression support.  Please use one having it.");
       return -5;    /* signals no compression support */
@@ -1188,6 +1191,9 @@ static int write_compression_header(struct blosc_context* context, int clevel, i
   {
     const char *compname;
     compname = clibcode_to_clibname(compformat);
+    if (compname == NULL) {
+        compname = "(null)";
+    }
     fprintf(stderr, "Blosc has not been compiled with '%s' ", compname);
     fprintf(stderr, "compression support.  Please use one having it.");
     return -5;    /* signals no compression support */


### PR DESCRIPTION
If `clibcode_to_clibname` fails, it returns NULL. This result is directly fed
into a %s format in `fprintf`. A null pointer argument for %s is undefined
behavior, but glibc will print the string `"(null)"`.

gcc-9 reports a warning because of this:

```
In function ‘fprintf’,
    inlined from ‘blosc_c’ at /home/joe/projects/c/c-blosc/blosc/blosc.c:704:7:
/usr/include/bits/stdio2.h:100:10: warning: ‘%s’ directive argument is null [-Wformat-overflow=]
  100 |   return __fprintf_chk (__stream, __USE_FORTIFY_LEVEL - 1, __fmt,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  101 |    __va_arg_pack ());
      |    ~~~~~~~~~~~~~~~~~
```

This patch explicitly checks for a NULL result from `clibcode_to_clibname` and
sets the string to "(null)". Given that surrounding code path is unlikely, the
extra NULL check should not have a meaningful performance impact.