### PR TITLE
Redefine blosc_internal_xgetbv for platforms with immintrin.h

### DIFF
--- a/blosc/shuffle.c
+++ b/blosc/shuffle.c
@@ -195,6 +195,10 @@ blosc_internal_xgetbv(uint32_t xcr) {
   return ((uint64_t)edx << 32) | eax;
 }
 
+#else
+
+#define blosc_internal_xgetbv _xgetbv
+
 #endif  // !(defined(_IMMINTRIN_H_INCLUDED) && (BLOSC_GCC_VERSION >= 900))
 #endif  /* defined(_MSC_FULL_VER) */
 


### PR DESCRIPTION
Commit 2f2d876 renamed _xgetbv to blosc_internal_xgetbv.  Commit 0b8608b
made it conditional to immintrin.h not being included, apparently
in order to prevent _xgetbv collision.  However, since the block
no longer defined _xgetbv but blosc_internal_xgetbv, it means that
the latter is not defined if the condition is false.  #define it to
_xgetbv to fix missing symbol.