### PR TITLE
Set -std=gnu99 for gcc on all architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,11 @@ if(APPLE)
   set(CMAKE_MACOSX_RPATH TRUE)
 endif()
 
+if(CMAKE_C_COMPILER_ID STREQUAL GNU)
+    # We need C99 (GNU99 more exactly)
+    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
+endif()
+
 # Based on the target system's processor and the compiler being used,
 # set build variables indicating which hardware features can be targeted
 # by the compiler. Note we DO NOT check which hardware features are supported
@@ -215,8 +220,6 @@ endif()
 message(STATUS "Building for system processor ${CMAKE_SYSTEM_PROCESSOR}")
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "(i386|i686|x86_64|amd64|AMD64)")
     if(CMAKE_C_COMPILER_ID STREQUAL GNU)
-        # We need C99 (GNU99 more exactly)
-        SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
         set(COMPILER_SUPPORT_SSE2 TRUE)
         if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 4.7 OR CMAKE_C_COMPILER_VERSION VERSION_EQUAL 4.7)
             set(COMPILER_SUPPORT_AVX2 TRUE)


### PR DESCRIPTION
Previously the cmake file only sets `-std=gnu99` when it is on x86(-64), which causes compilation failure on other architectures when gcc is used.

GCC currently defaults to `-std=gnu23`, which would fail the build with:

    blosc/shuffle.c:26:15: error: ‘bool’ cannot be defined via ‘typedef’

This patch fixes it by setting `-std=gnu99` for gcc on all architectures.