### PR TITLE
Add GitHub Actions CI workflow for CMake.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,167 @@
+name: CI CMake
+on: [push, pull_request]
+jobs:
+  ci-cmake:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [
+          Ubuntu GCC,
+          Ubuntu GCC OSB,
+          Ubuntu GCC External LZ4,
+          Ubuntu GCC External SNAPPY,
+          Ubuntu GCC External ZLIB,
+          Ubuntu GCC External ZSTD,
+          Ubuntu Clang,
+          Ubuntu Clang No SSE2,
+          Ubuntu Clang No AVX2,
+          Ubuntu Clang No AVX2 No SSE2,
+          Ubuntu Clang No LZ4,
+          Ubuntu Clang No SNAPPY,
+          Ubuntu Clang No ZLIB,
+          Ubuntu Clang No ZSTD,
+          Windows MSVC Win32,
+          Windows MSVC Win64,
+          Windows GCC,
+          macOS Clang,
+          macOS GCC
+        ]
+        include:
+          - name: Ubuntu GCC
+            os: ubuntu-latest
+            compiler: gcc
+
+          # Out of source build
+          - name: Ubuntu GCC OSB
+            os: ubuntu-latest
+            compiler: gcc
+            build-dir: ../build
+            build-src-dir: ../c-blosc
+
+          - name: Ubuntu GCC External LZ4
+            os: ubuntu-latest
+            compiler: gcc
+            packages: liblz4-1 liblz4-dev
+            cmake-args: -DPREFER_EXTERNAL_LZ4=ON
+
+          - name: Ubuntu GCC External SNAPPY
+            os: ubuntu-latest
+            compiler: gcc
+            packages: libsnappy-dev
+            cmake-args: -DPREFER_EXTERNAL_SNAPPY=ON
+
+          - name: Ubuntu GCC External ZLIB
+            os: ubuntu-latest
+            compiler: gcc
+            packages: zlib1g-dev
+            cmake-args: -DPREFER_EXTERNAL_ZLIB=ON
+
+          - name: Ubuntu GCC External ZSTD
+            os: ubuntu-latest
+            compiler: gcc
+            packages: zstd libzstd-dev
+            cmake-args: -DPREFER_EXTERNAL_ZSTD=ON
+
+          - name: Ubuntu Clang
+            os: ubuntu-latest
+            compiler: clang
+
+          - name: Ubuntu Clang No SSE2
+            os: ubuntu-latest
+            compiler: clang
+            cmake-args: -DDEACTIVATE_SSE2=ON
+
+          - name: Ubuntu Clang No AVX2
+            os: ubuntu-latest
+            compiler: clang
+            cmake-args: -DDEACTIVATE_AVX2=ON
+
+          - name: Ubuntu Clang No AVX2 No SSE2
+            os: ubuntu-latest
+            compiler: clang
+            cmake-args: -DDEACTIVATE_AVX2=ON -DDEACTIVATE_SSE2=ON
+
+          - name: Ubuntu Clang No LZ4
+            os: ubuntu-latest
+            compiler: clang
+            cmake-args: -DDEACTIVATE_LZ4=ON
+
+          - name: Ubuntu Clang No SNAPPY
+            os: ubuntu-latest
+            compiler: clang
+            cmake-args: -DDEACTIVATE_SNAPPY=ON
+
+          - name: Ubuntu Clang No ZLIB
+            os: ubuntu-latest
+            compiler: clang
+            cmake-args: -DDEACTIVATE_ZLIB=ON
+
+          - name: Ubuntu Clang No ZSTD
+            os: ubuntu-latest
+            compiler: clang
+            cmake-args: -DDEACTIVATE_ZSTD=ON
+
+          - name: Windows MSVC Win32
+            os: windows-latest
+            compiler: cl
+            cmake-args: -A Win32
+
+          - name: Windows MSVC Win64
+            os: windows-latest
+            compiler: cl
+            cmake-args: -A x64
+
+          - name: Windows GCC
+            os: windows-latest
+            compiler: gcc
+            cmake-args: -G Ninja
+
+          - name: macOS Clang
+            os: macOS-latest
+            compiler: clang
+
+          - name: macOS GCC
+            os: macOS-latest
+            compiler: gcc
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Install packages (Ubuntu)
+      if: runner.os == 'Linux' && matrix.packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ${{ matrix.packages }}
+
+    - name: Install packages (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        choco install ninja ${{ matrix.packages }}
+
+    - name: Install packages (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        brew install ninja ${{ matrix.packages }}
+
+    - name: Generate project files
+      run: |
+        mkdir ${{ matrix.build-dir || '.not-used' }}
+        cd ${{ matrix.build-dir || '.' }}
+        ${{ matrix.cmake-prefix }} cmake ${{ matrix.build-src-dir || '.' }} ${{ matrix.cmake-args }} -DCMAKE_BUILD_TYPE=${{ matrix.build-config || 'Release' }} -DBUILD_SHARED_LIBS=OFF
+      env:
+        CC: ${{ matrix.compiler }}
+        CFLAGS: ${{ matrix.cflags }}
+        LDFLAGS: ${{ matrix.ldflags }}
+        CI: true
+
+    - name: Compile source code
+      run: |
+        cd ${{ matrix.build-dir || '.' }}
+        ${{ matrix.cmake-prefix }} cmake --build . --config ${{ matrix.build-config || 'Release' }}
+
+    - name: Run test cases
+      run: |
+        cd ${{ matrix.build-dir || '.' }}
+        ctest -C Release --output-on-failure --max-width 120

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,8 +255,8 @@ if(DEACTIVATE_SSE2)
     set(COMPILER_SUPPORT_SSE2 FALSE)
 endif()
 
-# disable AVX2 if specified
-if(DEACTIVATE_AVX2)
+# disable AVX2 if specified or if SSE is deactivated
+if(DEACTIVATE_AVX2 OR DEACTIVATE_SSE2)
     set(COMPILER_SUPPORT_AVX2 FALSE)
 endif()
 

--- a/compat/CMakeLists.txt
+++ b/compat/CMakeLists.txt
@@ -20,6 +20,13 @@ if (BUILD_TESTS)
     if (TEST_INCLUDE_COMPAT)
         file(GLOB DATAFILES *.cdata)
         foreach(datafile ${DATAFILES})
+            # Don't test data if compressor is deactivated
+            if((datafile MATCHES "lz4" AND DEACTIVATE_LZ4) OR
+               (datafile MATCHES "snappy" AND DEACTIVATE_SNAPPY) OR
+               (datafile MATCHES "zlib" AND DEACTIVATE_ZLIB) OR
+               (datafile MATCHES "zstd" AND DEACTIVATE_ZSTD))
+               continue()
+            endif()
             get_filename_component(fname ${datafile} NAME)
             add_test(test_compat_${fname} filegen decompress ${datafile})
         endforeach(datafile)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,8 +20,8 @@ foreach(source ${SOURCES})
         endif()
     endif()
 
-    # test_compressor will be enabled only when LZ4 support is in
-    if(target STREQUAL test_compressor AND DEACTIVATE_LZ4)
+    # Disable targets that use lz4 compressor when lz4 is deactivated
+    if((target STREQUAL test_compressor) OR (target STREQUAL test_bitshuffle_leftovers) AND DEACTIVATE_LZ4)
         message("Skipping ${target} on non-LZ4 builds")
         continue()
     endif()


### PR DESCRIPTION
This PR adds GitHub Actions CI for CMake. It installs pre-requisite packages if needed, generates project files, and compiles them. Then it will run all the CMake tests.

AFAIK GitHub Actions shared runners support AVX2 so #138 may not be necessary.