### PR TITLE
CMake: Fix PThread Flag

### DIFF
--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -74,11 +74,19 @@ if(WIN32)
         message(STATUS "using the internal pthread library for win32 systems.")
         set(SOURCES ${SOURCES} win32/pthread.c)
     else(NOT Threads_FOUND)
-        set(LIBS ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
+        if(CMAKE_VERSION VERSION_LESS 3.1)
+            set(LIBS ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
+        else()
+            set(LIBS ${LIBS} Threads::Threads)
+        endif()
     endif(NOT Threads_FOUND)
 else(WIN32)
     find_package(Threads REQUIRED)
-    set(LIBS ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
+    if(CMAKE_VERSION VERSION_LESS 3.1)
+        set(LIBS ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
+    else()
+        set(LIBS ${LIBS} Threads::Threads)
+    endif()
 endif(WIN32)
 
 if(NOT DEACTIVATE_LZ4)
@@ -187,13 +195,6 @@ if (BUILD_TESTS)
     set_property(
         TARGET blosc_shared_testing
         APPEND PROPERTY COMPILE_DEFINITIONS BLOSC_TESTING)
-    # TEMP : CMake doesn't automatically add -lpthread here like it does
-    # for the blosc_shared target. Force it for now.
-    if(UNIX)
-        set_property(
-            TARGET blosc_shared_testing
-            APPEND PROPERTY LINK_FLAGS "-lpthread")
-    endif()
 endif()
 
 if (BUILD_SHARED)

--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -65,7 +65,8 @@ set(SOURCES ${SOURCES} shuffle.c)
 set(lib_dir lib${LIB_SUFFIX})
 set(version_string ${BLOSC_VERSION_MAJOR}.${BLOSC_VERSION_MINOR}.${BLOSC_VERSION_PATCH})
 
-set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE) # pre 3.1
+set(THREADS_PREFER_PTHREAD_FLAG TRUE) # CMake 3.1+
 if(WIN32)
     # try to use the system library
     find_package(Threads)


### PR DESCRIPTION
## Addressed Issue

On recent manylinux builds for ppc64le, I realized problems with
```
undefined reference to `pthread_atfork'
```

at linktime when propagating a static blosc library to downstream libraries (all via CMake).


## Fix: CMake Control Variable

An outdated CMake flag that would request the right pthread flags is used:

Old:
`CMAKE_THREAD_PREFER_PTHREAD` ([docs](https://cmake.org/cmake/help/v3.2/module/FindThreads.html))

New:
`THREADS_PREFER_PTHREAD_FLAG` ([docs](https://cmake.org/cmake/help/latest/module/FindThreads.html))

## Fix: CMake Thread Target

Prefer `Threads::Threads` for CMake 3.1+: This target does potentially contain CXX flags and linker flags and should thus be preferred.

It should also address the already work-arounded pthread linker issue in one of the tests that @jack-pappas added in #123

## To Do

- [x] finish tests