### PR TITLE
Consistency between blosc and blosc2

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,4 +1,4 @@
-name: CIFuzz
+name: CI Fuzz
 on: [push, pull_request]
 jobs:
   Fuzzing:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 #   BUILD_TESTS: default ON
 #       build test programs and generates the "test" target
 #   BUILD_FUZZERS: default ON
-#       build fuzz test programs and generates the "test" target
+#       build fuzz test programs and generates the "fuzz" target
 #   BUILD_BENCHMARKS: default ON
 #       build the benchmark program
 #   HIDE_SYMBOLS: default ON
@@ -33,10 +33,10 @@
 #       when found, use the installed LZ4 libs instead of included
 #       sources
 #   PREFER_EXTERNAL_ZLIB: default OFF
-#       when found, use the installed zlib libs instead of included
+#       when found, use the installed Zlib libs instead of included
 #       sources
 #   PREFER_EXTERNAL_ZSTD: default OFF
-#       when found, use the installed zstd libs instead of included
+#       when found, use the installed Zstd libs instead of included
 #       sources
 #   TEST_INCLUDE_BENCH_SHUFFLE_1: default ON
 #       add a test that runs the benchmark program passing "shuffle" with 1
@@ -73,7 +73,7 @@
 
 
 cmake_minimum_required(VERSION 2.8.12)
-if (NOT CMAKE_VERSION VERSION_LESS 3.3)
+if(NOT CMAKE_VERSION VERSION_LESS 3.3)
     cmake_policy(SET CMP0063 NEW)
 endif()
 project(blosc C)
@@ -136,11 +136,11 @@ if(NOT DEACTIVATE_LZ4)
         find_package(LZ4)
     else()
         message(STATUS "Using LZ4 internal sources.")
-    endif(PREFER_EXTERNAL_LZ4)
+    endif()
     # HAVE_LZ4 will be set to true because even if the library is
     # not found, we will use the included sources for it
     set(HAVE_LZ4 TRUE)
-endif(NOT DEACTIVATE_LZ4)
+endif()
 
 if(NOT DEACTIVATE_SNAPPY)
     find_package(Snappy)
@@ -150,37 +150,37 @@ if(NOT DEACTIVATE_SNAPPY)
     else()
         message(STATUS "SNAPPY *not* found.  De-activating support for it.")
     endif()
-endif(NOT DEACTIVATE_SNAPPY)
+endif()
 
 if(NOT DEACTIVATE_ZLIB)
     # import the ZLIB_ROOT environment variable to help finding the zlib library
     if(PREFER_EXTERNAL_ZLIB)
         set(ZLIB_ROOT $ENV{ZLIB_ROOT})
         find_package(ZLIB)
-        if (NOT ZLIB_FOUND )
+        if(NOT ZLIB_FOUND )
             message(STATUS "No zlib found.  Using internal sources.")
-        endif (NOT ZLIB_FOUND )
+        endif()
     else()
         message(STATUS "Using zlib internal sources.")
-    endif(PREFER_EXTERNAL_ZLIB)
+    endif()
     # HAVE_ZLIB will be set to true because even if the library is not found,
     # we will use the included sources for it
     set(HAVE_ZLIB TRUE)
-endif(NOT DEACTIVATE_ZLIB)
+endif()
 
-if (NOT DEACTIVATE_ZSTD)
-    if (PREFER_EXTERNAL_ZSTD)
+if(NOT DEACTIVATE_ZSTD)
+    if(PREFER_EXTERNAL_ZSTD)
         find_package(Zstd)
-    else ()
+    else()
         message(STATUS "Using ZSTD internal sources.")
-    endif (PREFER_EXTERNAL_ZSTD)
+    endif()
     # HAVE_ZSTD will be set to true because even if the library is
     # not found, we will use the included sources for it
     set(HAVE_ZSTD TRUE)
-endif (NOT DEACTIVATE_ZSTD)
+endif()
 
 # create the config.h file
-configure_file ("blosc/config.h.in"  "blosc/config.h" )
+configure_file("blosc/config.h.in"  "blosc/config.h" )
 
 # now make sure that you set the build directory on your "Include" path when compiling
 include_directories("${PROJECT_BINARY_DIR}/blosc/")
@@ -209,10 +209,10 @@ endif()
 # for newer hardware on older machines as well as cross-compilation.
 message(STATUS "Building for system processor ${CMAKE_SYSTEM_PROCESSOR}")
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL i386 OR
-   CMAKE_SYSTEM_PROCESSOR STREQUAL i686 OR
-   CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR
-   CMAKE_SYSTEM_PROCESSOR STREQUAL amd64 OR
-   CMAKE_SYSTEM_PROCESSOR STREQUAL AMD64)
+    CMAKE_SYSTEM_PROCESSOR STREQUAL i686 OR
+    CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR
+    CMAKE_SYSTEM_PROCESSOR STREQUAL amd64 OR
+    CMAKE_SYSTEM_PROCESSOR STREQUAL AMD64)
     if(CMAKE_C_COMPILER_ID STREQUAL GNU)
         # We need C99 (GNU99 more exactly)
         SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
@@ -269,50 +269,50 @@ endif()
 # Set -Wall and other useful warning flags.
 if(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
     add_compile_options(-Wall -Wwrite-strings -Wno-unused-function)
-endif(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
+endif()
 
 # @NOTE: -O3 is enabled in Release mode (CMAKE_BUILD_TYPE="Release")
 
 # Set the "-msse2" build flag if supported.
 if(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
-     if(COMPILER_SUPPORT_SSE2)
-         add_compile_options(-msse2)
-     endif(COMPILER_SUPPORT_SSE2)
-endif(CMAKE_C_COMPILER_ID STREQUAL GNU OR CMAKE_C_COMPILER_ID STREQUAL Clang OR CMAKE_C_COMPILER_ID STREQUAL Intel)
+    if(COMPILER_SUPPORT_SSE2)
+        add_compile_options(-msse2)
+    endif()
+endif()
 
 if(MSVC)
     if(NOT CMAKE_C_FLAGS)
         set(CMAKE_C_FLAGS "/Ox" CACHE STRING "C flags." FORCE)
-    endif(NOT CMAKE_C_FLAGS)
+    endif()
 
     # Turn off misguided "secure CRT" warnings in MSVC.
     # Microsoft wants people to use the MS-specific <function>_s
     # versions of certain C functions but this is difficult to do
     # in platform-independent code.
     add_definitions( -D_CRT_SECURE_NO_WARNINGS )
-endif(MSVC)
+endif()
 
 if(WIN32)
     # For some supporting headers
     include_directories("${CMAKE_CURRENT_SOURCE_DIR}/blosc")
-endif(WIN32)
+endif()
 
 if(HAIKU)
     # Haiku have posix_memalign, required by test_common.h
     SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_POSIX_C_SOURCE=200112L")
-endif(HAIKU)
+endif()
 
-if (NOT DEFINED BLOSC_IS_SUBPROJECT)
-  if ("^${CMAKE_SOURCE_DIR}$" STREQUAL "^${PROJECT_SOURCE_DIR}$")
-    set (BLOSC_IS_SUBPROJECT FALSE)
-  else ()
-    set (BLOSC_IS_SUBPROJECT TRUE)
-    message(STATUS "Detected that BLOSC is used a subproject.")
-  endif ()
-endif ()
+if(NOT DEFINED BLOSC_IS_SUBPROJECT)
+    if("^${CMAKE_SOURCE_DIR}$" STREQUAL "^${PROJECT_SOURCE_DIR}$")
+        set(BLOSC_IS_SUBPROJECT FALSE)
+    else()
+        set(BLOSC_IS_SUBPROJECT TRUE)
+        message(STATUS "Detected that BLOSC is used a subproject.")
+    endif()
+endif()
 
-if (NOT DEFINED BLOSC_INSTALL)
-    if (BLOSC_IS_SUBPROJECT)
+if(NOT DEFINED BLOSC_INSTALL)
+    if(BLOSC_IS_SUBPROJECT)
         set(BLOSC_INSTALL FALSE)
     else()
         set(BLOSC_INSTALL TRUE)
@@ -327,7 +327,7 @@ if(BUILD_TESTS)
     enable_testing()
     add_subdirectory(tests)
     add_subdirectory(compat)
-endif(BUILD_TESTS)
+endif()
 
 if(BUILD_FUZZERS)
     if(NOT BUILD_STATIC)
@@ -335,15 +335,15 @@ if(BUILD_FUZZERS)
     endif()
     enable_testing()
     add_subdirectory(tests/fuzz)
-endif(BUILD_FUZZERS)
+endif()
 
 if(BUILD_BENCHMARKS)
     add_subdirectory(bench)
-endif(BUILD_BENCHMARKS)
+endif()
 
 
 # uninstall target
-if (BLOSC_INSTALL)
+if(BLOSC_INSTALL)
     configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/blosc.pc.in"
         "${CMAKE_CURRENT_BINARY_DIR}/blosc.pc"
@@ -360,7 +360,7 @@ if (BLOSC_INSTALL)
 endif()
 
 # packaging
-if (NOT BLOSC_IS_SUBPROJECT)
+if(NOT BLOSC_IS_SUBPROJECT)
     include(InstallRequiredSystemLibraries)
 
     set(CPACK_GENERATOR TGZ ZIP)


### PR DESCRIPTION
Follow the CMake manual:
https://cmake.org/cmake/help/latest/command/endif.html

* No space before `(`.
* No deprecated `<condition>` argument to `endif()`.
  >The optional `<condition>` argument is supported for backward compatibility only. If used it must be a verbatim repeat of the argument of the opening `if` clause.