### PR TITLE
Revert building `shuffle.c` with SSE2/AVX2 compilation flags 

### DIFF
--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -162,15 +162,9 @@ if(COMPILER_SUPPORT_SSE2)
         # MSVC targets SSE2 by default on 64-bit configurations, but not 32-bit configurations.
         if (${CMAKE_SIZEOF_VOID_P} EQUAL 4)
             set_source_files_properties(shuffle-sse2.c bitshuffle-sse2.c PROPERTIES COMPILE_FLAGS "/arch:SSE2")
-            set_property(
-                    SOURCE shuffle.c
-                    APPEND PROPERTY COMPILE_OPTIONS "/arch:SSE2")
         endif (${CMAKE_SIZEOF_VOID_P} EQUAL 4)
     else (MSVC)
         set_source_files_properties(shuffle-sse2.c bitshuffle-sse2.c PROPERTIES COMPILE_FLAGS -msse2)
-        set_property(
-                SOURCE shuffle.c
-                APPEND PROPERTY COMPILE_OPTIONS -msse2)
     endif (MSVC)
 
     # Define a symbol for the shuffle-dispatch implementation
@@ -184,15 +178,9 @@ if(COMPILER_SUPPORT_AVX2)
     if (MSVC)
         set_source_files_properties(shuffle-avx2.c bitshuffle-avx2.c
                 PROPERTIES COMPILE_FLAGS "/arch:AVX2")
-        set_property(
-                SOURCE shuffle.c
-                APPEND PROPERTY COMPILE_OPTIONS "/arch:AVX2")
     else (MSVC)
         set_source_files_properties(shuffle-avx2.c bitshuffle-avx2.c
                 PROPERTIES COMPILE_FLAGS -mavx2)
-        set_property(
-                SOURCE shuffle.c
-                APPEND PROPERTY COMPILE_OPTIONS -mavx2)
     endif (MSVC)
 
     # Define a symbol for the shuffle-dispatch implementation

--- a/blosc/bitshuffle-avx2.c
+++ b/blosc/bitshuffle-avx2.c
@@ -17,8 +17,21 @@
 #include "bitshuffle-avx2.h"
 
 
-/* Make sure AVX2 is available for the compilation target and compiler. */
-#if defined(__AVX2__)
+/* Define dummy functions if AVX2 is not available for the compilation target and compiler. */
+#if !defined(__AVX2__)
+#include <stdlib.h>
+
+int64_t blosc_internal_bshuf_trans_bit_elem_avx2(void* in, void* out, const size_t size,
+                                                 const size_t elem_size, void* tmp_buf) {
+    abort();
+}
+
+int64_t blosc_internal_bshuf_untrans_bit_elem_avx2(void* in, void* out, const size_t size,
+                                                   const size_t elem_size, void* tmp_buf) {
+    abort();
+}
+
+#else /* defined(__AVX2__) */
 
 #include <immintrin.h>
 

--- a/blosc/bitshuffle-sse2.c
+++ b/blosc/bitshuffle-sse2.c
@@ -15,8 +15,21 @@
 #include "bitshuffle-generic.h"
 #include "bitshuffle-sse2.h"
 
-/* Make sure SSE2 is available for the compilation target and compiler. */
-#if defined(__SSE2__)
+/* Define dummy functions if SSE2 is not available for the compilation target and compiler. */
+#if !defined(__SSE2__)
+#include <stdlib.h>
+
+int64_t blosc_internal_bshuf_trans_byte_elem_sse2(void* in, void* out, const size_t size,
+                                                  const size_t elem_size, void* tmp_buf) {
+    abort();
+}
+
+int64_t blosc_internal_bshuf_untrans_bit_elem_sse2(void* in, void* out, const size_t size,
+				                                   const size_t elem_size, void* tmp_buf) {
+    abort();
+}
+
+#else /* defined(__SSE2__) */
 
 #include <emmintrin.h>
 

--- a/blosc/shuffle-avx2.c
+++ b/blosc/shuffle-avx2.c
@@ -9,8 +9,23 @@
 #include "shuffle-generic.h"
 #include "shuffle-avx2.h"
 
-/* Make sure AVX2 is available for the compilation target and compiler. */
-#if defined(__AVX2__)
+/* Define dummy functions if AVX2 is not available for the compilation target and compiler. */
+#if !defined(__AVX2__)
+#include <stdlib.h>
+
+void
+blosc_internal_shuffle_avx2(const size_t bytesoftype, const size_t blocksize,
+                            const uint8_t* const _src, uint8_t* const _dest) {
+  abort();
+}
+
+void
+blosc_internal_unshuffle_avx2(const size_t bytesoftype, const size_t blocksize,
+                              const uint8_t* const _src, uint8_t* const _dest) {
+  abort();
+}
+
+#else /* defined(__AVX2__) */
 
 #include <immintrin.h>
 

--- a/blosc/shuffle-sse2.c
+++ b/blosc/shuffle-sse2.c
@@ -9,8 +9,22 @@
 #include "shuffle-generic.h"
 #include "shuffle-sse2.h"
 
-/* Make sure SSE2 is available for the compilation target and compiler. */
-#if defined(__SSE2__)
+/* Define dummy functions if SSE2 is not available for the compilation target and compiler. */
+#if !defined(__SSE2__)
+
+void
+blosc_internal_shuffle_sse2(const size_t bytesoftype, const size_t blocksize,
+                            const uint8_t* const _src, uint8_t* const _dest) {
+  abort();
+}
+
+void
+blosc_internal_unshuffle_sse2(const size_t bytesoftype, const size_t blocksize,
+                              const uint8_t* const _src, uint8_t* const _dest) {
+  abort();
+}
+
+# else /* defined(__SSE2__) */
 
 #include <emmintrin.h>
 

--- a/blosc/shuffle.c
+++ b/blosc/shuffle.c
@@ -77,8 +77,10 @@ typedef enum {
 } blosc_cpu_features;
 
 /*  Detect hardware and set function pointers to the best shuffle/unshuffle
-    implementations supported by the host processor. */
-#if defined(SHUFFLE_AVX2_ENABLED) || defined(SHUFFLE_SSE2_ENABLED)   /* Intel/i686 */
+    implementations supported by the host processor for Intel/i686
+     */
+#if (defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(_M_IX86)) \
+    && (defined(SHUFFLE_AVX2_ENABLED) || defined(SHUFFLE_SSE2_ENABLED))
 
 /*  Disabled the __builtin_cpu_supports() call, as it has issues with
     new versions of gcc (like 5.3.1 in forthcoming ubuntu/xenial:

--- a/blosc/shuffle.c
+++ b/blosc/shuffle.c
@@ -35,26 +35,19 @@ typedef unsigned char bool;
 #define HAVE_CPU_FEAT_INTRIN
 #endif
 
-#if defined(SHUFFLE_AVX2_ENABLED) && defined(__AVX2__)
-#define SHUFFLE_USE_AVX2
-#endif
-
-#if defined(SHUFFLE_SSE2_ENABLED) && defined(__SSE2__)
-#define SHUFFLE_USE_SSE2
-#endif
 
 /*  Include hardware-accelerated shuffle/unshuffle routines based on
     the target architecture. Note that a target architecture may support
     more than one type of acceleration!*/
-#if defined(SHUFFLE_USE_AVX2)
+#if defined(SHUFFLE_AVX2_ENABLED)
   #include "shuffle-avx2.h"
   #include "bitshuffle-avx2.h"
-#endif  /* defined(SHUFFLE_USE_AVX2) */
+#endif  /* defined(SHUFFLE_AVX2_ENABLED) */
 
-#if defined(SHUFFLE_USE_SSE2)
+#if defined(SHUFFLE_SSE2_ENABLED)
   #include "shuffle-sse2.h"
   #include "bitshuffle-sse2.h"
-#endif  /* defined(SHUFFLE_USE_SSE2) */
+#endif  /* defined(SHUFFLE_SSE2_ENABLED) */
 
 
 /*  Define function pointer types for shuffle/unshuffle routines. */
@@ -85,7 +78,7 @@ typedef enum {
 
 /*  Detect hardware and set function pointers to the best shuffle/unshuffle
     implementations supported by the host processor. */
-#if defined(SHUFFLE_USE_AVX2) || defined(SHUFFLE_USE_SSE2)   /* Intel/i686 */
+#if defined(SHUFFLE_AVX2_ENABLED) || defined(SHUFFLE_SSE2_ENABLED)   /* Intel/i686 */
 
 /*  Disabled the __builtin_cpu_supports() call, as it has issues with
     new versions of gcc (like 5.3.1 in forthcoming ubuntu/xenial:
@@ -317,7 +310,7 @@ static shuffle_implementation_t get_shuffle_implementation(void) {
   blosc_cpu_features cpu_features = blosc_get_cpu_features();
   shuffle_implementation_t impl_generic;
 
-#if defined(SHUFFLE_USE_AVX2)
+#if defined(SHUFFLE_AVX2_ENABLED)
   if (cpu_features & BLOSC_HAVE_AVX2) {
     shuffle_implementation_t impl_avx2;
     impl_avx2.name = "avx2";
@@ -327,9 +320,9 @@ static shuffle_implementation_t get_shuffle_implementation(void) {
     impl_avx2.bitunshuffle = (bitunshuffle_func)blosc_internal_bshuf_untrans_bit_elem_avx2;
     return impl_avx2;
   }
-#endif  /* defined(SHUFFLE_USE_AVX2) */
+#endif  /* defined(SHUFFLE_AVX2_ENABLED) */
 
-#if defined(SHUFFLE_USE_SSE2)
+#if defined(SHUFFLE_SSE2_ENABLED)
   if (cpu_features & BLOSC_HAVE_SSE2) {
     shuffle_implementation_t impl_sse2;
     impl_sse2.name = "sse2";
@@ -339,7 +332,7 @@ static shuffle_implementation_t get_shuffle_implementation(void) {
     impl_sse2.bitunshuffle = (bitunshuffle_func)blosc_internal_bshuf_untrans_bit_elem_sse2;
     return impl_sse2;
   }
-#endif  /* defined(SHUFFLE_USE_SSE2) */
+#endif  /* defined(SHUFFLE_SSE2_ENABLED) */
 
   /*  Processor doesn't support any of the hardware-accelerated implementations,
       so use the generic implementation. */


### PR DESCRIPTION
This PR aims at fixing #371. It:

- Reverts commit eb981b792dcab4329a6f4c3c0dcb40fba1bed07a from PR #352 to disable SSE2/AVX2 flags when buidling `shuffle.c` which is responsible for issue #371.
- Adds dummy functions for (bit)shuffle-sse2|avx2 if `__SSE2__` (resp. `__AVX2__`) is not available, so that the symbols are always defined (useful for multiple architecture compilation like for macos universal build (x86 + arm).
- Adds a test of x86 architecture (on top of having `SHUFFLE_AVX2_ENABLED` or `SHUFFLE_SSE2_ENABLED` defined) for using a `blosc_get_cpu_features` implementation that detects hardware.

