### PR TITLE
Disable C++ compiler detection by default when not compiling snappy.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ cmake_minimum_required(VERSION 2.8.12)
 if (NOT CMAKE_VERSION VERSION_LESS 3.3)
     cmake_policy(SET CMP0063 NEW)
 endif()
-project(blosc)
+project(blosc C)
 
 # parse the full version numbers from blosc.h
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/blosc/blosc.h _blosc_h_contents)
@@ -141,6 +141,8 @@ if(NOT DEACTIVATE_SNAPPY)
         find_package(Snappy)
     else()
         message(STATUS "Using Snappy internal sources.")
+        # Enable C++ compiler for snappy internal sources
+        enable_language(CXX)
     endif(PREFER_EXTERNAL_SNAPPY)
     # HAVE_SNAPPY will be set to true because even if the library is not found,
     # we will use the included sources for it

--- a/conanfile.py
+++ b/conanfile.py
@@ -19,7 +19,7 @@ class CbloscConan(ConanFile):
 
     def build(self):
         os.mkdir("build")
-        tools.replace_in_file("CMakeLists.txt", "project(blosc)", '''project(blosc)
+        tools.replace_in_file("CMakeLists.txt", "project(blosc C)", '''project(blosc C)
             include(${CMAKE_BINARY_DIR}/../conanbuildinfo.cmake)
             conan_basic_setup(NO_OUTPUT_DIRS)''')
         cmake = CMake(self)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(PackageTest CXX)
+project(PackageTest C)
 cmake_minimum_required(VERSION 2.8.12)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
See #284.