### PR TITLE
Fix typo found by codespell

### DIFF
--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -837,7 +837,7 @@ static int serial_blosc(struct blosc_context* context)
                          context->destsize, context->src+j*context->blocksize,
                          context->dest+ntbytes, tmp, tmp2);
         if (cbytes == 0) {
-          ntbytes = 0;              /* uncompressible data */
+          ntbytes = 0;              /* incompressible data */
           break;
         }
       }
@@ -1836,7 +1836,7 @@ static void *t_blosc(void *ctxt)
         ntdest = context->parent_context->num_output_bytes;
         _sw32(bstarts + nblock_ * 4, ntdest); /* update block start counter */
         if ( (cbytes == 0) || (ntdest+cbytes > maxbytes) ) {
-          context->parent_context->thread_giveup_code = 0;  /* uncompressible buffer */
+          context->parent_context->thread_giveup_code = 0;  /* incompressible buffer */
           pthread_mutex_unlock(&context->parent_context->count_mutex);
           break;
         }

--- a/compat/filegen.c
+++ b/compat/filegen.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[]) {
     /* Compress with clevel=9 and shuffle active  */
     csize = blosc_compress(9, 1, sizeof(int32_t), isize, data, data_out, osize);
     if (csize == 0) {
-      printf("Buffer is uncompressible.  Giving up.\n");
+      printf("Buffer is incompressible.  Giving up.\n");
       return 1;
     } else if (csize < 0) {
       printf("Compression error.  Error code: %d\n", csize);

--- a/examples/noinit.c
+++ b/examples/noinit.c
@@ -56,7 +56,7 @@ int main(){
   /* Compress with clevel=5 and shuffle active  */
   csize = blosc_compress(5, 1, sizeof(float), isize, data, data_out, osize);
   if (csize == 0) {
-    printf("Buffer is uncompressible.  Giving up.\n");
+    printf("Buffer is incompressible.  Giving up.\n");
     return 1;
   }
   else if (csize < 0) {

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -54,7 +54,7 @@ int main(){
   /* Compress with clevel=5 and shuffle active  */
   csize = blosc_compress(5, 1, sizeof(float), isize, data, data_out, osize);
   if (csize == 0) {
-    printf("Buffer is uncompressible.  Giving up.\n");
+    printf("Buffer is incompressible.  Giving up.\n");
     return 1;
   }
   else if (csize < 0) {

--- a/examples/win-dynamic-linking.c
+++ b/examples/win-dynamic-linking.c
@@ -93,7 +93,7 @@ int main(){
   /* Compress with clevel=3, shuffle active, 16-bytes data size, blosclz and 2 threads */
   csize = blosc_compress_ctx(3, 1, 16, isize, data, data_out, osize, "blosclz", 0, 2);
   if (csize == 0) {
-    printf("Buffer is uncompressible.  Giving up.\n");
+    printf("Buffer is incompressible.  Giving up.\n");
     return 1;
   }
   else if (csize < 0) {

--- a/tests/gcc-segfault-issue.c
+++ b/tests/gcc-segfault-issue.c
@@ -63,7 +63,7 @@ int main(){
   /* Compress with clevel=9 and shuffle active */
   csize = blosc_compress(9, 1, sizeof(double), isize, data, data_out, osize);
   if (csize == 0) {
-    printf("Buffer is uncompressible.  Giving up.\n");
+    printf("Buffer is incompressible.  Giving up.\n");
     return 1;
   }
   else if (csize < 0) {

--- a/tests/test_bitshuffle_leftovers.c
+++ b/tests/test_bitshuffle_leftovers.c
@@ -24,7 +24,7 @@ static int test_roundtrip_bitshuffle8(int size, void *data, void *data_out, void
   FILE *fout = fopen("test-bitshuffle8-nomemcpy.cdata", "w");
 
   if (csize == 0) {
-    printf("Buffer is uncompressible.  Giving up.\n");
+    printf("Buffer is incompressible.  Giving up.\n");
     return 1;
   }
   else if (csize < 0) {
@@ -65,7 +65,7 @@ static int test_roundtrip_bitshuffle4(int size, void *data, void *data_out, void
   FILE *fout = fopen("test-bitshuffle4-memcpy.cdata", "w");
 
   if (csize == 0) {
-    printf("Buffer is uncompressible.  Giving up.\n");
+    printf("Buffer is incompressible.  Giving up.\n");
     return 1;
   }
   else if (csize < 0) {


### PR DESCRIPTION
Although `uncompressible` is not uncommon, most dictionaries do not show it as valid:
* [Cambridge Dictionary](https://dictionary.cambridge.org/dictionary/english/incompressible)
* [Oxford Learner's Dictionaries](https://www.oxfordlearnersdictionaries.com/definition/english/incomprehensible)
* [Merriam-Webster](https://www.merriam-webster.com/dictionary/incompressible)
* [Collins](https://www.collinsdictionary.com/dictionary/english/incompressible)
* [Dictionary.com](https://www.dictionary.com/browse/incompressible)
* [TheFreeDictionary.com](https://www.thefreedictionary.com/incompressible)