### PR TITLE
Check that source size is greater than BLOSC_MIN_HEADER_LENGTH

### DIFF
--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -1450,7 +1450,7 @@ static int blosc_run_decompression_with_context(struct blosc_context* context,
   context->compressedsize = sw32_(context->src + 12); /* compressed buffer size */
   context->bstarts = (uint8_t*)(context->src + 16);
 
-  if (context->sourcesize == 0) {
+  if (context->sourcesize <= BLOSC_MIN_HEADER_LENGTH) {
     /* Source buffer was empty, so we are done */
     return 0;
   }


### PR DESCRIPTION
This is so that `blosc_decompress` does not read past end of source buffer if source size is `BLOSC_MIN_HEADER_LENGTH`. 

It is unclear from [README_HEADER](https://github.com/Blosc/c-blosc/blob/master/README_HEADER.rst) whether or not `nbytes` or `ctbytes` include the size of the header.