### PR TITLE
Add public function blosc_compression_bound

### DIFF
--- a/blosc/blosc.h
+++ b/blosc/blosc.h
@@ -224,6 +224,11 @@ BLOSC_EXPORT int blosc_compress(int clevel, int doshuffle, size_t typesize,
 				size_t nbytes, const void *src, void *dest,
 				size_t destsize);
 
+/**
+  Returns the maximal size of the compressed representation of input data
+  that is "cursize" bytes in length.
+  */
+BLOSC_EXPORT size_t blosc_compression_bound(size_t cursize);
 
 /**
   Context interface to blosc compression. This does not require a call


### PR DESCRIPTION
This function can be used to determine the output buffer length when
compressing.

Fixes #320 