### PR TITLE
Fix how-to compile example instructions

### DIFF
--- a/examples/noinit.c
+++ b/examples/noinit.c
@@ -12,8 +12,7 @@
 
     or, if you don't have the blosc library installed yet:
 
-    $ gcc -O3 -msse2 noinit.c -I../blosc -o noinit -L../build/blosc
-    $ export LD_LIBRARY_PATH=../build/blosc
+    $ gcc -O3 -msse2 noinit.c ../blosc/*.c  -I../blosc -o noinit
 
     Using MSVC on Windows:
 

--- a/examples/noinit.c
+++ b/examples/noinit.c
@@ -12,7 +12,7 @@
 
     or, if you don't have the blosc library installed yet:
 
-    $ gcc -O3 -msse2 noinit.c ../blosc/*.c  -I../blosc -o noinit
+    $ gcc noinit.c -I../blosc -o noinit ../build/blosc/libblosc.a
 
     Using MSVC on Windows:
 

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -11,7 +11,7 @@
 
     or, if you don't have the blosc library installed:
 
-    $ gcc -O3 -msse2 simple.c -I../blosc -o simple -L../build/blosc
+    $ gcc -O3 -msse2 simple.c ../blosc/*.c  -I../blosc -o simple
 
     Using MSVC on Windows:
 

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -11,7 +11,7 @@
 
     or, if you don't have the blosc library installed:
 
-    $ gcc -O3 -msse2 simple.c ../blosc/*.c  -I../blosc -o simple
+    $ gcc simple.c -I../blosc -o simple ../build/blosc/libblosc.a
 
     Using MSVC on Windows:
 


### PR DESCRIPTION
Fixes #379 

I could not compile `examples/simple.c` using the instructions in the file. This PR proposes an update on how-to compile `examples/simple.c` and `examples/noinit.c`. I'm not experienced in using GCC, so this change may be incorrect in some subtle way, but these new instructions work on my machine.