### PR TITLE
Fixed undefined shift ubsan warning in lz4hc_wrap_compress.

### DIFF
--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -423,7 +423,7 @@ static int lz4hc_wrap_compress(const char* input, size_t input_length,
                                char* output, size_t maxout, int clevel)
 {
   int cbytes;
-  if (input_length > (size_t)(2<<30))
+  if (input_length > (size_t)(UINT32_C(2)<<30))
     return -1;   /* input larger than 1 GB is not supported */
   /* clevel for lz4hc goes up to 12, at least in LZ4 1.7.5
    * but levels larger than 9 does not buy much compression. */


### PR DESCRIPTION
The new _compress_fuzzer_ found a ubsan warning:
```
blosc/blosc.c:426:32: runtime error: left shift of 2 by 30 places cannot be represented in type 'int'
```
Attached is the testcase for the _compress_fuzzer_ that can be built using `-DBUILD_FUZZERS=ON -DCMAKE_C_FLAGS=-fsanitize=address,undefined`.

[clusterfuzz-testcase-compress_fuzzer-6310509673709568.tar.gz](https://github.com/Blosc/c-blosc/files/4817093/clusterfuzz-testcase-compress_fuzzer-6310509673709568.tar.gz)

If you want I can make another PR for c-blosc2.
