### PR TITLE
Correct the return code on too small compression buffers

### DIFF
--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -1090,9 +1090,7 @@ static int initialize_context_compression(struct blosc_context* context,
     return -1;
   }
   if (destsize < BLOSC_MAX_OVERHEAD) {
-    fprintf(stderr, "Output buffer size should be larger than %d bytes\n",
-            BLOSC_MAX_OVERHEAD);
-    return -1;
+    return 0;
   }
 
   /* Compression level */

--- a/tests/test_maxout.c
+++ b/tests/test_maxout.c
@@ -105,17 +105,17 @@ static const char *test_maxout_great_memcpy(void) {
 static const char *test_max_overhead(void) {
   blosc_init();
   cbytes = blosc_compress(0, doshuffle, typesize, size, src, dest, BLOSC_MAX_OVERHEAD - 1);
-  mu_assert("ERROR: cbytes is not correct", cbytes < 0);
+  mu_assert("ERROR: cbytes is not correct", cbytes == 0);
   blosc_destroy();
 
   blosc_init();
   cbytes = blosc_compress(0, doshuffle, typesize, size, src, dest, BLOSC_MAX_OVERHEAD - 2);
-  mu_assert("ERROR: cbytes is not correct", cbytes < 0);
+  mu_assert("ERROR: cbytes is not correct", cbytes == 0);
   blosc_destroy();
 
   blosc_init();
   cbytes = blosc_compress(0, doshuffle, typesize, size, src, dest, 0);
-  mu_assert("ERROR: cbytes is not correct", cbytes < 0);
+  mu_assert("ERROR: cbytes is not correct", cbytes == 0);
   blosc_destroy();
 
   return 0;


### PR DESCRIPTION
Fixes https://github.com/Blosc/c-blosc/issues/293