### PR TITLE
WIP: allow threading backend to be replaced by caller

### DIFF
--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -1917,6 +1917,8 @@ static void t_blosc_do_job(void *ctxt)
 static void *t_blosc(void *ctxt)
 {
   struct thread_context* context = (struct thread_context*)ctxt;
+  int rc;
+  (void)rc;  // just to avoid 'unused-variable' warning
 
   while(1)
   {

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -153,12 +153,14 @@ static int32_t g_splitmode = BLOSC_FORWARD_COMPAT_SPLIT;
 
 /* global variable to change threading backend from Blosc-managed to caller-managed */
 static blosc_threads_callback threads_callback = 0;
+static void *threads_callback_data = 0;
 
 /* non-threadsafe function should be called before any other Blosc function in
    order to change how threads are managed */
-void blosc_set_threads_callback(blosc_threads_callback callback)
+void blosc_set_threads_callback(blosc_threads_callback callback, void *callback_data)
 {
   threads_callback = callback;
+  threads_callback_data = callback_data;
 }
 
 /* Wrapped function to adjust the number of threads used by blosc */
@@ -911,7 +913,8 @@ static int parallel_blosc(struct blosc_context* context)
   context->thread_nblock = -1;
 
   if (threads_callback) {
-    threads_callback(t_blosc_do_job, context->numthreads, sizeof(void*), (void*) context->thread_contexts);
+    threads_callback(threads_callback_data, t_blosc_do_job,
+                     context->numthreads, sizeof(void*), (void*) context->thread_contexts);
   }
   else {
     /* Synchronization point for all threads (wait for initialization) */

--- a/blosc/blosc.h
+++ b/blosc/blosc.h
@@ -349,15 +349,16 @@ BLOSC_EXPORT int blosc_getitem_unsafe(const void* src, int start, int nitems,
   possibly in parallel threads (but not returning until all `dojob` calls have returned.   This allows the
   caller to provide a custom threading backend as an alternative to the default Blosc-managed threads.
  */
-typedef void (*blosc_threads_callback)(void (*dojob)(void *), int numjobs, size_t jobdata_elsize, void *jobdata);
+typedef void (*blosc_threads_callback)(void *callback_data, void (*dojob)(void *), int numjobs, size_t jobdata_elsize, void *jobdata);
 
 /**
   Set the threading backend for parallel compression/decompression to use `callback` to execute work
   instead of using the Blosc-managed threads.   This function is *not* thread-safe and should be called
   before any other Blosc function: it affects not only the global context but also the thread-safe
   compress_ctx and decompress_ctx functions.  Passing `NULL` uses the default Blosc threading backend.
+  The `callback_data` argument is passed through to the callback.
  */
-BLOSC_EXPORT void blosc_set_threads_callback(blosc_threads_callback callback);
+BLOSC_EXPORT void blosc_set_threads_callback(blosc_threads_callback callback, void *callback_data);
 
 /**
   Returns the current number of threads that are used for

--- a/blosc/blosc.h
+++ b/blosc/blosc.h
@@ -343,6 +343,22 @@ BLOSC_EXPORT int blosc_getitem(const void *src, int start, int nitems, void *des
 BLOSC_EXPORT int blosc_getitem_unsafe(const void* src, int start, int nitems,
                                       void* dest);
 
+
+/**
+  Pointer to a callback function that executes `dojob(jobdata + i*jobdata_elsize)` for `i = 0 to numjobs-1`,
+  possibly in parallel threads (but not returning until all `dojob` calls have returned.   This allows the
+  caller to provide a custom threading backend as an alternative to the default Blosc-managed threads.
+ */
+typedef void (*blosc_threads_callback)(void (*dojob)(void *), int numjobs, size_t jobdata_elsize, void *jobdata);
+
+/**
+  Set the threading backend for parallel compression/decompression to use `callback` to execute work
+  instead of using the Blosc-managed threads.   This function is *not* thread-safe and should be called
+  before any other Blosc function: it affects not only the global context but also the thread-safe
+  compress_ctx and decompress_ctx functions.  Passing `NULL` uses the default Blosc threading backend.
+ */
+BLOSC_EXPORT void blosc_set_threads_callback(blosc_threads_callback callback);
+
 /**
   Returns the current number of threads that are used for
   compression/decompression.


### PR DESCRIPTION
This PR adds a new function `blosc_set_threads_callback` that allows the caller to register a callback in order to change the threading backend at runtime — instead of spawning its own threads and passing work to them with a mutex, Blosc will pass an array of work (an array of `thread_context*`)  to the callback, which can execute the work in serial or in parallel using whatever mechanism it wants.

Motivation: this allows Blosc threading to be *composable* with caller multithreading, instead of having Blosc and the caller fight over the same CPUs.    In particular, this enables Blosc threading to be composable with:

* Julia's [new partr threading scheduler](https://julialang.org/blog/2019/07/multithreading).
* Callers using [Intels's Threading Building Blocks (TBB)](https://en.wikipedia.org/wiki/Threading_Building_Blocks).
* Callers using Cilk, OpenMP, etcetera.

The design and implementation is very similar to the new pluggable threading backend for FFTW (FFTW/fftw3#175), which worked out very well for us.   Aside from a trivial refactoring of the `t_blosc` function, required changes seem pretty minimal — only a couple of dozen lines, with a practical overhead of a single `if` statement in the `parallel_blosc` function for people not using this feature.

Marking it as a WIP since I haven't tested it yet other than checking that it compiles, but I wanted to get some early feedback.