### PR TITLE
Add windows name for lz4 library to FindLZ4 cmake

### DIFF
--- a/cmake/FindLZ4.cmake
+++ b/cmake/FindLZ4.cmake
@@ -1,6 +1,8 @@
 find_path(LZ4_INCLUDE_DIR lz4.h)
 
-find_library(LZ4_LIBRARY NAMES lz4)
+# On Windows, the lz4 library is called liblz4.lib, which is not
+# found by using the lz4 name.
+find_library(LZ4_LIBRARY NAMES lz4 liblz4)
 
 if (LZ4_INCLUDE_DIR AND LZ4_LIBRARY)
     set(LZ4_FOUND TRUE)


### PR DESCRIPTION
The windows version of the lz4 library uses a slightly unorthodox filename (see [here](https://github.com/lz4/lz4/blob/bdc9d3b0c10cbf7e1ff40fc6e27dad5f693a00e7/lib/dll/example/README.md#lz4-windows-binary-package)).

In essence, the import lib is called `liblz4.lib`, whereas the more conventional naming would be simply `lz4.lib`. The actual current name is not found by the existing cmake finding code. This PR adds the name. Alternatively, a platform detection could be possible, but I opted for this simple solution since I cannot foresee a problem on the other platforms.