### PR TITLE
Variant for the © symbol: (C) → (c)

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2,8 +2,8 @@ BSD License
 
 For Blosc - A blocking, shuffling and lossless compression library
 
-Copyright (C) 2009-2018 Francesc Alted <francesc@blosc.org>
-Copyright (C) 2019-present Blosc Development team <blosc@blosc.org>
+Copyright (c) 2009-2018 Francesc Alted <francesc@blosc.org>
+Copyright (c) 2019-present Blosc Development team <blosc@blosc.org>
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/blosclz.h
+++ b/blosc/blosclz.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/multithread.c
+++ b/examples/multithread.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014  Francesc Alted
+    Copyright (c) 2014  Francesc Alted
     https://blosc.org
     License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/noinit.c
+++ b/examples/noinit.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2016  Francesc Alted
+    Copyright (c) 2016  Francesc Alted
     https://blosc.org
     License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014  Francesc Alted
+    Copyright (c) 2014  Francesc Alted
     https://blosc.org
     License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/win-dynamic-linking.c
+++ b/examples/win-dynamic-linking.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2015  Francesc Alted
+    Copyright (c) 2015  Francesc Alted
     https://blosc.org
     License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/gcc-segfault-issue.c
+++ b/tests/gcc-segfault-issue.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2016  Francesc Alted
+    Copyright (c) 2016  Francesc Alted
     https://blosc.org
     License: BSD 3-Clause (see LICENSE.txt)
 


### PR DESCRIPTION
As in https://github.com/Blosc/c-blosc2/pull/472.