### PR TITLE
Add bounds check back to beginning of blosclz_decompress

### DIFF
--- a/blosc/blosclz_impl.inc
+++ b/blosc/blosclz_impl.inc
@@ -8,7 +8,7 @@ int blosclz_decompress(const void* input, int length, void* output, int maxout) 
   const uint8_t* ip = (const uint8_t*)input;
   const uint8_t* ip_limit = ip + length;
   uint8_t* op = (uint8_t*)output;
-  int32_t ctrl = (*ip++) & 31;
+  int32_t ctrl;
   int32_t loop = 1;
 #ifdef BLOSCLZ_SAFE
   uint8_t* op_limit = op + maxout;
@@ -16,6 +16,7 @@ int blosclz_decompress(const void* input, int length, void* output, int maxout) 
     return 0;
   }
 #endif
+  ctrl = (*ip++) & 31;
 
   do {
     uint8_t* ref = op;


### PR DESCRIPTION
The bounds check before the initial read was lost in
dfcd0e949a89bf4bdaab71fb0805625f7f7a284a.

I haven't verified that this is exploitable, but it seems wise to have
it there in any case.