### PR TITLE
Enable macos `universal2` build with AVX2/SSE2 optimisation for x86_64 target

### DIFF
--- a/blosc/bitshuffle-avx2.c
+++ b/blosc/bitshuffle-avx2.c
@@ -19,8 +19,8 @@
 
 /* Make sure AVX2 is available for the compilation target and compiler. */
 #if !defined(__AVX2__)
-  #error AVX2 is not supported by the target architecture/platform and/or this compiler.
-#endif
+  #warning AVX2 is not supported by the target architecture/platform and/or this compiler.
+#else
 
 #include <immintrin.h>
 
@@ -243,3 +243,5 @@ int64_t blosc_internal_bshuf_untrans_bit_elem_avx2(void* in, void* out, const si
 
     return count;
 }
+
+#endif /* !defined(__AVX2__) */

--- a/blosc/bitshuffle-avx2.c
+++ b/blosc/bitshuffle-avx2.c
@@ -18,9 +18,7 @@
 
 
 /* Make sure AVX2 is available for the compilation target and compiler. */
-#if !defined(__AVX2__)
-  #warning AVX2 is not supported by the target architecture/platform and/or this compiler.
-#else
+#if defined(__AVX2__)
 
 #include <immintrin.h>
 

--- a/blosc/bitshuffle-sse2.c
+++ b/blosc/bitshuffle-sse2.c
@@ -17,8 +17,8 @@
 
 /* Make sure SSE2 is available for the compilation target and compiler. */
 #if !defined(__SSE2__)
-  #error SSE2 is not supported by the target architecture/platform and/or this compiler.
-#endif
+  #warning SSE2 is not supported by the target architecture/platform and/or this compiler.
+#else
 
 #include <emmintrin.h>
 
@@ -465,3 +465,5 @@ int64_t blosc_internal_bshuf_untrans_bit_elem_sse2(void* in, void* out, const si
 
     return count;
 }
+
+#endif /* !defined(__SSE2__) */

--- a/blosc/bitshuffle-sse2.c
+++ b/blosc/bitshuffle-sse2.c
@@ -16,9 +16,7 @@
 #include "bitshuffle-sse2.h"
 
 /* Make sure SSE2 is available for the compilation target and compiler. */
-#if !defined(__SSE2__)
-  #warning SSE2 is not supported by the target architecture/platform and/or this compiler.
-#else
+#if defined(__SSE2__)
 
 #include <emmintrin.h>
 

--- a/blosc/shuffle-avx2.c
+++ b/blosc/shuffle-avx2.c
@@ -11,8 +11,8 @@
 
 /* Make sure AVX2 is available for the compilation target and compiler. */
 #if !defined(__AVX2__)
-  #error AVX2 is not supported by the target architecture/platform and/or this compiler.
-#endif
+  #warning AVX2 is not supported by the target architecture/platform and/or this compiler.
+#else
 
 #include <immintrin.h>
 
@@ -755,3 +755,5 @@ blosc_internal_unshuffle_avx2(const size_t bytesoftype, const size_t blocksize,
     unshuffle_generic_inline(bytesoftype, vectorizable_bytes, blocksize, _src, _dest);
   }
 }
+
+#endif /* !defined(__AVX2__) */

--- a/blosc/shuffle-avx2.c
+++ b/blosc/shuffle-avx2.c
@@ -10,9 +10,7 @@
 #include "shuffle-avx2.h"
 
 /* Make sure AVX2 is available for the compilation target and compiler. */
-#if !defined(__AVX2__)
-  #warning AVX2 is not supported by the target architecture/platform and/or this compiler.
-#else
+#if defined(__AVX2__)
 
 #include <immintrin.h>
 

--- a/blosc/shuffle-sse2.c
+++ b/blosc/shuffle-sse2.c
@@ -11,8 +11,8 @@
 
 /* Make sure SSE2 is available for the compilation target and compiler. */
 #if !defined(__SSE2__)
-  #error SSE2 is not supported by the target architecture/platform and/or this compiler.
-#endif
+  #warning SSE2 is not supported by the target architecture/platform and/or this compiler.
+#else
 
 #include <emmintrin.h>
 
@@ -624,3 +624,5 @@ blosc_internal_unshuffle_sse2(const size_t bytesoftype, const size_t blocksize,
     unshuffle_generic_inline(bytesoftype, vectorizable_bytes, blocksize, _src, _dest);
   }
 }
+
+#endif /* !defined(__SSE2__) */

--- a/blosc/shuffle-sse2.c
+++ b/blosc/shuffle-sse2.c
@@ -10,9 +10,7 @@
 #include "shuffle-sse2.h"
 
 /* Make sure SSE2 is available for the compilation target and compiler. */
-#if !defined(__SSE2__)
-  #warning SSE2 is not supported by the target architecture/platform and/or this compiler.
-#else
+#if defined(__SSE2__)
 
 #include <emmintrin.h>
 

--- a/blosc/shuffle.c
+++ b/blosc/shuffle.c
@@ -35,18 +35,26 @@ typedef unsigned char bool;
 #define HAVE_CPU_FEAT_INTRIN
 #endif
 
+#if defined(SHUFFLE_AVX2_ENABLED) && defined(__AVX2__)
+#define SHUFFLE_USE_AVX2
+#endif
+
+#if defined(SHUFFLE_SSE2_ENABLED) && defined(__SSE2__)
+#define SHUFFLE_USE_SSE2
+#endif
+
 /*  Include hardware-accelerated shuffle/unshuffle routines based on
     the target architecture. Note that a target architecture may support
     more than one type of acceleration!*/
-#if defined(SHUFFLE_AVX2_ENABLED)
+#if defined(SHUFFLE_USE_AVX2)
   #include "shuffle-avx2.h"
   #include "bitshuffle-avx2.h"
-#endif  /* defined(SHUFFLE_AVX2_ENABLED) */
+#endif  /* defined(SHUFFLE_USE_AVX2) */
 
-#if defined(SHUFFLE_SSE2_ENABLED)
+#if defined(SHUFFLE_USE_SSE2)
   #include "shuffle-sse2.h"
   #include "bitshuffle-sse2.h"
-#endif  /* defined(SHUFFLE_SSE2_ENABLED) */
+#endif  /* defined(SHUFFLE_USE_SSE2) */
 
 
 /*  Define function pointer types for shuffle/unshuffle routines. */
@@ -77,7 +85,7 @@ typedef enum {
 
 /*  Detect hardware and set function pointers to the best shuffle/unshuffle
     implementations supported by the host processor. */
-#if defined(SHUFFLE_AVX2_ENABLED) || defined(SHUFFLE_SSE2_ENABLED)    /* Intel/i686 */
+#if defined(SHUFFLE_USE_AVX2) || defined(SHUFFLE_USE_SSE2)   /* Intel/i686 */
 
 /*  Disabled the __builtin_cpu_supports() call, as it has issues with
     new versions of gcc (like 5.3.1 in forthcoming ubuntu/xenial:
@@ -316,7 +324,7 @@ static shuffle_implementation_t get_shuffle_implementation(void) {
   blosc_cpu_features cpu_features = blosc_get_cpu_features();
   shuffle_implementation_t impl_generic;
 
-#if defined(SHUFFLE_AVX2_ENABLED)
+#if defined(SHUFFLE_USE_AVX2)
   if (cpu_features & BLOSC_HAVE_AVX2) {
     shuffle_implementation_t impl_avx2;
     impl_avx2.name = "avx2";
@@ -326,9 +334,9 @@ static shuffle_implementation_t get_shuffle_implementation(void) {
     impl_avx2.bitunshuffle = (bitunshuffle_func)blosc_internal_bshuf_untrans_bit_elem_avx2;
     return impl_avx2;
   }
-#endif  /* defined(SHUFFLE_AVX2_ENABLED) */
+#endif  /* defined(SHUFFLE_USE_AVX2) */
 
-#if defined(SHUFFLE_SSE2_ENABLED)
+#if defined(SHUFFLE_USE_SSE2)
   if (cpu_features & BLOSC_HAVE_SSE2) {
     shuffle_implementation_t impl_sse2;
     impl_sse2.name = "sse2";
@@ -338,7 +346,7 @@ static shuffle_implementation_t get_shuffle_implementation(void) {
     impl_sse2.bitunshuffle = (bitunshuffle_func)blosc_internal_bshuf_untrans_bit_elem_sse2;
     return impl_sse2;
   }
-#endif  /* defined(SHUFFLE_SSE2_ENABLED) */
+#endif  /* defined(SHUFFLE_USE_SSE2) */
 
   /*  Processor doesn't support any of the hardware-accelerated implementations,
       so use the generic implementation. */


### PR DESCRIPTION
This PR proposes a fix to allow building `c-blosc` as part of a Python package that is built as a `universal2` binary package on macos with enabled AVX2/SSE2 optimisation for the x86_64 target only.

To achieve this, `c-blosc` should support defining `SHUFFLE_AVX2_ENABLED` and `SHUFFLE_SSE2_ENABLED` and be able to build all files (including `*-avx2.c` and `*-sse2.c`) even when AVX2/SSE2 are not supported.

This is done by toggling AVX2/SSE2 with both `SHUFFLE_AVX2_ENABLED`, `SHUFFLE_SSE2_ENABLED` and `__AVX2__`, `__SSE2__`.

Related to #334
Related to https://github.com/silx-kit/hdf5plugin/issues/186