### PR TITLE
Update to BSD 3-Clause license

### DIFF
--- a/examples/multithread.c
+++ b/examples/multithread.c
@@ -1,7 +1,7 @@
 /*
     Copyright (C) 2014  Francesc Alted
     https://blosc.org
-    License: MIT (see LICENSE.txt)
+    License: BSD 3-Clause (see LICENSE.txt)
 
     Example program demonstrating use of the Blosc filter from C code.
 

--- a/examples/noinit.c
+++ b/examples/noinit.c
@@ -1,7 +1,7 @@
 /*
     Copyright (C) 2016  Francesc Alted
     https://blosc.org
-    License: MIT (see LICENSE.txt)
+    License: BSD 3-Clause (see LICENSE.txt)
 
     Example program demonstrating that from 1.9.0 on, Blosc does not
     need to be initialized (although it is recommended).

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -1,7 +1,7 @@
 /*
     Copyright (C) 2014  Francesc Alted
     https://blosc.org
-    License: MIT (see LICENSE.txt)
+    License: BSD 3-Clause (see LICENSE.txt)
 
     Example program demonstrating use of the Blosc filter from C code.
 

--- a/examples/win-dynamic-linking.c
+++ b/examples/win-dynamic-linking.c
@@ -1,7 +1,7 @@
 /*
     Copyright (C) 2015  Francesc Alted
     https://blosc.org
-    License: MIT (see LICENSE.txt)
+    License: BSD 3-Clause (see LICENSE.txt)
 
     Example program demonstrating use of the Blosc filter using the Windows Run-Time Dynamic Linking technique:
     

--- a/tests/gcc-segfault-issue.c
+++ b/tests/gcc-segfault-issue.c
@@ -1,7 +1,7 @@
 /*
     Copyright (C) 2016  Francesc Alted
     https://blosc.org
-    License: MIT (see LICENSE.txt)
+    License: BSD 3-Clause (see LICENSE.txt)
 
     Test program trying to replicate the python-blosc issue:
 


### PR DESCRIPTION
These files still references the MIT license, which the project moved away from in 2016. This changes the license to BSD 3-Clause, which the file 'LICENSE.TXT' also refers to. 

This pr together with the already included pr #358, fixes #324.