### PR TITLE
Fixed ubsan buffer over-read when hashing ip after match. 

### DIFF
--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -82,7 +82,6 @@
   }                                                      \
 }
 
-#define IP_BOUNDARY 2
 #define BYTES_IN_CYCLE 512
 
 #if defined(__AVX2__)
@@ -329,7 +328,7 @@ int blosclz_compress(const int clevel, const void* input, int length,
   uint8_t* ibase = (uint8_t*)input;
   uint8_t* ip = ibase;
   uint8_t* icycle = ibase;
-  uint8_t* ip_bound = ibase + length - IP_BOUNDARY;
+  uint8_t* ip_bound = ibase + length - 1;
   uint8_t* ip_limit = ibase + length - 12;
   uint8_t* op = (uint8_t*)output;
   uint8_t* ocycle = op;
@@ -452,11 +451,11 @@ int blosclz_compress(const int clevel, const void* input, int length,
     }
     else {
 #if defined(__AVX2__)
-      ip = get_match_32(ip, ip_bound + IP_BOUNDARY, ref);
+      ip = get_match_32(ip, ip_bound, ref);
 #elif defined(__SSE2__)
-      ip = get_match_16(ip, ip_bound + IP_BOUNDARY, ref);
+      ip = get_match_16(ip, ip_bound, ref);
 #else
-      ip = get_match(ip, ip_bound + IP_BOUNDARY, ref);
+      ip = get_match(ip, ip_bound, ref);
 #endif
     }
 
@@ -523,7 +522,6 @@ int blosclz_compress(const int clevel, const void* input, int length,
   }
 
   /* left-over as literal copy */
-  ip_bound++;
   while (BLOSCLZ_UNEXPECT_CONDITIONAL(ip <= ip_bound)) {
     if (BLOSCLZ_UNEXPECT_CONDITIONAL(op + 2 > op_limit)) goto out;
     *op++ = *ip++;


### PR DESCRIPTION
The address of `ip` returned from `get_match` should have at least `sizeof(uint32_t)` bytes between it and `ip_bounds` after -= 3 so it can do integer hashing.

Currently, `get_match`  is sent `ip_bounds` value of essentially `ibase + length`. The problem with that is that it does not allow for enough room to do integer hashing of the match afterwards. Remember, that the hashing happens after `ip -= 3` has been applied to `ip` returned from `get_match`. So the max boundary we can have is `ibase + length - 1`. This allows maximum for `ip` to be `ibase + length - 4` before it reads the integer for hashing.

I have attached the file (zipped) that causes it to produced an undefined behavior warning. You can test it using the standalone `fuzz_compress` that is part of #301. Just build with `-DBUILD_FUZZERS=ON -DCMAKE_C_FLAGS=-fsanitize=address,undefined`.

[crash-fa4a981c0dffd15b0ac7bdc191bb6a73a36fa763.zip](https://github.com/Blosc/c-blosc/files/4810240/crash-fa4a981c0dffd15b0ac7bdc191bb6a73a36fa763.zip)

Here is the undefined behavior sanitizer error:

```
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/nathan/Source/c-blosc/blosc/blosclz.c:249:29 in 
=================================================================
==5836==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60d0000000c1 at pc 0x0000004eb767 bp 0x7fffffff7bd0 sp 0x7fffffff7bc8
READ of size 4 at 0x60d0000000c1 thread T0
    #0 0x4eb766 in blosclz_compress /home/nathan/Source/c-blosc/blosc/blosclz.c:514:11
    #1 0x4df6b2 in blosc_c /home/nathan/Source/c-blosc/blosc/blosc.c:653:16
    #2 0x4dd6dd in serial_blosc /home/nathan/Source/c-blosc/blosc/blosc.c:836:18
    #3 0x4c8b02 in do_job /home/nathan/Source/c-blosc/blosc/blosc.c:914:15
    #4 0x4c80c5 in blosc_compress_context /home/nathan/Source/c-blosc/blosc/blosc.c:1255:13
    #5 0x4cfad2 in blosc_compress /home/nathan/Source/c-blosc/blosc/blosc.c:1417:14
    #6 0x4c6f13 in LLVMFuzzerTestOneInput /home/nathan/Source/c-blosc/tests/fuzz/fuzz_compress.c:31:7
    #7 0x4c76cd in main /home/nathan/Source/c-blosc/tests/fuzz/standalone.c:32:7
    #8 0x7ffff6ee582f in __libc_start_main /build/glibc-LK5gWL/glibc-2.23/csu/../csu/libc-start.c:291
    #9 0x41f128 in _start (/home/nathan/Source/c-blosc/build/tests/fuzz/compress_fuzzer+0x41f128)

0x60d0000000c4 is located 0 bytes to the right of 132-byte region [0x60d000000040,0x60d0000000c4)
allocated by thread T0 here:
    #0 0x49703d in malloc /tmp/final/llvm.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:145:3
    #1 0x4c763b in main /home/nathan/Source/c-blosc/tests/fuzz/standalone.c:28:28
    #2 0x7ffff6ee582f in __libc_start_main /build/glibc-LK5gWL/glibc-2.23/csu/../csu/libc-start.c:291

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/nathan/Source/c-blosc/blosc/blosclz.c:514:11 in blosclz_compress
Shadow bytes around the buggy address:
  0x0c1a7fff7fc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c1a7fff7fd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c1a7fff7fe0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c1a7fff7ff0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c1a7fff8000: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
=>0x0c1a7fff8010: 00 00 00 00 00 00 00 00[04]fa fa fa fa fa fa fa
  0x0c1a7fff8020: fa fa 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c1a7fff8030: 00 00 05 fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c1a7fff8040: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c1a7fff8050: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c1a7fff8060: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
```

There were a couple of ways I could have fixed this. I thought about putting an if statement instead:

```
if (ip + sizeof(uint32_t) < ip_bound + IP_BOUNDARY) {
    /* update the hash at match boundary */
    seq = BLOSCLZ_READU32(ip);
    HASH_FUNCTION(hval, seq, hashlog)
    htab[hval] = (uint32_t) (ip++ - ibase);
    seq >>= 8U;
    HASH_FUNCTION(hval, seq, hashlog)
    htab[hval] = (uint32_t) (ip++ - ibase);
}
```
Or just calling `get_match` like so:
```
#if defined(__AVX2__)
      ip = get_match_32(ip, ip_bound + 1, ref);
#elif defined(__SSE2__)
      ip = get_match_16(ip, ip_bound + 1, ref);
#else
      ip = get_match(ip, ip_bound + 1, ref);
#endif
```
Once this issue is fixed I can submit a PR to blosc-2 if you'd like.