### PR TITLE
Added OSS-Fuzz to CI for pull requests.

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,23 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'c-blosc'
+        dry-run: false
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'c-blosc'
+        fuzz-seconds: 600
+        dry-run: false
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
Since this project is part of OSS-Fuzz (see #274), this PR adds fuzzing workflow to GitHub Actions CI. The fuzzing only happens on pull requests.

![image](https://user-images.githubusercontent.com/1364432/81466792-1a89b180-9189-11ea-90cc-140560593673.png)

After this is merged #274 can be closed.