### PR TITLE
Allow to expose symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@
 #       build fuzz test programs and generates the "test" target
 #   BUILD_BENCHMARKS: default ON
 #       build the benchmark program
+#   HIDE_SYMBOLS: default ON
+#       hide the symols that aren't specifically exported
 #   DEACTIVATE_SSE2: default OFF
 #       do not attempt to build with SSE2 instructions
 #   DEACTIVATE_AVX2: default OFF
@@ -98,6 +100,11 @@ option(BUILD_TESTS
     "Build test programs from the blosc compression library" ON)
 option(BUILD_FUZZERS
     "Build fuzzer programs from the blosc compression library" ${BUILD_STATIC})
+# Hide symbols by default unless they're specifically exported.
+# This makes it easier to keep the set of exported symbols the
+# same across all compilers/platforms.
+option(HIDE_SYMBOLS
+    "Build a libraries with hidden symbols unless they're specifically exported" ON)
 option(BUILD_BENCHMARKS
     "Build benchmark programs from the blosc compression library" ON)
 option(DEACTIVATE_SSE2

--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -3,10 +3,9 @@ add_definitions(-DUSING_CMAKE)
 
 set(INTERNAL_LIBS ${PROJECT_SOURCE_DIR}/internal-complibs)
 
-# Hide symbols by default unless they're specifically exported.
-# This makes it easier to keep the set of exported symbols the
-# same across all compilers/platforms.
-set(CMAKE_C_VISIBILITY_PRESET hidden)
+if(HIDE_SYMBOLS)
+  set(CMAKE_C_VISIBILITY_PRESET hidden)
+endif(HIDE_SYMBOLS)
 
 # includes
 set(BLOSC_INCLUDE_DIRS ${BLOSC_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
We would like to propose a new option to CMake, which allows exposing functions to the linker.

Some project like https://github.com/google/sandboxed-api requires this to build a sandbox.

By default, the option will still be disabled, but it would be good to allow the user to change this setting.